### PR TITLE
feat(learning): reconstruct a fake-model script from a journal (P3, closes #6)

### DIFF
--- a/include/geistshell/eval.h
+++ b/include/geistshell/eval.h
@@ -79,6 +79,22 @@ spg_eval_run_case(const struct spg_fake_response *script, size_t script_n,
                   const struct spg_eval_expect *expect,
                   struct spg_eval_case_result *result);
 
+/* Reconstruct a fake-model script from a run's journal (docs/LEARNING.md P3):
+ * each MODEL_OUTPUT event becomes one spg_fake_response, in sequence order.
+ * The response texts are copied into text_buf; each response's `text` points
+ * into it. Replaying the returned script through spg_eval_run_case against the
+ * same inputs reproduces the run deterministically (the journal is
+ * byte-replayable), so a real run becomes a frozen case the mint gate can
+ * re-run without live inference.
+ *
+ * Fills responses[0..*count) and returns SPG_OK. SPG_E_INVALID_ARG on null
+ * args; SPG_E_JOURNAL_CORRUPT / SPG_E_IO on a read failure; SPG_E_LIMIT if the
+ * outputs exceed max_responses or text_cap. */
+[[nodiscard]] enum spg_status spg_eval_script_from_journal(
+    const char *journal_path, size_t max_responses,
+    struct spg_fake_response responses[], size_t text_cap, char text_buf[],
+    size_t *count);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/eval/eval.c
+++ b/src/eval/eval.c
@@ -1,5 +1,7 @@
 #include "geistshell/eval.h"
 
+#include "geistshell/journal.h"
+
 #include <string.h>
 
 const char *spg_eval_outcome_to_string(const enum spg_eval_outcome o) {
@@ -85,4 +87,68 @@ spg_eval_run_case(const struct spg_fake_response *script, const size_t script_n,
     result->outcome =
         spg_eval_judge(expect, &loop, status, workspace->observation);
     return SPG_OK;
+}
+
+enum spg_status spg_eval_script_from_journal(
+    const char *journal_path, const size_t max_responses,
+    struct spg_fake_response responses[], const size_t text_cap,
+    char text_buf[], size_t *count) {
+    if (journal_path == nullptr || responses == nullptr ||
+        text_buf == nullptr || count == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *count = 0u;
+
+    struct spg_journal_reader reader;
+    enum spg_status status = spg_journal_reader_open(&reader, journal_path);
+    if (status != SPG_OK) {
+        return status;
+    }
+
+    /* A recommendation is small; the scratch only needs to hold one MODEL_OUTPUT
+     * payload. Larger records (the MODEL_INPUT context) overflow it and are
+     * skipped — we do not need them. */
+    char            scratch[8192];
+    size_t          used   = 0u; /* bytes of text_buf consumed */
+    size_t          n      = 0u; /* fake responses collected */
+    enum spg_status result = SPG_OK;
+    for (;;) {
+        struct spg_journal_record record = {};
+        const enum spg_status rs = spg_journal_reader_next(
+            &reader, sizeof scratch, (uint8_t *)scratch, &record);
+        if (rs == SPG_E_NOT_FOUND) {
+            break; /* end of journal */
+        }
+        if (rs == SPG_E_LIMIT) {
+            /* Payload larger than the scratch. A MODEL_OUTPUT that big cannot
+             * be reconstructed; any other kind we skip. */
+            if (record.header.event_kind == SPG_JOURNAL_EVENT_MODEL_OUTPUT) {
+                result = SPG_E_LIMIT;
+                break;
+            }
+            continue;
+        }
+        if (rs != SPG_OK) {
+            result = rs;
+            break;
+        }
+        if (record.header.event_kind != SPG_JOURNAL_EVENT_MODEL_OUTPUT) {
+            continue;
+        }
+        if (n >= max_responses || used + record.payload_used > text_cap) {
+            result = SPG_E_LIMIT;
+            break;
+        }
+        memcpy(text_buf + used, scratch, record.payload_used);
+        responses[n].n    = record.payload_used;
+        responses[n].text = text_buf + used;
+        used += record.payload_used;
+        n += 1u;
+    }
+
+    (void)spg_journal_reader_close(&reader);
+    if (result == SPG_OK) {
+        *count = n;
+    }
+    return result;
 }

--- a/test/test_eval_replay.c
+++ b/test/test_eval_replay.c
@@ -1,0 +1,105 @@
+/* P3 (docs/LEARNING.md): reconstruct a fake-model script from a run's journal.
+ * Write a journal with known MODEL_OUTPUT events interleaved with other kinds
+ * (including an oversized MODEL_INPUT that must be skipped), then reconstruct
+ * and assert the script is exactly the model outputs, in order. */
+#include "geistshell/eval.h"
+#include "geistshell/journal.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static const char out0[] =
+    "(recommend (kind local_shell) (capability \"build.run\") (cost 1) "
+    "(uses_network false) (confidence_bp 6000) (reason \"probe\") "
+    "(command \"echo hi\"))";
+static const char out1[] = "(recommend (kind finish) (reason \"done\"))";
+
+static enum spg_status write_fixture(const char *path) {
+    struct spg_journal_writer w;
+    enum spg_status s = spg_journal_writer_open(&w, path);
+    if (s != SPG_OK) {
+        return s;
+    }
+    uint64_t seq = 0u;
+    /* a big MODEL_INPUT (the context) — larger than the reconstructor's
+     * scratch, so it exercises the skip-on-overflow path */
+    static char big[16384];
+    memset(big, 'x', sizeof big);
+    s = spg_journal_writer_append(&w, 1u, 0u, SPG_JOURNAL_EVENT_MODEL_INPUT,
+                                  SPG_OK, sizeof big, (const uint8_t *)big, &seq);
+    if (s == SPG_OK) {
+        s = spg_journal_writer_append(
+            &w, 2u, seq, SPG_JOURNAL_EVENT_MODEL_OUTPUT, SPG_OK,
+            sizeof out0 - 1u, (const uint8_t *)out0, &seq);
+    }
+    if (s == SPG_OK) {
+        s = spg_journal_writer_append(&w, 3u, seq, SPG_JOURNAL_EVENT_ACTION,
+                                      SPG_OK, 3u, (const uint8_t *)"act", &seq);
+    }
+    if (s == SPG_OK) {
+        s = spg_journal_writer_append(
+            &w, 4u, seq, SPG_JOURNAL_EVENT_MODEL_OUTPUT, SPG_OK,
+            sizeof out1 - 1u, (const uint8_t *)out1, &seq);
+    }
+    const enum spg_status cs = spg_journal_writer_close(&w);
+    return s != SPG_OK ? s : cs;
+}
+
+int main(void) {
+    char path[] = "/tmp/spg_replay_XXXXXX";
+    int  fd     = mkstemp(path);
+    if (fd < 0) {
+        return 1;
+    }
+    close(fd);
+
+    int rc = 1;
+    if (write_fixture(path) != SPG_OK) {
+        fprintf(stderr, "write_fixture failed\n");
+        goto done;
+    }
+
+    struct spg_fake_response responses[8];
+    char                     text[4096];
+    size_t                   count = 0u;
+    if (spg_eval_script_from_journal(path, 8u, responses, sizeof text, text,
+                                     &count) != SPG_OK) {
+        fprintf(stderr, "reconstruct failed\n");
+        goto done;
+    }
+    /* exactly the two MODEL_OUTPUTs, in order, byte-for-byte; the big
+     * MODEL_INPUT and the ACTION event are absent */
+    if (count != 2u) {
+        fprintf(stderr, "count=%zu, expected 2\n", count);
+        goto done;
+    }
+    if (responses[0].n != sizeof out0 - 1u ||
+        memcmp(responses[0].text, out0, responses[0].n) != 0 ||
+        responses[1].n != sizeof out1 - 1u ||
+        memcmp(responses[1].text, out1, responses[1].n) != 0) {
+        fprintf(stderr, "reconstructed script does not match the outputs\n");
+        goto done;
+    }
+
+    /* capacity is enforced, not overrun */
+    if (spg_eval_script_from_journal(path, 1u, responses, sizeof text, text,
+                                     &count) != SPG_E_LIMIT) {
+        fprintf(stderr, "max_responses cap not enforced\n");
+        goto done;
+    }
+    if (spg_eval_script_from_journal(nullptr, 8u, responses, sizeof text, text,
+                                     &count) != SPG_E_INVALID_ARG) {
+        fprintf(stderr, "null arg not rejected\n");
+        goto done;
+    }
+
+    rc = 0;
+done:
+    unlink(path);
+    if (rc == 0) {
+        printf("test_eval_replay: PASS\n");
+    }
+    return rc;
+}


### PR DESCRIPTION
Phase 3 (docs/LEARNING.md, tracking #3). Pipeline step 2.

`spg_eval_script_from_journal` reads a run's journal and reconstructs the fake-model script: each `MODEL_OUTPUT` event → one `spg_fake_response` (the raw recommendation text), in sequence order. Replaying it through `spg_eval_run_case` against the same inputs reproduces the run deterministically — a real run becomes a frozen case the mint gate (P5) can re-run without live inference.

- Payloads copied into a caller buffer; responses point into it.
- The large `MODEL_INPUT` context overflows the small scratch and is skipped (only outputs are needed); an oversized `MODEL_OUTPUT` is a real `SPG_E_LIMIT`.
- Caps enforced (`SPG_E_LIMIT`), null args rejected.

**Test** (`test_eval_replay`): a fixture journal — big `MODEL_INPUT` + two `MODEL_OUTPUT`s + an `ACTION` — reconstructs to exactly the two outputs byte-for-byte, in order; oversized input and action skipped; caps/null rejected. ASan/UBSan clean, full suite green (17 CLI + all unit).

Closes #6.