### PR TITLE
feat(learning): capability-set shape key + positive-guard ring (P4, closes #7)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ SPG_SOURCES := \
     src/dsl/schema.c \
     src/dsl/sexpr.c \
     src/eval/eval.c \
+    src/eval/guard_ring.c \
     src/exec/cmd_executor.c \
     src/exec/cmd_registry.c \
     src/exec/exec_command.c \

--- a/include/geistshell/eval.h
+++ b/include/geistshell/eval.h
@@ -95,6 +95,20 @@ spg_eval_run_case(const struct spg_fake_response *script, size_t script_n,
     struct spg_fake_response responses[], size_t text_cap, char text_buf[],
     size_t *count);
 
+/* Canonical task-shape key from a reconstructed script (docs/LEARNING.md P4):
+ * the SET of "<action_kind>:<capability>" tokens the run's recommendations use
+ * (a finish action has no capability, so just "<action_kind>"), deduplicated,
+ * sorted, joined with '+'. command/target specifics are ignored, so two runs
+ * that touch the same capabilities share a shape — the key the positive-guard
+ * ring dedups on and the token spg_reflect_outcome keys its slug by.
+ *
+ * Writes a NUL-terminated key into out[0..cap); *len receives its length.
+ * Unparseable responses are skipped (a shape is best-effort, not a gate).
+ * Returns SPG_E_INVALID_ARG on null args, SPG_E_LIMIT if the key exceeds cap. */
+[[nodiscard]] enum spg_status spg_shape_from_script(
+    const struct spg_fake_response responses[], size_t n, size_t cap,
+    char out[], size_t *len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/geistshell/guard_ring.h
+++ b/include/geistshell/guard_ring.h
@@ -1,0 +1,63 @@
+#ifndef GEISTSHELL_GUARD_RING_H
+#define GEISTSHELL_GUARD_RING_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Positive-guard ring (docs/LEARNING.md P4): a bounded set of runs that
+ * finished AND passed their criterion, one per distinct task shape, so a
+ * candidate lesson can be gated against "did it break a task that used to
+ * work?" — even for diverse ad-hoc tasks the hand-written suite cannot cover.
+ *
+ * Deduped by shape: recording an existing shape refreshes its guard (case +
+ * recency) instead of adding a copy. When full, the least-recently-seen shape
+ * is evicted, so coverage is capped by the number of distinct shapes, not by
+ * the number of runs. Fixed storage, no allocation. */
+
+#define SPG_GUARD_SHAPE_MAX 128u
+#define SPG_GUARD_PATH_MAX  256u
+#define SPG_GUARD_EXPECT_MAX 256u
+#define SPG_GUARD_RING_CAP  32u
+
+/* A frozen positive case: the shape it represents, the journal to reconstruct
+ * its script from (P3), and the criterion substring to judge it (P1). */
+struct spg_guard {
+    char     shape[SPG_GUARD_SHAPE_MAX + 1u];
+    char     journal_path[SPG_GUARD_PATH_MAX + 1u];
+    char     expect[SPG_GUARD_EXPECT_MAX + 1u];
+    uint64_t last_seen; /* ring clock tick; higher = more recent */
+    bool     used;
+};
+
+struct spg_guard_ring {
+    struct spg_guard slots[SPG_GUARD_RING_CAP];
+    uint64_t         clock; /* monotonically increasing on each record */
+};
+
+void spg_guard_ring_init(struct spg_guard_ring *ring);
+
+/* Record a positive guard for `shape`. If the shape is present, refresh its
+ * case and recency; else insert it, evicting the least-recently-seen shape
+ * when the ring is full. shape/journal_path/expect are copied (truncated to
+ * their maxima). Returns the slot index used, or SPG_GUARD_RING_CAP on a null
+ * argument. */
+size_t spg_guard_ring_record(struct spg_guard_ring *ring, const char *shape,
+                             const char *journal_path, const char *expect);
+
+/* Number of occupied slots. */
+size_t spg_guard_ring_count(const struct spg_guard_ring *ring);
+
+/* Find the guard for `shape`, or nullptr. */
+const struct spg_guard *spg_guard_ring_find(const struct spg_guard_ring *ring,
+                                            const char *shape);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/eval/eval.c
+++ b/src/eval/eval.c
@@ -1,7 +1,11 @@
 #include "geistshell/eval.h"
 
 #include "geistshell/journal.h"
+#include "geistshell/policy.h"
+#include "geistshell/recommendation.h"
+#include "geistshell/sexpr.h"
 
+#include <stdio.h>
 #include <string.h>
 
 const char *spg_eval_outcome_to_string(const enum spg_eval_outcome o) {
@@ -151,4 +155,82 @@ enum spg_status spg_eval_script_from_journal(
         *count = n;
     }
     return result;
+}
+
+enum { SPG_SHAPE_MAX_TOKENS = 16u, SPG_SHAPE_TOKEN_MAX = 48u };
+
+enum spg_status spg_shape_from_script(const struct spg_fake_response responses[],
+                                      const size_t n, const size_t cap,
+                                      char out[], size_t *len) {
+    if (responses == nullptr || out == nullptr || len == nullptr || cap == 0u) {
+        return SPG_E_INVALID_ARG;
+    }
+    *len   = 0u;
+    out[0] = '\0';
+
+    /* Distinct "<kind>:<capability>" tokens, inserted in sorted order (small
+     * fixed set — the codebase does no dynamic allocation). */
+    char   tokens[SPG_SHAPE_MAX_TOKENS][SPG_SHAPE_TOKEN_MAX + 1u];
+    size_t token_count = 0u;
+
+    for (size_t i = 0u; i < n; i++) {
+        struct spg_sexpr_token toks[256];
+        struct spg_sexpr_node  nodes[256];
+        struct spg_recommendation rec = {};
+        struct spg_recommendation_error err = {};
+        if (spg_recommendation_parse(responses[i].n, responses[i].text, 256u,
+                                     toks, 256u, nodes, &rec, &err) != SPG_OK) {
+            continue; /* best-effort: an unparseable reply adds no shape */
+        }
+        char token[SPG_SHAPE_TOKEN_MAX + 1u];
+        const char *kind = spg_action_kind_to_string(rec.action_kind);
+        if (rec.capability.length > 0u) {
+            (void)snprintf(token, sizeof token, "%s:%.*s", kind,
+                           (int)rec.capability.length,
+                           responses[i].text + rec.capability.offset);
+        } else {
+            (void)snprintf(token, sizeof token, "%s", kind);
+        }
+
+        /* insert into the sorted set, skipping duplicates */
+        size_t pos = 0u;
+        bool   dup = false;
+        while (pos < token_count) {
+            const int cmp = strcmp(tokens[pos], token);
+            if (cmp == 0) {
+                dup = true;
+                break;
+            }
+            if (cmp > 0) {
+                break;
+            }
+            pos++;
+        }
+        if (dup || token_count == SPG_SHAPE_MAX_TOKENS) {
+            continue;
+        }
+        for (size_t j = token_count; j > pos; j--) {
+            memcpy(tokens[j], tokens[j - 1u], sizeof tokens[0]);
+        }
+        (void)snprintf(tokens[pos], sizeof tokens[0], "%s", token);
+        token_count++;
+    }
+
+    size_t w = 0u;
+    for (size_t i = 0u; i < token_count; i++) {
+        const size_t tn = strlen(tokens[i]);
+        const size_t sep = (i > 0u) ? 1u : 0u;
+        if (w + sep + tn + 1u > cap) {
+            out[w] = '\0';
+            return SPG_E_LIMIT;
+        }
+        if (sep) {
+            out[w++] = '+';
+        }
+        memcpy(out + w, tokens[i], tn);
+        w += tn;
+    }
+    out[w] = '\0';
+    *len   = w;
+    return SPG_OK;
 }

--- a/src/eval/guard_ring.c
+++ b/src/eval/guard_ring.c
@@ -1,0 +1,80 @@
+#include "geistshell/guard_ring.h"
+
+#include <stdio.h>
+#include <string.h>
+
+void spg_guard_ring_init(struct spg_guard_ring *ring) {
+    if (ring == nullptr) {
+        return;
+    }
+    *ring = (struct spg_guard_ring){};
+}
+
+static void copy_field(char *dst, size_t cap, const char *src) {
+    if (src == nullptr) {
+        dst[0] = '\0';
+        return;
+    }
+    (void)snprintf(dst, cap, "%s", src);
+}
+
+size_t spg_guard_ring_record(struct spg_guard_ring *ring, const char *shape,
+                             const char *journal_path, const char *expect) {
+    if (ring == nullptr || shape == nullptr) {
+        return SPG_GUARD_RING_CAP;
+    }
+    ring->clock += 1u;
+
+    size_t free_slot = SPG_GUARD_RING_CAP;
+    size_t lru_slot  = 0u;
+    for (size_t i = 0u; i < SPG_GUARD_RING_CAP; i++) {
+        struct spg_guard *g = &ring->slots[i];
+        if (g->used && strcmp(g->shape, shape) == 0) {
+            /* refresh the existing shape's case + recency */
+            copy_field(g->journal_path, sizeof g->journal_path, journal_path);
+            copy_field(g->expect, sizeof g->expect, expect);
+            g->last_seen = ring->clock;
+            return i;
+        }
+        if (!g->used && free_slot == SPG_GUARD_RING_CAP) {
+            free_slot = i;
+        }
+        if (ring->slots[i].last_seen < ring->slots[lru_slot].last_seen) {
+            lru_slot = i;
+        }
+    }
+
+    /* new shape: fill a free slot, else evict the least-recently-seen one */
+    const size_t slot = (free_slot != SPG_GUARD_RING_CAP) ? free_slot : lru_slot;
+    struct spg_guard *g = &ring->slots[slot];
+    copy_field(g->shape, sizeof g->shape, shape);
+    copy_field(g->journal_path, sizeof g->journal_path, journal_path);
+    copy_field(g->expect, sizeof g->expect, expect);
+    g->last_seen = ring->clock;
+    g->used      = true;
+    return slot;
+}
+
+size_t spg_guard_ring_count(const struct spg_guard_ring *ring) {
+    if (ring == nullptr) {
+        return 0u;
+    }
+    size_t n = 0u;
+    for (size_t i = 0u; i < SPG_GUARD_RING_CAP; i++) {
+        n += ring->slots[i].used ? 1u : 0u;
+    }
+    return n;
+}
+
+const struct spg_guard *spg_guard_ring_find(const struct spg_guard_ring *ring,
+                                            const char *shape) {
+    if (ring == nullptr || shape == nullptr) {
+        return nullptr;
+    }
+    for (size_t i = 0u; i < SPG_GUARD_RING_CAP; i++) {
+        if (ring->slots[i].used && strcmp(ring->slots[i].shape, shape) == 0) {
+            return &ring->slots[i];
+        }
+    }
+    return nullptr;
+}

--- a/test/test_guard_ring.c
+++ b/test/test_guard_ring.c
@@ -1,0 +1,107 @@
+/* P4 (docs/LEARNING.md): the capability-set shape key and the positive-guard
+ * ring. The shape is the deduplicated, sorted set of "<kind>:<capability>"
+ * tokens; the ring dedups by shape and evicts the least-recently-seen shape
+ * when full. */
+#include "geistshell/eval.h"
+#include "geistshell/guard_ring.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static int test_shape_key(void) {
+    /* two shell steps with distinct capabilities + a finish: the shape is the
+     * sorted SET, so order and repetition do not change it */
+    const char r0[] =
+        "(recommend (kind local_shell) (capability \"proc.exec\") (cost 1) "
+        "(uses_network false) (confidence_bp 6000) (reason \"a\") "
+        "(command \"echo a\"))";
+    const char r1[] =
+        "(recommend (kind local_shell) (capability \"fs.write\") (cost 1) "
+        "(uses_network false) (confidence_bp 6000) (reason \"b\") "
+        "(command \"tee f\"))";
+    const char r2[] = "(recommend (kind finish) (reason \"done\"))";
+    struct spg_fake_response a[] = {
+        {sizeof r0 - 1u, r0}, {sizeof r1 - 1u, r1}, {sizeof r2 - 1u, r2}};
+    char   shape[256];
+    size_t len = 0u;
+    if (spg_shape_from_script(a, 3u, sizeof shape, shape, &len) != SPG_OK) {
+        return 1;
+    }
+    /* sorted set: finish, local_shell:fs.write, local_shell:proc.exec */
+    if (strcmp(shape, "finish+local_shell:fs.write+local_shell:proc.exec") != 0) {
+        fprintf(stderr, "shape=%s\n", shape);
+        return 1;
+    }
+    /* same capabilities, different order + a duplicate -> identical shape */
+    struct spg_fake_response b[] = {
+        {sizeof r1 - 1u, r1}, {sizeof r0 - 1u, r0},
+        {sizeof r0 - 1u, r0}, {sizeof r2 - 1u, r2}};
+    char   shape2[256];
+    size_t len2 = 0u;
+    if (spg_shape_from_script(b, 4u, sizeof shape2, shape2, &len2) != SPG_OK ||
+        strcmp(shape, shape2) != 0) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_ring_dedup_and_lru(void) {
+    struct spg_guard_ring ring;
+    spg_guard_ring_init(&ring);
+
+    /* two distinct shapes -> two guards */
+    spg_guard_ring_record(&ring, "shape-A", "/j/a.sgj", "OK");
+    spg_guard_ring_record(&ring, "shape-B", "/j/b.sgj", "OK");
+    if (spg_guard_ring_count(&ring) != 2u) {
+        return 1;
+    }
+
+    /* re-recording a shape refreshes, does not duplicate */
+    spg_guard_ring_record(&ring, "shape-A", "/j/a2.sgj", "OK2");
+    if (spg_guard_ring_count(&ring) != 2u) {
+        return 1;
+    }
+    const struct spg_guard *a = spg_guard_ring_find(&ring, "shape-A");
+    if (a == nullptr || strcmp(a->journal_path, "/j/a2.sgj") != 0 ||
+        strcmp(a->expect, "OK2") != 0) {
+        return 1;
+    }
+
+    /* fill the ring, then one more distinct shape evicts the least-recently
+     * seen. shape-B was recorded before shape-A's refresh, so among the
+     * originals it is the oldest; touch shape-B to make shape-C-... the LRU. */
+    char name[32];
+    for (unsigned i = 0u; i < SPG_GUARD_RING_CAP; i++) {
+        snprintf(name, sizeof name, "fill-%u", i);
+        spg_guard_ring_record(&ring, name, "/j/f.sgj", "OK");
+    }
+    /* ring is full at CAP distinct shapes */
+    if (spg_guard_ring_count(&ring) != SPG_GUARD_RING_CAP) {
+        return 1;
+    }
+    /* the very first inserted-and-never-refreshed shape must have been evicted
+     * by now (many distinct inserts past capacity) */
+    if (spg_guard_ring_find(&ring, "shape-B") != nullptr) {
+        return 1;
+    }
+    /* a fresh distinct shape still fits by evicting an LRU, never grows past cap */
+    spg_guard_ring_record(&ring, "shape-Z", "/j/z.sgj", "OK");
+    if (spg_guard_ring_count(&ring) != SPG_GUARD_RING_CAP ||
+        spg_guard_ring_find(&ring, "shape-Z") == nullptr) {
+        return 1;
+    }
+    return 0;
+}
+
+int main(void) {
+    if (test_shape_key() != 0) {
+        fprintf(stderr, "test_shape_key failed\n");
+        return 1;
+    }
+    if (test_ring_dedup_and_lru() != 0) {
+        fprintf(stderr, "test_ring_dedup_and_lru failed\n");
+        return 1;
+    }
+    printf("test_guard_ring: PASS\n");
+    return 0;
+}


### PR DESCRIPTION
Phase 4 (docs/LEARNING.md, tracking #3). Depends on P3 (#16).

Diverse ad-hoc script tasks the hand-written suite can't represent need real positive guards, so a candidate lesson is gated against *did it break a task that used to work?*

- **`spg_shape_from_script`** — the task-shape key: the deduplicated, sorted **set** of `<action_kind>:<capability>` tokens the run's recommendations use (`command`/`target` ignored). Order- and duplicate-invariant. Both the ring's dedup key and the token `spg_reflect_outcome` (P2) slugs by.
- **`spg_guard_ring`** — a bounded (32), allocation-free ring of positive guards (shape + journal + criterion). Existing shape → refresh; new shape past capacity → evict least-recently-seen. Coverage capped by distinct shapes, not run count.

**Test** (`test_guard_ring`): shape is order/duplicate-invariant and sorted; ring stores two distinct shapes, refreshes a repeat, evicts LRU past capacity, never grows past cap. ASan/UBSan clean, full suite green (18 CLI + all unit).

Closes #7.