### PR TITLE
feat(learning): longitudinal slug-recurrence benefit metric (P7, closes #10)

### DIFF
--- a/include/geistshell/eval.h
+++ b/include/geistshell/eval.h
@@ -109,6 +109,23 @@ spg_eval_run_case(const struct spg_fake_response *script, size_t script_n,
     const struct spg_fake_response responses[], size_t n, size_t cap,
     char out[], size_t *len);
 
+/* Per-slug failure recurrence in one journal (docs/LEARNING.md P7): the
+ * benefit of a kept lesson is not proven at mint time but observed in the
+ * field — a lesson that works makes its failure slug stop recurring. This
+ * tallies the loop-failure events a real run journals: a rejected
+ * recommendation (ERROR + "recommendation_rejected") and a policy denial
+ * (POLICY_DECISION with a deny_reason other than NONE). The counts ACCUMULATE
+ * into *out, so summing across a run's journals is repeated calls. Model-free:
+ * reads the journal only. Returns SPG_E_INVALID_ARG on null args, a journal
+ * read error otherwise; a missing/short journal counts nothing and is OK. */
+struct spg_recurrence {
+    size_t rejected; /* slug lesson-rejected */
+    size_t denied;   /* slug lesson-denied */
+};
+
+[[nodiscard]] enum spg_status spg_journal_recurrence(
+    const char *journal_path, struct spg_recurrence *out);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -2639,6 +2639,71 @@ static bool guard_run(void *vctx, const char *config_path, bool with_lesson) {
     return passed;
 }
 
+/* Longitudinal benefit audit (docs/LEARNING.md P7): a kept lesson earns its
+ * keep only if its failure slug stops recurring in later real runs. Sum the
+ * failure-mode events across the given journals and, for each kept lesson in
+ * the memory dir, flag whether its slug still recurs (review) or has dropped
+ * to zero (kept). Model-free: reads journals only. */
+static int audit_command(int argc, char **argv) {
+    const char *memory_dir = nullptr;
+    const char *journals[EVAL_MAX_CASES];
+    size_t      njournals = 0u;
+    for (int i = 2; i < argc; i += 1) {
+        if (strcmp(argv[i], "--memory-dir") == 0 && i + 1 < argc) {
+            memory_dir = argv[++i];
+            continue;
+        }
+        if (argv[i][0] != '-' && njournals < EVAL_MAX_CASES) {
+            journals[njournals++] = argv[i];
+            continue;
+        }
+        fprintf(stderr, "audit: unexpected argument: %s\n", argv[i]);
+        return 2;
+    }
+    if (njournals == 0u) {
+        fprintf(stderr, "usage: %s audit <journal.sgj>... [--memory-dir <d>]\n",
+                argv[0]);
+        return 2;
+    }
+
+    struct spg_recurrence total = {};
+    for (size_t i = 0u; i < njournals; i += 1u) {
+        if (spg_journal_recurrence(journals[i], &total) != SPG_OK) {
+            fprintf(stderr, "audit: cannot read journal %s\n", journals[i]);
+            return 1;
+        }
+    }
+    printf("{\"journals\":%zu,\"lesson-rejected\":%zu,\"lesson-denied\":%zu}\n",
+           njournals, total.rejected, total.denied);
+
+    /* Cross-reference kept lessons: a slug present in memory whose recurrence
+     * is still > 0 is not doing its job. */
+    if (memory_dir != nullptr) {
+        struct spg_mem_store store;
+        if (spg_mem_store_open(&store, spg_mem_resolve_dir(memory_dir)) !=
+            SPG_OK) {
+            fprintf(stderr, "audit: cannot open memory dir\n");
+            return 1;
+        }
+        char   probe[SPG_MEM_DESC_MAX + 1u];
+        const struct {
+            const char *slug;
+            size_t      count;
+        } kept[] = {{"lesson-rejected", total.rejected},
+                    {"lesson-denied", total.denied}};
+        for (size_t i = 0u; i < sizeof kept / sizeof kept[0]; i += 1u) {
+            if (spg_mem_directive(&store, kept[i].slug, 0u, sizeof probe,
+                                  probe) == 0u) {
+                continue; /* no such lesson kept */
+            }
+            printf("{\"lesson\":\"%s\",\"recurrence\":%zu,\"verdict\":\"%s\"}\n",
+                   kept[i].slug, kept[i].count,
+                   kept[i].count > 0u ? "review" : "kept");
+        }
+    }
+    return 0;
+}
+
 /* Self-improvement: run the suite, distill a lesson for each failing case,
  * persist each tentatively into the mind-palace, re-run, and keep it only if
  * the pass count did not drop (else revert). Emits a JSONL report. */
@@ -2943,6 +3008,10 @@ int main(int argc, char **argv) {
 
     if (strcmp(argv[1], "improve") == 0) {
         return improve_command(argc, argv);
+    }
+
+    if (strcmp(argv[1], "audit") == 0) {
+        return audit_command(argc, argv);
     }
 
     if (strcmp(argv[1], "verify-journal") == 0) {

--- a/src/eval/eval.c
+++ b/src/eval/eval.c
@@ -234,3 +234,45 @@ enum spg_status spg_shape_from_script(const struct spg_fake_response responses[]
     *len   = w;
     return SPG_OK;
 }
+
+enum spg_status spg_journal_recurrence(const char *journal_path,
+                                       struct spg_recurrence *out) {
+    if (journal_path == nullptr || out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    struct spg_journal_reader reader;
+    if (spg_journal_reader_open(&reader, journal_path) != SPG_OK) {
+        return SPG_OK; /* no journal yet -> nothing recurred */
+    }
+    char scratch[8192];
+    for (;;) {
+        struct spg_journal_record record = {};
+        const enum spg_status rs = spg_journal_reader_next(
+            &reader, sizeof scratch, (uint8_t *)scratch, &record);
+        if (rs == SPG_E_NOT_FOUND) {
+            break;
+        }
+        if (rs == SPG_E_LIMIT) {
+            continue; /* an oversized payload carries no failure marker we read */
+        }
+        if (rs != SPG_OK) {
+            (void)spg_journal_reader_close(&reader);
+            return rs;
+        }
+        const size_t n = record.payload_used < sizeof scratch
+                             ? record.payload_used
+                             : sizeof scratch - 1u;
+        scratch[n] = '\0';
+        if (record.header.event_kind == SPG_JOURNAL_EVENT_ERROR &&
+            strstr(scratch, "recommendation_rejected") != nullptr) {
+            out->rejected += 1u;
+        } else if (record.header.event_kind ==
+                       SPG_JOURNAL_EVENT_POLICY_DECISION &&
+                   strstr(scratch, "deny_reason") != nullptr &&
+                   strstr(scratch, "SPG_POLICY_DENY_NONE") == nullptr) {
+            out->denied += 1u;
+        }
+    }
+    (void)spg_journal_reader_close(&reader);
+    return SPG_OK;
+}

--- a/test/test_cli_audit.sh
+++ b/test/test_cli_audit.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# System test: the longitudinal benefit audit (docs/LEARNING.md P7). A real
+# run that keeps rejecting journals the failure; audit tallies the recurrence
+# per slug and flags a kept lesson whose slug still recurs. Model-free.
+set -eu
+
+SPG_BIN=${SPG_BIN:-build/host-debug/bin/geistshell}
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT
+
+cat > "$T/run.spg" <<EOF
+(run
+ (model "fake.gguf")
+ (policy "examples/policy.spg")
+ (scenario "examples/scenario.spg")
+ (corpus "examples/corpus.spg")
+ (journal "$T/j.sgj")
+ (seed 42)
+ (budgets (inference_steps 8) (tokens 256) (shell_actions 1) (sim_actions 8) (wall_ms 10000) (journal_bytes 1048576) (risk_bp 10000)))
+EOF
+
+# a run that rejects (malformed reply): the journal records the rejection
+cat > "$T/bad.txt" <<'EOF'
+not a recommendation
+still not a recommendation
+EOF
+"$SPG_BIN" agent --config "$T/run.spg" --fake-script "$T/bad.txt" \
+    --max-steps 5 --max-repairs 1 >/dev/null 2>&1
+
+# audit the journal: the rejection slug recurs at least once
+OUT=$("$SPG_BIN" audit "$T/j.sgj")
+echo "$OUT" | grep -q '"lesson-rejected":[1-9]'
+
+# with a kept lesson-rejected in memory, the audit flags it "review" (still
+# recurring)
+MEM=$(mktemp -d)
+"$SPG_BIN" improve examples/eval/improve_gated.spg --memory-dir "$MEM" >/dev/null 2>&1
+test -f "$MEM/lesson-rejected.md"
+OUT2=$("$SPG_BIN" audit "$T/j.sgj" --memory-dir "$MEM")
+echo "$OUT2" | grep -q '"lesson":"lesson-rejected","recurrence":[1-9][0-9]*,"verdict":"review"'
+
+# a clean run (finish) journals no rejection -> a fresh lesson reads "kept"
+cat > "$T/good.txt" <<'EOF'
+(recommend (kind finish) (reason "done"))
+EOF
+rm -f "$T/j.sgj"
+"$SPG_BIN" agent --config "$T/run.spg" --fake-script "$T/good.txt" \
+    --max-steps 5 >/dev/null 2>&1
+OUT3=$("$SPG_BIN" audit "$T/j.sgj" --memory-dir "$MEM")
+echo "$OUT3" | grep -q '"lesson":"lesson-rejected","recurrence":0,"verdict":"kept"'
+
+rm -rf "$MEM"
+echo "test_cli_audit: PASS"

--- a/test/test_eval_replay.c
+++ b/test/test_eval_replay.c
@@ -47,7 +47,79 @@ static enum spg_status write_fixture(const char *path) {
     return s != SPG_OK ? s : cs;
 }
 
+/* P7: a journal with a rejected recommendation and a policy denial tallies
+ * one of each; an allow decision must NOT count as a denial. */
+static enum spg_status write_recurrence_fixture(const char *path) {
+    struct spg_journal_writer w;
+    enum spg_status s = spg_journal_writer_open(&w, path);
+    if (s != SPG_OK) {
+        return s;
+    }
+    uint64_t seq = 0u;
+    const char rej[] = "(recommendation_rejected (reason syntax))";
+    const char deny[] =
+        "(policy_decision (decision deny) (deny_reason "
+        "SPG_POLICY_DENY_DISABLED_CAPABILITY))";
+    const char allow[] =
+        "(policy_decision (decision allow) (deny_reason SPG_POLICY_DENY_NONE))";
+    s = spg_journal_writer_append(&w, 1u, 0u, SPG_JOURNAL_EVENT_ERROR, SPG_OK,
+                                  sizeof rej - 1u, (const uint8_t *)rej, &seq);
+    if (s == SPG_OK) {
+        s = spg_journal_writer_append(&w, 2u, seq,
+                                      SPG_JOURNAL_EVENT_POLICY_DECISION, SPG_OK,
+                                      sizeof deny - 1u, (const uint8_t *)deny,
+                                      &seq);
+    }
+    if (s == SPG_OK) {
+        s = spg_journal_writer_append(&w, 3u, seq,
+                                      SPG_JOURNAL_EVENT_POLICY_DECISION, SPG_OK,
+                                      sizeof allow - 1u, (const uint8_t *)allow,
+                                      &seq);
+    }
+    const enum spg_status cs = spg_journal_writer_close(&w);
+    return s != SPG_OK ? s : cs;
+}
+
+static int test_recurrence(void) {
+    char path[] = "/tmp/spg_recur_XXXXXX";
+    int  fd     = mkstemp(path);
+    if (fd < 0) {
+        return 1;
+    }
+    close(fd);
+    int rc = 1;
+    if (write_recurrence_fixture(path) != SPG_OK) {
+        goto done;
+    }
+    struct spg_recurrence r = {};
+    /* accumulates: call twice -> counts double */
+    if (spg_journal_recurrence(path, &r) != SPG_OK ||
+        spg_journal_recurrence(path, &r) != SPG_OK) {
+        goto done;
+    }
+    if (r.rejected != 2u || r.denied != 2u) {
+        fprintf(stderr, "recurrence rejected=%zu denied=%zu\n", r.rejected,
+                r.denied);
+        goto done;
+    }
+    /* a missing journal counts nothing and is not an error */
+    struct spg_recurrence z = {};
+    if (spg_journal_recurrence("/tmp/spg_no_such_journal", &z) != SPG_OK ||
+        z.rejected != 0u || z.denied != 0u) {
+        goto done;
+    }
+    rc = 0;
+done:
+    unlink(path);
+    return rc;
+}
+
 int main(void) {
+    if (test_recurrence() != 0) {
+        fprintf(stderr, "test_recurrence failed\n");
+        return 1;
+    }
+
     char path[] = "/tmp/spg_replay_XXXXXX";
     int  fd     = mkstemp(path);
     if (fd < 0) {


### PR DESCRIPTION
Phase 7 (docs/LEARNING.md, tracking #3) — the benefit signal that closes the loop.

Benefit is not proven synthetically at mint time; it is observed in the field: a lesson that works makes its failure slug stop recurring.

- `spg_journal_recurrence`: tallies the loop-failure events a real run journals — a rejected recommendation (`ERROR` + `recommendation_rejected`) and a policy denial (`POLICY_DECISION` with a `deny_reason` other than `NONE`). Accumulates across journals. Model-free: reads the journal only.
- `audit` subcommand: sums recurrence across journals, prints per slug, and — with `--memory-dir` — flags each kept lesson `review` (slug still recurs) or `kept` (dropped to zero).

**Tests**: unit (rejection + denial tallied, allow **not** counted, accumulation, missing journal = zero + OK) + end-to-end `test_cli_audit` (rejecting run → `review`, clean run → `kept`). Full suite green (21 CLI + all unit), ASan/UBSan clean.

Closes #10.