### PR TITLE
feat(learning): live guard-gate machinery, Weg 2 (P5, #8 partial)

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -37,11 +37,17 @@ is the honest place to build "learns from use."
      observed-vs-expected (`"file not found" instead of "SUCCESS"`). No invented
      fix — the fact, and recurrence judges whether stating it helps.
 
-4. **Mint and gate — regression only.** The lesson is persisted tentatively,
-   then re-checked by frozen replay against the shipped hand-written suite
-   **plus a bounded ring of real positive guards** (finished + criterion-passed
-   runs), deduped by capability-set task shape, LRU-evicted. No live inference,
-   sequence-length-neutral. Kept iff `candidate_passed >= baseline_passed`.
+4. **Mint and gate.** The lesson is persisted tentatively, then re-checked
+   against the shipped hand-written suite (frozen, `gate_marker`-reactive)
+   **and a bounded ring of real positive guards** (finished + criterion-passed
+   runs), deduped by capability-set task shape, LRU-evicted. Kept iff nothing
+   regressed. **Weg 2 (chosen):** each guard is re-run **live** — a frozen
+   replay of a real guard ignores context and so cannot react to the lesson at
+   all, so the guard is re-run from its config with, then without, the lesson
+   in the mind-palace; a guard that passed at baseline and fails with the
+   lesson vetoes it. This costs live inference and loads the sequence length —
+   the price accepted for catching a regression on a diverse task at mint time
+   rather than only later (see decision 3).
 
 5. **Measure benefit longitudinally.** No synthetic proof at mint time. If a
    lesson works, its failure slug stops recurring in later journals; if the
@@ -68,7 +74,7 @@ is the honest place to build "learns from use."
 |---|---|---|
 | 1 | Verifier signal is programmatic (exit code, output substring) | Model-judged trajectory — blows a small model's sequence length; is Hermes' self-grading defect. |
 | 2 | Criterion reuses `spg_eval_expect`, optional on the live run | A new type — the eval loop already consumes this one. |
-| 3 | Mint-time gate is regression-only (frozen replay); benefit is longitudinal slug-recurrence | Live re-run to prove benefit — the only path that loads the sequence length, and non-deterministic on the small model. Kept open (see below). |
+| 3 | **Weg 2:** guards are re-run **live** at mint time (with vs without the lesson); a guard that passed and now fails vetoes it. Benefit is still longitudinal slug-recurrence. | Frozen replay of guards — a frozen tape ignores context, so it can never react to a lesson and thus gates nothing (found during P5 implementation). The live re-run's sequence-length cost is accepted for early regression detection on diverse tasks. |
 | 4 | Slug-triggered auto-injection of the single relevant lesson | Model-directed recall — a small model may never emit `memory_read`, so lessons sit unused. |
 | 5 | Frozen suite accumulates real positive guards | Shipped hand-written suite only — cannot represent diverse ad-hoc script tasks; the longitudinal signal is too slow to catch a broken rare type. |
 | 6 | Task-shape key = capability set `(action_kind, capability-class)` | Scenario name — ad-hoc runs have none. `expect` hash — collides unrelated tasks that share "exit 0". |
@@ -77,8 +83,6 @@ is the honest place to build "learns from use."
 
 ## Deliberately open — practice decides
 
-- **Hybrid gate (decision 3c):** a live re-run to prove a lesson helps its own
-  case at mint time. Build only if longitudinal slug-recurrence proves too slow.
 - **Sequence over set (decision 6):** the finer shape key, if too many distinct
   scripts share one capability set and a guard misses regressions.
 - **Post-check command (decision 2):** a last-step shell probe (`exit 0 =

--- a/include/geistshell/guard_ring.h
+++ b/include/geistshell/guard_ring.h
@@ -9,27 +9,31 @@
 extern "C" {
 #endif
 
-/* Positive-guard ring (docs/LEARNING.md P4): a bounded set of runs that
+/* Positive-guard ring (docs/LEARNING.md P4/P5): a bounded set of runs that
  * finished AND passed their criterion, one per distinct task shape, so a
  * candidate lesson can be gated against "did it break a task that used to
  * work?" — even for diverse ad-hoc tasks the hand-written suite cannot cover.
  *
- * Deduped by shape: recording an existing shape refreshes its guard (case +
+ * Weg 2 (P5): a guard is re-run LIVE at mint time from its run config (which
+ * carries the model, scenario, policy and the (expect) criterion) so the real
+ * model reacts to the candidate lesson injected into context — a frozen replay
+ * cannot, it ignores context. A guard therefore stores the config path, not a
+ * frozen journal.
+ *
+ * Deduped by shape: recording an existing shape refreshes its guard (config +
  * recency) instead of adding a copy. When full, the least-recently-seen shape
  * is evicted, so coverage is capped by the number of distinct shapes, not by
  * the number of runs. Fixed storage, no allocation. */
 
 #define SPG_GUARD_SHAPE_MAX 128u
 #define SPG_GUARD_PATH_MAX  256u
-#define SPG_GUARD_EXPECT_MAX 256u
 #define SPG_GUARD_RING_CAP  32u
 
-/* A frozen positive case: the shape it represents, the journal to reconstruct
- * its script from (P3), and the criterion substring to judge it (P1). */
+/* A positive case: the shape it represents and the run config that re-runs and
+ * judges it live (P1's (expect) field lives in the config). */
 struct spg_guard {
     char     shape[SPG_GUARD_SHAPE_MAX + 1u];
-    char     journal_path[SPG_GUARD_PATH_MAX + 1u];
-    char     expect[SPG_GUARD_EXPECT_MAX + 1u];
+    char     config_path[SPG_GUARD_PATH_MAX + 1u];
     uint64_t last_seen; /* ring clock tick; higher = more recent */
     bool     used;
 };
@@ -42,12 +46,12 @@ struct spg_guard_ring {
 void spg_guard_ring_init(struct spg_guard_ring *ring);
 
 /* Record a positive guard for `shape`. If the shape is present, refresh its
- * case and recency; else insert it, evicting the least-recently-seen shape
- * when the ring is full. shape/journal_path/expect are copied (truncated to
- * their maxima). Returns the slot index used, or SPG_GUARD_RING_CAP on a null
+ * config and recency; else insert it, evicting the least-recently-seen shape
+ * when the ring is full. shape/config_path are copied (truncated to their
+ * maxima). Returns the slot index used, or SPG_GUARD_RING_CAP on a null
  * argument. */
 size_t spg_guard_ring_record(struct spg_guard_ring *ring, const char *shape,
-                             const char *journal_path, const char *expect);
+                             const char *config_path);
 
 /* Number of occupied slots. */
 size_t spg_guard_ring_count(const struct spg_guard_ring *ring);
@@ -55,6 +59,31 @@ size_t spg_guard_ring_count(const struct spg_guard_ring *ring);
 /* Find the guard for `shape`, or nullptr. */
 const struct spg_guard *spg_guard_ring_find(const struct spg_guard_ring *ring,
                                             const char *shape);
+
+/* The per-guard veto rule (docs/LEARNING.md P5, Weg 2): a candidate lesson is
+ * only rejected by a guard that PASSED without it and now FAILS with it. A
+ * guard that already failed at baseline (non-determinism, or an unrelated
+ * breakage) carries no signal and never vetoes. True = this guard is fine with
+ * the lesson. */
+static inline bool spg_guard_survives(bool baseline_passed,
+                                      bool trial_passed) {
+    return trial_passed || !baseline_passed;
+}
+
+/* Live-run one guard config and return whether it passed its (expect). When
+ * with_lesson, the candidate lesson is present in the mind-palace so the real
+ * model reacts to it; otherwise it is absent (the baseline). The runner owns
+ * toggling the store and doing the agent run; the gate only sequences it.
+ * ctx is the caller's opaque state. */
+typedef bool (*spg_guard_run_fn)(void *ctx, const char *config_path,
+                                 bool with_lesson);
+
+/* Gate a candidate lesson against every guard (docs/LEARNING.md P5, Weg 2).
+ * For each guard, run it without then with the lesson; the lesson is vetoed
+ * the moment a guard that passed at baseline fails with it. Returns true if
+ * the lesson survives every guard (no regression). An empty ring accepts. */
+bool spg_guard_ring_gate(const struct spg_guard_ring *ring,
+                         spg_guard_run_fn run, void *ctx);
 
 #ifdef __cplusplus
 }

--- a/src/eval/guard_ring.c
+++ b/src/eval/guard_ring.c
@@ -19,7 +19,7 @@ static void copy_field(char *dst, size_t cap, const char *src) {
 }
 
 size_t spg_guard_ring_record(struct spg_guard_ring *ring, const char *shape,
-                             const char *journal_path, const char *expect) {
+                             const char *config_path) {
     if (ring == nullptr || shape == nullptr) {
         return SPG_GUARD_RING_CAP;
     }
@@ -30,9 +30,8 @@ size_t spg_guard_ring_record(struct spg_guard_ring *ring, const char *shape,
     for (size_t i = 0u; i < SPG_GUARD_RING_CAP; i++) {
         struct spg_guard *g = &ring->slots[i];
         if (g->used && strcmp(g->shape, shape) == 0) {
-            /* refresh the existing shape's case + recency */
-            copy_field(g->journal_path, sizeof g->journal_path, journal_path);
-            copy_field(g->expect, sizeof g->expect, expect);
+            /* refresh the existing shape's config + recency */
+            copy_field(g->config_path, sizeof g->config_path, config_path);
             g->last_seen = ring->clock;
             return i;
         }
@@ -48,8 +47,7 @@ size_t spg_guard_ring_record(struct spg_guard_ring *ring, const char *shape,
     const size_t slot = (free_slot != SPG_GUARD_RING_CAP) ? free_slot : lru_slot;
     struct spg_guard *g = &ring->slots[slot];
     copy_field(g->shape, sizeof g->shape, shape);
-    copy_field(g->journal_path, sizeof g->journal_path, journal_path);
-    copy_field(g->expect, sizeof g->expect, expect);
+    copy_field(g->config_path, sizeof g->config_path, config_path);
     g->last_seen = ring->clock;
     g->used      = true;
     return slot;
@@ -77,4 +75,23 @@ const struct spg_guard *spg_guard_ring_find(const struct spg_guard_ring *ring,
         }
     }
     return nullptr;
+}
+
+bool spg_guard_ring_gate(const struct spg_guard_ring *ring,
+                         const spg_guard_run_fn run, void *ctx) {
+    if (ring == nullptr || run == nullptr) {
+        return false;
+    }
+    for (size_t i = 0u; i < SPG_GUARD_RING_CAP; i++) {
+        const struct spg_guard *g = &ring->slots[i];
+        if (!g->used) {
+            continue;
+        }
+        const bool baseline = run(ctx, g->config_path, false);
+        const bool trial    = run(ctx, g->config_path, true);
+        if (!spg_guard_survives(baseline, trial)) {
+            return false; /* this guard regressed under the lesson */
+        }
+    }
+    return true;
 }

--- a/test/test_guard_ring.c
+++ b/test/test_guard_ring.c
@@ -50,20 +50,19 @@ static int test_ring_dedup_and_lru(void) {
     spg_guard_ring_init(&ring);
 
     /* two distinct shapes -> two guards */
-    spg_guard_ring_record(&ring, "shape-A", "/j/a.sgj", "OK");
-    spg_guard_ring_record(&ring, "shape-B", "/j/b.sgj", "OK");
+    spg_guard_ring_record(&ring, "shape-A", "/cfg/a.spg");
+    spg_guard_ring_record(&ring, "shape-B", "/cfg/b.spg");
     if (spg_guard_ring_count(&ring) != 2u) {
         return 1;
     }
 
     /* re-recording a shape refreshes, does not duplicate */
-    spg_guard_ring_record(&ring, "shape-A", "/j/a2.sgj", "OK2");
+    spg_guard_ring_record(&ring, "shape-A", "/cfg/a2.spg");
     if (spg_guard_ring_count(&ring) != 2u) {
         return 1;
     }
     const struct spg_guard *a = spg_guard_ring_find(&ring, "shape-A");
-    if (a == nullptr || strcmp(a->journal_path, "/j/a2.sgj") != 0 ||
-        strcmp(a->expect, "OK2") != 0) {
+    if (a == nullptr || strcmp(a->config_path, "/cfg/a2.spg") != 0) {
         return 1;
     }
 
@@ -73,7 +72,7 @@ static int test_ring_dedup_and_lru(void) {
     char name[32];
     for (unsigned i = 0u; i < SPG_GUARD_RING_CAP; i++) {
         snprintf(name, sizeof name, "fill-%u", i);
-        spg_guard_ring_record(&ring, name, "/j/f.sgj", "OK");
+        spg_guard_ring_record(&ring, name, "/cfg/f.spg");
     }
     /* ring is full at CAP distinct shapes */
     if (spg_guard_ring_count(&ring) != SPG_GUARD_RING_CAP) {
@@ -85,9 +84,74 @@ static int test_ring_dedup_and_lru(void) {
         return 1;
     }
     /* a fresh distinct shape still fits by evicting an LRU, never grows past cap */
-    spg_guard_ring_record(&ring, "shape-Z", "/j/z.sgj", "OK");
+    spg_guard_ring_record(&ring, "shape-Z", "/cfg/z.spg");
     if (spg_guard_ring_count(&ring) != SPG_GUARD_RING_CAP ||
         spg_guard_ring_find(&ring, "shape-Z") == nullptr) {
+        return 1;
+    }
+    return 0;
+}
+
+/* P5 (Weg 2): only a guard that passed without the lesson and fails with it
+ * vetoes; an already-failing guard carries no signal. */
+static int test_guard_veto_rule(void) {
+    if (!spg_guard_survives(true, true)) {   /* passed both -> fine */
+        return 1;
+    }
+    if (spg_guard_survives(true, false)) {   /* pass -> fail: the veto */
+        return 1;
+    }
+    if (!spg_guard_survives(false, false)) { /* already broken -> no signal */
+        return 1;
+    }
+    if (!spg_guard_survives(false, true)) {  /* lesson even helped -> fine */
+        return 1;
+    }
+    return 0;
+}
+
+/* A fake live-runner: a designated "regressing" guard passes at baseline and
+ * fails with the lesson; all others pass both ways. Records the call sequence. */
+struct fake_runner {
+    const char *regressing_config; /* the guard that breaks under the lesson */
+    int         calls;
+};
+static bool fake_run(void *ctx, const char *config_path, bool with_lesson) {
+    struct fake_runner *f = (struct fake_runner *)ctx;
+    f->calls++;
+    if (f->regressing_config != nullptr &&
+        strcmp(config_path, f->regressing_config) == 0) {
+        return !with_lesson; /* passes baseline, fails with the lesson */
+    }
+    return true;
+}
+
+/* P5 (Weg 2): the gate accepts when every guard survives, vetoes the moment a
+ * guard that passed at baseline fails with the lesson. */
+static int test_guard_gate(void) {
+    struct spg_guard_ring ring;
+    spg_guard_ring_init(&ring);
+    spg_guard_ring_record(&ring, "shape-A", "/cfg/a.spg");
+    spg_guard_ring_record(&ring, "shape-B", "/cfg/b.spg");
+
+    /* no guard regresses -> the lesson survives */
+    struct fake_runner ok = {.regressing_config = nullptr};
+    if (!spg_guard_ring_gate(&ring, fake_run, &ok) || ok.calls != 4) {
+        return 1; /* 2 guards x (baseline + trial) */
+    }
+
+    /* one guard regresses under the lesson -> vetoed */
+    struct fake_runner bad = {.regressing_config = "/cfg/b.spg"};
+    if (spg_guard_ring_gate(&ring, fake_run, &bad)) {
+        return 1;
+    }
+
+    /* an empty ring accepts; a null runner is rejected */
+    struct spg_guard_ring empty;
+    spg_guard_ring_init(&empty);
+    struct fake_runner e = {.regressing_config = nullptr};
+    if (!spg_guard_ring_gate(&empty, fake_run, &e) ||
+        spg_guard_ring_gate(&ring, nullptr, &e)) {
         return 1;
     }
     return 0;
@@ -100,6 +164,14 @@ int main(void) {
     }
     if (test_ring_dedup_and_lru() != 0) {
         fprintf(stderr, "test_ring_dedup_and_lru failed\n");
+        return 1;
+    }
+    if (test_guard_veto_rule() != 0) {
+        fprintf(stderr, "test_guard_veto_rule failed\n");
+        return 1;
+    }
+    if (test_guard_gate() != 0) {
+        fprintf(stderr, "test_guard_gate failed\n");
         return 1;
     }
     printf("test_guard_ring: PASS\n");


### PR DESCRIPTION
Phase 5, Weg 2 (docs/LEARNING.md, tracking #3). Depends on P2/P3/P4.

**Design correction found during implementation:** a *frozen* replay of a real positive guard ignores context, so it cannot react to a candidate lesson — it gates nothing. Only a *live* re-run of the real model reacts to the mind-palace lesson. So **Weg 2**: guards are re-run live at mint time. Decisions 3 and 5 in LEARNING.md corrected.

This PR lands the **verifiable gate machinery**:
- guard stores `config_path` (re-runnable task; P1's `(expect)` lives in the config), not a frozen journal.
- `spg_guard_survives`: only a guard that **passed** without the lesson and **fails** with it vetoes; an already-failing guard carries no signal.
- `spg_guard_ring_gate`: sequences baseline-then-trial over every guard through an **injected runner**, so the full gate logic is unit-tested with a fake runner (designated guard regresses → veto; none → accept; empty ring accepts; null runner rejected).

**Remaining for #8** (kept open): the CLI `--guard` live runner — loads the model, toggles the lesson in the store around the two runs — plus a GGUF-gated end-to-end veto test. The real-model reaction cannot be exercised with a fake model, so that test is model-gated.

Full suite green (18 CLI + all unit), ASan/UBSan clean.