### PR TITLE
feat(learning): outcome-failure reflect path (P2, closes #5)

### DIFF
--- a/include/geistshell/improve.h
+++ b/include/geistshell/improve.h
@@ -36,6 +36,24 @@ struct spg_lesson {
 [[nodiscard]] bool spg_reflect_case(const struct spg_eval_case_result *result,
                                     struct spg_lesson *out);
 
+/* Distill a lesson from a FINISHED-but-criterion-failed run (docs/LEARNING.md
+ * P2) — the class spg_reflect_case cannot judge, because the failure is in the
+ * outcome, not the loop's termination. The verifier (P1) supplies the ground
+ * truth; this states the concrete miss, it does not invent a fix.
+ *
+ * slug = "lesson-outcome-<shape_token>", so lessons dedup per task shape.
+ * shape_token is the caller's task-shape key (until P4 it may be any stable,
+ * non-empty token; P4 supplies the capability-set key). It is sanitized to a
+ * mind-palace-safe slug ([a-z0-9-], truncated). The description is a terse
+ * directive; the body quotes observed-vs-expected verbatim. Whether stating
+ * the miss helps is decided later by slug-recurrence (P7), never assumed here.
+ *
+ * Returns false (out untouched) on null/empty args. Deterministic. */
+[[nodiscard]] bool spg_reflect_outcome(const char *shape_token,
+                                       const char *expected_substring,
+                                       const char *observation,
+                                       struct spg_lesson *out);
+
 /* The acceptance gate: keep a tentatively-persisted lesson only if the suite's
  * pass count did not drop. Equality keeps (a lesson that neither helps nor hurts
  * is retained, since it may help cases outside the suite). */

--- a/src/improve/improve.c
+++ b/src/improve/improve.c
@@ -157,9 +157,69 @@ bool spg_reflect_case(const struct spg_eval_case_result *result,
             result->steps_taken);
         return true;
     case SPG_AGENT_LOOP_FINISHED:
-        /* Finished cleanly but missed an eval expectation: no agent-level
-         * lesson to learn from the failure mode. */
+        /* Finished cleanly but missed an eval expectation: the failure is in
+         * the outcome, not the termination — spg_reflect_outcome handles it. */
         return false;
     }
     return false;
+}
+
+/* Append a slug-safe rendering of token to dst: [a-z0-9] kept (lowercased),
+ * every other run collapses to a single '-'; no leading/trailing '-';
+ * truncated to cap-1. Returns bytes written (0 if token yields nothing). */
+static size_t slugify_into(char *dst, size_t cap, const char *token) {
+    size_t w            = 0u;
+    bool   pending_dash = false;
+    for (const char *p = token; *p != '\0' && w + 1u < cap; p++) {
+        unsigned char c = (unsigned char)*p;
+        if (c >= 'A' && c <= 'Z') {
+            c = (unsigned char)(c - 'A' + 'a');
+        }
+        if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
+            if (pending_dash && w > 0u && w + 1u < cap) {
+                dst[w++] = '-';
+            }
+            pending_dash = false;
+            if (w + 1u < cap) {
+                dst[w++] = (char)c;
+            }
+        } else {
+            pending_dash = w > 0u; /* no leading dash */
+        }
+    }
+    dst[w] = '\0';
+    return w;
+}
+
+bool spg_reflect_outcome(const char *shape_token, const char *expected_substring,
+                         const char *observation, struct spg_lesson *out) {
+    if (out == nullptr || shape_token == nullptr || shape_token[0] == '\0' ||
+        expected_substring == nullptr || expected_substring[0] == '\0' ||
+        observation == nullptr) {
+        return false;
+    }
+
+    /* slug = "lesson-outcome-<shape>", deduping per task shape. If the token
+     * sanitizes to nothing (e.g. all punctuation), fall back so the slug stays
+     * valid and stable rather than colliding on the bare prefix. */
+    const size_t w =
+        (size_t)snprintf(out->slug, sizeof out->slug, "%s", "lesson-outcome-");
+    if (slugify_into(out->slug + w, sizeof out->slug - w, shape_token) == 0u) {
+        (void)snprintf(out->slug + w, sizeof out->slug - w, "%s", "x");
+    }
+
+    (void)snprintf(out->description, sizeof out->description,
+                   "Finish only when the output shows the expected result; "
+                   "last run missed \"%.80s\".",
+                   expected_substring);
+
+    /* The concrete miss, verbatim — the fact, not an invented correction. */
+    (void)snprintf(
+        out->body, sizeof out->body,
+        "A previous run finished but its output did not meet the success "
+        "criterion. Expected the observation to contain: \"%.200s\". The "
+        "observation was: \"%.400s\". Before emitting (recommend (kind finish) "
+        "...), make sure the required result is actually present.",
+        expected_substring, observation[0] != '\0' ? observation : "(empty)");
+    return true;
 }

--- a/test/test_improve.c
+++ b/test/test_improve.c
@@ -121,6 +121,47 @@ static int test_reflect_finished_no_lesson(void) {
     return spg_reflect_case(&result, &lesson) ? 1 : 0;
 }
 
+/* P2 (docs/LEARNING.md): a finished-but-criterion-failed run yields an
+ * outcome lesson keyed per task shape, quoting the concrete miss. */
+static int test_reflect_outcome(void) {
+    struct spg_lesson lesson = {};
+    if (!spg_reflect_outcome("proc.exec+fs.write", "SUCCESS",
+                             "error: file not found", &lesson)) {
+        return 1;
+    }
+    /* slug is per-shape and mind-palace-safe */
+    if (strcmp(lesson.slug, "lesson-outcome-proc-exec-fs-write") != 0 ||
+        !spg_mem_slug_valid(lesson.slug)) {
+        return 1;
+    }
+    /* the body quotes both the expected criterion and the actual observation */
+    if (strstr(lesson.body, "SUCCESS") == nullptr ||
+        strstr(lesson.body, "file not found") == nullptr) {
+        return 1;
+    }
+    /* two different shapes dedup to two different slugs */
+    struct spg_lesson other = {};
+    if (!spg_reflect_outcome("net.http", "200 OK", "503", &other) ||
+        strcmp(lesson.slug, other.slug) == 0) {
+        return 1;
+    }
+    /* a token that sanitizes to nothing still yields a valid, stable slug */
+    struct spg_lesson punct = {};
+    if (!spg_reflect_outcome("///", "x", "y", &punct) ||
+        !spg_mem_slug_valid(punct.slug) ||
+        strcmp(punct.slug, "lesson-outcome-x") != 0) {
+        return 1;
+    }
+    /* null/empty args produce no lesson */
+    struct spg_lesson none = {};
+    if (spg_reflect_outcome(nullptr, "x", "y", &none) ||
+        spg_reflect_outcome("s", "", "y", &none) ||
+        spg_reflect_outcome("s", "x", nullptr, &none)) {
+        return 1;
+    }
+    return 0;
+}
+
 static int test_accept_gate(void) {
     /* keep on improvement and on no-change; revert on regression */
     if (!spg_improve_accept(2u, 3u) || !spg_improve_accept(2u, 2u) ||
@@ -197,6 +238,10 @@ int main(void) {
     }
     if (test_reflect_finished_no_lesson() != 0) {
         fprintf(stderr, "test_reflect_finished_no_lesson failed\n");
+        return 1;
+    }
+    if (test_reflect_outcome() != 0) {
+        fprintf(stderr, "test_reflect_outcome failed\n");
         return 1;
     }
     if (test_accept_gate() != 0) {


### PR DESCRIPTION
Phase 2 (docs/LEARNING.md, tracking #3). Depends on P1 (#14).

`spg_reflect_case` returns false for a finished run that missed its criterion — the failure is in the outcome, not the termination. P2 adds `spg_reflect_outcome` for that class, the one the verifier exists to catch.

- **slug** = `lesson-outcome-<shape_token>`, deduped per task shape; sanitized to a mind-palace-safe identifier with a stable fallback. The caller supplies the token (P4 will pass the capability-set key).
- **description**: terse directive. **body**: quotes expected-vs-observed **verbatim** — the concrete fact, no invented correction. Whether stating it helps is judged later by slug-recurrence (P7), never assumed.
- Deterministic, model-free.

**Test** (`test_improve`): per-shape slug + mind-palace-safe, body quotes both sides, distinct shapes → distinct slugs, punctuation-only token → stable fallback, null/empty → no lesson. Full suite green (16 CLI + all unit).

Closes #5.