### PR TITLE
feat(learning): slug-triggered lesson auto-injection (P6, closes #9)

### DIFF
--- a/include/geistshell/agent_loop.h
+++ b/include/geistshell/agent_loop.h
@@ -47,6 +47,14 @@ struct spg_agent_loop_config {
      * workspace (observation_buf). */
     size_t max_repairs;
 
+    /* Slug-triggered lesson auto-injection budget (docs/LEARNING.md P6): when a
+     * step is rejected and a stored lesson names that failure slug, its
+     * one-line directive is injected into the repair observation without the
+     * model having to recall it — capped to this many bytes (0 = the store's
+     * description cap; a small model with a short sequence length sets it low).
+     * At most one directive per tick. Requires state->store. */
+    size_t lesson_budget_bytes;
+
     /* Optional trajectory feedback: a caller-owned array the loop binds to the
      * journal writer so every event from earlier steps is rendered into the
      * next step's context (the agent sees its own history, not just the last

--- a/include/geistshell/mem_store.h
+++ b/include/geistshell/mem_store.h
@@ -90,6 +90,17 @@ struct spg_mem_store {
                                             size_t *out_required,
                                             bool   *truncated);
 
+/* The one-line DIRECTIVE (description) of a single memory, for slug-triggered
+ * auto-injection on small models (docs/LEARNING.md P6): when the loop hits a
+ * failure whose slug names a stored lesson, its directive is injected without
+ * the model having to recall it, and the full body is left in the mind-palace
+ * for larger models. budget_bytes caps the injected length (0 = the store's
+ * description cap); an over-budget or missing directive writes nothing.
+ * Writes a NUL-terminated directive into dst[0..dst_cap) and returns its
+ * length, or 0 when the slug has no memory / does not fit / on bad args. */
+size_t spg_mem_directive(struct spg_mem_store *store, const char *slug,
+                         size_t budget_bytes, size_t dst_cap, char dst[]);
+
 /* Enumerate memory slugs (slug-sorted) into slugs[0..*count). Returns
  * SPG_E_LIMIT if there are more than cap (the first cap are written). */
 [[nodiscard]] enum spg_status

--- a/src/memory/mem_store.c
+++ b/src/memory/mem_store.c
@@ -486,3 +486,47 @@ enum spg_status spg_mem_list(struct spg_mem_store *store, const size_t cap,
     *count = n;
     return total > cap ? SPG_E_LIMIT : SPG_OK;
 }
+
+size_t spg_mem_directive(struct spg_mem_store *store, const char *slug,
+                         const size_t budget_bytes, const size_t dst_cap,
+                         char dst[]) {
+    if (store == nullptr || slug == nullptr || dst == nullptr || dst_cap == 0u) {
+        return 0u;
+    }
+    dst[0] = '\0';
+
+    /* The index renders one "- <slug>: <description>\n" line per memory; the
+     * directive is a slug's description, extracted without a new read path. */
+    static char index[SPG_MEM_INDEX_CACHE_BYTES];
+    if (spg_mem_index(store, sizeof index, index, nullptr, nullptr) != SPG_OK) {
+        return 0u;
+    }
+
+    char prefix[SPG_MEM_SLUG_MAX + 4u];
+    const int pn = snprintf(prefix, sizeof prefix, "- %s: ", slug);
+    if (pn <= 0 || (size_t)pn >= sizeof prefix) {
+        return 0u;
+    }
+    const char *line = index;
+    while (*line != '\0') {
+        const char *eol = strchr(line, '\n');
+        const size_t line_n = eol != nullptr ? (size_t)(eol - line) : strlen(line);
+        if (strncmp(line, prefix, (size_t)pn) == 0) {
+            const char  *desc   = line + pn;
+            const size_t desc_n = line_n - (size_t)pn;
+            const size_t budget =
+                budget_bytes > 0u ? budget_bytes : SPG_MEM_DESC_MAX;
+            if (desc_n == 0u || desc_n > budget || desc_n + 1u > dst_cap) {
+                return 0u; /* one slot, description-only, budget-capped */
+            }
+            memcpy(dst, desc, desc_n);
+            dst[desc_n] = '\0';
+            return desc_n;
+        }
+        if (eol == nullptr) {
+            break;
+        }
+        line = eol + 1u;
+    }
+    return 0u;
+}

--- a/src/run/agent_loop.c
+++ b/src/run/agent_loop.c
@@ -1,5 +1,7 @@
 #include "geistshell/agent_loop.h"
 
+#include "geistshell/mem_store.h" /* P6: slug-triggered directive injection */
+
 #include <stdio.h>
 
 static void add_u64(uint64_t *acc, const uint64_t v) {
@@ -146,12 +148,25 @@ enum spg_status spg_agent_loop_run(
             if (result->repairs_used < config->max_repairs &&
                 workspace->observation_buf != nullptr &&
                 workspace->observation_capacity > 0u) {
+                /* Slug-triggered auto-injection (P6): if a stored lesson names
+                 * this failure slug, lead the repair observation with its
+                 * earned directive — no memory_read needed, one slot, budgeted.
+                 * The generic hint always follows so a repair works even when
+                 * no lesson exists yet. */
+                char   directive[SPG_MEM_DESC_MAX + 1u];
+                size_t dn =
+                    state->store != nullptr
+                        ? spg_mem_directive(state->store, "lesson-rejected",
+                                            config->lesson_budget_bytes,
+                                            sizeof directive, directive)
+                        : 0u;
                 (void)snprintf(
                     workspace->observation_buf,
                     workspace->observation_capacity,
-                    "[invalid recommendation: %s] Reply with exactly one valid "
-                    "(recommend ...) form, or (recommend (kind finish) "
+                    "%s%s[invalid recommendation: %s] Reply with exactly one "
+                    "valid (recommend ...) form, or (recommend (kind finish) "
                     "(reason \"...\")).",
+                    dn > 0u ? directive : "", dn > 0u ? " " : "",
                     spg_recommendation_reject_reason_to_string(
                         step_result.recommendation.reject_reason));
                 result->repairs_used += 1u;

--- a/test/test_cli_autoinject.sh
+++ b/test/test_cli_autoinject.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# System test: slug-triggered lesson auto-injection (docs/LEARNING.md P6).
+# When a stored lesson names the current failure slug, the loop leads the
+# repair observation with its earned directive — no memory_read needed. With
+# no such lesson, only the generic hint appears. Model-free (fake script).
+set -eu
+
+SPG_BIN=${SPG_BIN:-build/host-debug/bin/geistshell}
+CHAT=$(dirname "$SPG_BIN")/geistshell-chat
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT
+
+cat > "$T/run.spg" <<EOF
+(run
+ (model "fake.gguf")
+ (policy "examples/policy.spg")
+ (scenario "examples/scenario.spg")
+ (corpus "examples/corpus.spg")
+ (journal "$T/j.sgj")
+ (seed 42)
+ (budgets (inference_steps 8) (tokens 256) (shell_actions 1) (sim_actions 8) (wall_ms 10000) (journal_bytes 1048576) (risk_bp 10000)))
+EOF
+
+# a script that stays malformed: repair fires once, then terminates rejected,
+# leaving the repair observation (with any directive) in the buffer
+cat > "$T/bad.txt" <<'EOF'
+not a recommendation
+still not a recommendation
+EOF
+
+MEM=$(mktemp -d)
+# Seed a lesson-rejected via improve over the shipped gated suite.
+"$SPG_BIN" improve examples/eval/improve_gated.spg --memory-dir "$MEM" >/dev/null 2>&1
+test -f "$MEM/lesson-rejected.md"
+
+# WITH the lesson in the store: the directive (its description) leads the
+# repair observation.
+"$SPG_BIN" agent --config "$T/run.spg" --fake-script "$T/bad.txt" \
+    --memory-dir "$MEM" --max-steps 5 --max-repairs 1 > "$T/with.out" 2>&1
+grep -q "termination=rejected" "$T/with.out"
+grep -q "Emit exactly one valid recommendation s-expression" "$T/with.out"
+
+# WITHOUT a lesson (empty memory dir): only the generic hint, no directive.
+MT=$(mktemp -d)
+"$SPG_BIN" agent --config "$T/run.spg" --fake-script "$T/bad.txt" \
+    --memory-dir "$MT" --max-steps 5 --max-repairs 1 > "$T/without.out" 2>&1
+grep -q "termination=rejected" "$T/without.out"
+! grep -q "Emit exactly one valid recommendation s-expression" "$T/without.out"
+
+rm -rf "$MEM" "$MT"
+echo "test_cli_autoinject: PASS"

--- a/test/test_mem_store.c
+++ b/test/test_mem_store.c
@@ -59,6 +59,46 @@ static int test_save_read_roundtrip(void) {
     return required == strlen(out) ? 0 : 1;
 }
 
+/* P6 (docs/LEARNING.md): the one-line directive for slug-triggered
+ * auto-injection — description only, budget-capped, one slot. */
+static int test_directive(void) {
+    struct spg_mem_store store;
+    char                 dir[64];
+    if (open_temp(&store, dir) != 0) {
+        return 1;
+    }
+    if (spg_mem_save(&store, "lesson-rejected", "Emit one valid form.",
+                     "long body text that must NOT be injected") != SPG_OK) {
+        return 1;
+    }
+    char   out[256];
+    /* the directive is the description, not the body */
+    size_t n = spg_mem_directive(&store, "lesson-rejected", 0u, sizeof out, out);
+    if (n != strlen("Emit one valid form.") ||
+        strcmp(out, "Emit one valid form.") != 0) {
+        return 1;
+    }
+    /* a budget smaller than the description injects nothing (over budget) */
+    if (spg_mem_directive(&store, "lesson-rejected", 5u, sizeof out, out) != 0u ||
+        out[0] != '\0') {
+        return 1;
+    }
+    /* a budget that fits still returns it */
+    if (spg_mem_directive(&store, "lesson-rejected", 64u, sizeof out, out) == 0u) {
+        return 1;
+    }
+    /* an unknown slug injects nothing */
+    if (spg_mem_directive(&store, "lesson-absent", 0u, sizeof out, out) != 0u) {
+        return 1;
+    }
+    /* null args are rejected */
+    if (spg_mem_directive(nullptr, "x", 0u, sizeof out, out) != 0u ||
+        spg_mem_directive(&store, nullptr, 0u, sizeof out, out) != 0u) {
+        return 1;
+    }
+    return 0;
+}
+
 static int test_upsert_overwrites(void) {
     struct spg_mem_store store;
     char                 dir[64];
@@ -235,6 +275,10 @@ int main(void) {
     }
     if (test_save_read_roundtrip() != 0) {
         fprintf(stderr, "test_save_read_roundtrip failed\n");
+        return 1;
+    }
+    if (test_directive() != 0) {
+        fprintf(stderr, "test_directive failed\n");
         return 1;
     }
     if (test_upsert_overwrites() != 0) {


### PR DESCRIPTION
Phase 6 (docs/LEARNING.md, tracking #3) — the small-model core.

A small model may never emit `memory_read`, so the loop injects the right lesson itself: the failure state it already knows is the trigger.

- `spg_mem_directive`: the one-line **directive** (a slug's description, not its body), budget-capped (one slot), extracted from the rendered index — no new store read path.
- **agent_loop repair path**: on a rejection, if a stored lesson names the slug (`lesson-rejected`), its directive leads the repair observation; the generic hint always follows. Sequence-length cost is one directive line, capped by `config.lesson_budget_bytes` — the per-model knob (a short-window model sets it low). Full body stays in the mind-palace for larger models.

**Tests**: unit (description-only, over-budget → nothing, unknown slug / null → nothing) + end-to-end `test_cli_autoinject` (the directive leads the repair observation **only** when the lesson is stored — proven both ways). Full suite green (20 CLI + all unit), ASan/UBSan clean.

Closes #9.