### PR TITLE
feat(learning): optional expect on the live run + verifier (P1, closes #4)

### DIFF
--- a/include/geistshell/run_config.h
+++ b/include/geistshell/run_config.h
@@ -31,6 +31,16 @@ struct spg_run_config {
 
     uint64_t               seed;
     struct spg_run_budgets budgets;
+
+    /* Optional success criterion for learning from real runs (docs/LEARNING.md,
+     * P1). When has_expect, the run is judged: it succeeded iff it finished and
+     * its observation contains expect_observation (a substring into `input`).
+     * The shell observation folds in the exit code, so a marker substring
+     * verifies real outcomes. Absent -> no success-side verdict; the run's
+     * terminal failures still teach through the existing path. Model-free,
+     * zero tokens: the world supplies the ground truth. */
+    bool                 has_expect;
+    struct spg_text_span expect_observation;
 };
 
 struct spg_run_config_error {

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -1996,6 +1996,28 @@ static int agent_command(int argc, char **argv) {
     }
     rc = (status == SPG_OK) ? 0 : 1;
 
+    /* Optional success criterion (docs/LEARNING.md P1): judge the real run the
+     * same way the eval loop judges a scripted case — model-free, zero tokens.
+     * The verdict is the ground truth a learning case needs; a FAIL exits
+     * non-zero so a caller (and a future miner) can act on it. */
+    if (run.has_expect && run.expect_observation.length < sizeof observation) {
+        char expect_obs[AGENT_OBS_BYTES];
+        memcpy(expect_obs, run_text.data + run.expect_observation.offset,
+               run.expect_observation.length);
+        expect_obs[run.expect_observation.length] = '\0';
+        const struct spg_eval_expect expect = {
+            .check_termination = true,
+            .termination       = SPG_AGENT_LOOP_FINISHED,
+            .observation       = expect_obs,
+        };
+        const enum spg_eval_outcome verdict =
+            spg_eval_judge(&expect, &loop_result, status, observation);
+        printf("verdict=%s\n", spg_eval_outcome_to_string(verdict));
+        if (verdict != SPG_EVAL_PASS && rc == 0) {
+            rc = 1;
+        }
+    }
+
 done:
     if (journal_open) {
         (void)spg_journal_writer_close(&journal);

--- a/src/core/run_config.c
+++ b/src/core/run_config.c
@@ -49,6 +49,14 @@ static const struct spg_schema_field_rule run_fields[] = {
      .max_values = 8u, /* 7 required + optional memory_actions */
      .required   = true,
      .unique     = true},
+    /* Optional success criterion (docs/LEARNING.md P1): a substring the
+     * finished run's observation must contain. Absent -> not judged. */
+    {.name       = "expect",
+     .value_kind = SPG_SCHEMA_VALUE_STRING,
+     .min_values = 1u,
+     .max_values = 1u,
+     .required   = false,
+     .unique     = true},
 };
 
 static const struct spg_schema_form_rule run_forms[] = {
@@ -57,7 +65,7 @@ static const struct spg_schema_form_rule run_forms[] = {
      .field_rules          = run_fields,
      .allow_unknown_fields = false,
      .min_fields           = 7u,
-     .max_fields           = 7u},
+     .max_fields           = 8u},
 };
 
 static const struct spg_schema run_schema = {
@@ -237,6 +245,19 @@ enum spg_status spg_run_config_load(
     status = parse_budgets(input_n, input, nodes, run_node, &out->budgets, error);
     if (status != SPG_OK) {
         return status;
+    }
+
+    /* Optional success criterion (docs/LEARNING.md P1): present or not, both
+     * valid. When present it must be a non-empty string. */
+    const uint32_t expect_field =
+        find_field(input_n, input, nodes, run_node, "expect");
+    if (expect_field != SPG_SEXPR_INVALID_INDEX) {
+        status = string_value_span(nodes, expect_field, &out->expect_observation);
+        if (status != SPG_OK) {
+            set_error(error, status, expect_field, nodes[expect_field].span.offset);
+            return status;
+        }
+        out->has_expect = true;
     }
 
     return SPG_OK;

--- a/test/test_cli_expect.sh
+++ b/test/test_cli_expect.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# System test: the optional success criterion (docs/LEARNING.md P1). A run
+# config carrying (expect "<substring>") is judged after the governed loop
+# finishes — model-free, the world's observation supplies the verdict. A
+# matching substring passes; a non-matching one fails and exits non-zero.
+set -eu
+
+SPG_BIN=${SPG_BIN:-build/host-debug/bin/geistshell}
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT
+
+# The shell step echoes a marker that reaches the observation channel.
+cat > "$T/script.txt" <<'EOF'
+(recommend (kind local_shell) (capability "build.run") (cost 1) (uses_network false) (confidence_bp 6000) (reason "probe") (command "echo VERIFIER-MARKER"))
+(recommend (kind finish) (reason "task complete"))
+EOF
+
+make_config() {  # $1 = journal, $2 = expect substring
+    cat > "$T/run.spg" <<EOF
+(run
+ (model "fake.gguf")
+ (policy "examples/policy.spg")
+ (scenario "examples/scenario.spg")
+ (corpus "examples/corpus.spg")
+ (journal "$1")
+ (seed 42)
+ (budgets (inference_steps 8) (tokens 256) (shell_actions 1) (sim_actions 8) (wall_ms 10000) (journal_bytes 1048576) (risk_bp 10000))
+ (expect "$2"))
+EOF
+}
+
+# --- criterion met: the observation contains the marker -> verdict pass, rc 0 ---
+make_config "$T/j.sgj" "VERIFIER-MARKER"
+rc=0
+"$SPG_BIN" agent --config "$T/run.spg" --fake-script "$T/script.txt" \
+    --allow-exec --max-steps 5 > "$T/pass.out" 2>&1 || rc=$?
+grep -q "verdict=pass" "$T/pass.out"
+[ "$rc" -eq 0 ]
+
+# --- criterion NOT met: marker absent from the observation -> fail, rc non-zero ---
+rm -f "$T/j.sgj"
+make_config "$T/j.sgj" "MARKER-THAT-NEVER-APPEARS"
+rc=0
+"$SPG_BIN" agent --config "$T/run.spg" --fake-script "$T/script.txt" \
+    --allow-exec --max-steps 5 > "$T/fail.out" 2>&1 || rc=$?
+grep -q "verdict=fail" "$T/fail.out"
+[ "$rc" -ne 0 ]
+
+# --- no (expect) field: behaves exactly as before, no verdict line ---
+rm -f "$T/j.sgj"
+cat > "$T/run_noexpect.spg" <<EOF
+(run
+ (model "fake.gguf")
+ (policy "examples/policy.spg")
+ (scenario "examples/scenario.spg")
+ (corpus "examples/corpus.spg")
+ (journal "$T/j.sgj")
+ (seed 42)
+ (budgets (inference_steps 8) (tokens 256) (shell_actions 1) (sim_actions 8) (wall_ms 10000) (journal_bytes 1048576) (risk_bp 10000)))
+EOF
+"$SPG_BIN" agent --config "$T/run_noexpect.spg" --fake-script "$T/script.txt" \
+    --allow-exec --max-steps 5 > "$T/noexpect.out" 2>&1
+grep -q "termination=finished" "$T/noexpect.out"
+! grep -q "verdict=" "$T/noexpect.out"
+
+echo "test_cli_expect: PASS"

--- a/test/test_run_config.c
+++ b/test/test_run_config.c
@@ -73,6 +73,47 @@ static int test_valid_run_config(void) {
     return 0;
 }
 
+/* P1 (docs/LEARNING.md): the optional success criterion. Absent is valid and
+ * leaves has_expect false; present parses the substring the finished run's
+ * observation must contain. */
+static int test_expect_absent(void) {
+    struct spg_run_config       config = {};
+    struct spg_run_config_error error  = {};
+    if (load_text(valid_run, &config, &error) != SPG_OK) {
+        return 1;
+    }
+    return config.has_expect ? 1 : 0;
+}
+
+static int test_expect_present(void) {
+    const char *text =
+        "(run"
+        " (model \"models/a.gguf\")"
+        " (policy \"policy/lab.spg\")"
+        " (scenario \"scenarios/lab.spg\")"
+        " (corpus \"corpus/manifest.spg\")"
+        " (journal \"runs/r1/run.sgj\")"
+        " (seed 42)"
+        " (budgets"
+        "  (inference_steps 100)"
+        "  (tokens 4096)"
+        "  (shell_actions 8)"
+        "  (sim_actions 250)"
+        "  (wall_ms 60000)"
+        "  (journal_bytes 1048576)"
+        "  (risk_bp 10000))"
+        " (expect \"report generated\"))";
+    struct spg_run_config       config = {};
+    struct spg_run_config_error error  = {};
+    if (load_text(text, &config, &error) != SPG_OK) {
+        return 1;
+    }
+    if (!config.has_expect) {
+        return 1;
+    }
+    return span_eq(text, config.expect_observation, "report generated") ? 0 : 1;
+}
+
 static int test_missing_required_field(void) {
     const char *text =
         "(run"
@@ -223,6 +264,14 @@ static int test_invalid_args(void) {
 int main(void) {
     if (test_valid_run_config() != 0) {
         fprintf(stderr, "test_valid_run_config failed\n");
+        return 1;
+    }
+    if (test_expect_absent() != 0) {
+        fprintf(stderr, "test_expect_absent failed\n");
+        return 1;
+    }
+    if (test_expect_present() != 0) {
+        fprintf(stderr, "test_expect_present failed\n");
         return 1;
     }
     if (test_missing_required_field() != 0) {


### PR DESCRIPTION
Phase 1 of the verifier design (docs/LEARNING.md, tracking #3). Gives a real run a place to declare success, judged model-free.

- `spg_run_config` gains an optional `(expect "<substring>")` field — the run succeeded iff it **finished** and its observation contains the substring. The shell observation folds in the exit code, so a marker verifies real outcomes. Absent → not judged; terminal failures still teach through the existing path.
- The `agent` command judges via the existing `spg_eval_judge` and prints `verdict=pass/fail`, exiting non-zero on fail — the signal a caller and the future miner (P3–P5) act on. Zero model tokens: the world supplies the ground truth.
- Schema: `expect` is optional; `max_fields` 7→8.

**Tests:** parse-level absent/present in `test_run_config`; end-to-end in `test_cli_expect` (marker met → `pass`, rc 0; absent → `fail`, rc≠0; no `expect` → unchanged, no verdict line). Full suite green (16 CLI + all unit).

Closes #4.