### PR TITLE
fix(portability): _POSIX_C_SOURCE for mkstemp on strict libc

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -1,3 +1,8 @@
+#define _POSIX_C_SOURCE 200809L /* mkstemp/write/unlink: the guard-gate temp suite */
+#if defined(__APPLE__)
+#    define _DARWIN_C_SOURCE 1
+#endif
+
 #include "geistshell/geistshell.h"
 
 #include "geistshell/agent_loop.h"

--- a/test/test_eval_replay.c
+++ b/test/test_eval_replay.c
@@ -2,6 +2,11 @@
  * Write a journal with known MODEL_OUTPUT events interleaved with other kinds
  * (including an oversized MODEL_INPUT that must be skipped), then reconstruct
  * and assert the script is exactly the model outputs, in order. */
+#define _POSIX_C_SOURCE 200809L /* mkstemp/close/unlink/write */
+#if defined(__APPLE__)
+#    define _DARWIN_C_SOURCE 1
+#endif
+
 #include "geistshell/eval.h"
 #include "geistshell/journal.h"
 


### PR DESCRIPTION
The P5/P3 code used mkstemp without the feature-test macro; macOS headers expose it under -std=c23 but glibc/musl hide it, so the Pi build failed on 'mkstemp undeclared'. Adds the codebase's standard `#define _POSIX_C_SOURCE 200809L` (+ _DARWIN_C_SOURCE) prologue to the two touched files.