### PR TITLE
bench(learning): context-cost benchmark + directive-beyond-cap fix (#25 partial)

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -89,6 +89,32 @@ is the honest place to build "learns from use."
   success`) verifying world state, for tasks that produce files rather than
   stdout.
 
+## Context-cost benchmark (2026-08-02, model-free)
+
+`eval/bench_context.sh` measures the load-bearing half of the small-seq-len
+claim: the context cost of learning per tick as the lesson set grows.
+
+| lessons | geistshell (directive) | full-index RAG |
+|---|---|---|
+| 1  | 72 B | 90 B |
+| 4  | 72 B | 360 B |
+| 8  | 72 B | 720 B |
+| 16 | 72 B | 1454 B |
+| 32 | 72 B | 2233 B |
+
+geistshell's per-tick learning cost is **flat** (one budgeted directive)
+while the mind-palace-index approach grows linearly — 31× more context at 32
+lessons, and widening. This substantiates the *denominator* of the SOTA
+claim (learning is context-invariant). It does **not** measure success lift:
+the numerator (does flat context still improve task success?) needs a
+model-completable task corpus and real inference — the remaining half of #25.
+A benchmark that measures only the free half must say so.
+
+The benchmark also surfaced and fixed a real bug: `spg_mem_directive`
+originally read the *capped* index, so a slug beyond `SPG_MEM_INDEX_TOPK`
+injected nothing; it now reads the description from the memory file, available
+for any slug.
+
 ## Hardware verification (2026-08-02, Pi 5 against Gemma 4 E2B)
 
 The model-dependent paths, run live through the whole stack (release build,

--- a/eval/bench_context.sh
+++ b/eval/bench_context.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Benchmark (geistshell#25): the context cost of learning, per tick, as the
+# lesson set grows. The load-bearing half of the small-seq-len claim, measured
+# model-free and deterministically.
+#
+#   geistshell arm  = one slug's directive (P6 auto-injection): must stay flat
+#   full-index RAG  = the whole mind-palace index (the large-model path): grows
+#
+# It does NOT measure task-success lift — that needs a model-completable corpus
+# and real inference (the remaining half of #25). This proves only the
+# denominator: geistshell's learning is context-invariant, RAG's is not.
+set -eu
+
+SPG_BIN=${SPG_BIN:-build/host-release/bin/geistshell}
+[ -x "$SPG_BIN" ] || SPG_BIN=build/host-debug/bin/geistshell
+MEM=$(mktemp -d)
+trap 'rm -rf "$MEM"' EXIT
+
+bytes() { wc -c | tr -d ' '; }
+
+printf '%-8s %-22s %-22s\n' "lessons" "geistshell_bytes/tick" "full_index_bytes/tick"
+K=0
+for TARGET in 1 4 8 16 32; do
+    while [ "$K" -lt "$TARGET" ]; do
+        K=$((K + 1))
+        # distinct slug + a realistic ~120-char directive (reflect-sized)
+        printf 'body for lesson %d\n' "$K" | "$SPG_BIN" memory save \
+            "lesson-shape-$K" \
+            "For a task of shape $K, emit exactly one valid form and finish promptly." \
+            --dir "$MEM" >/dev/null
+    done
+    GS=$("$SPG_BIN" memory directive "lesson-shape-1" --dir "$MEM" | bytes)
+    RAG=$("$SPG_BIN" memory list --dir "$MEM" | bytes)
+    printf '%-8s %-22s %-22s\n' "$K" "$GS" "$RAG"
+done

--- a/src/memory/mem_command.c
+++ b/src/memory/mem_command.c
@@ -75,6 +75,23 @@ int spg_memory_command(const int argc, char **argv) {
         return 0;
     }
 
+    if (strcmp(verb, "directive") == 0) {
+        /* The one-line P6 injection for a slug (docs/LEARNING.md): what the
+         * small-model auto-injection actually costs, vs the full `list` index. */
+        if (np < 2u) {
+            usage();
+            return 2;
+        }
+        char         line[SPG_MEM_DESC_MAX + 1u];
+        const size_t n =
+            spg_mem_directive(&store, pos[1], 0u, sizeof line, line);
+        if (n == 0u) {
+            return 1;
+        }
+        puts(line);
+        return 0;
+    }
+
     if (strcmp(verb, "save") == 0) {
         if (np < 3u) {
             usage();

--- a/src/memory/mem_store.c
+++ b/src/memory/mem_store.c
@@ -495,38 +495,29 @@ size_t spg_mem_directive(struct spg_mem_store *store, const char *slug,
     }
     dst[0] = '\0';
 
-    /* The index renders one "- <slug>: <description>\n" line per memory; the
-     * directive is a slug's description, extracted without a new read path. */
-    static char index[SPG_MEM_INDEX_CACHE_BYTES];
-    if (spg_mem_index(store, sizeof index, index, nullptr, nullptr) != SPG_OK) {
+    /* Read the slug's memory directly and lift the "description:" frontmatter
+     * line. Reading the file (not the rendered index) is what makes the
+     * directive available for ANY slug — the index is capped at
+     * SPG_MEM_INDEX_TOPK lines, so a slug beyond the cap has no index line and
+     * its directive would silently vanish (found via the #25 benchmark). */
+    static char content[SPG_MEM_BODY_MAX + SPG_MEM_DESC_MAX + 256u];
+    if (spg_mem_read(store, slug, sizeof content, content, nullptr) != SPG_OK) {
         return 0u;
     }
-
-    char prefix[SPG_MEM_SLUG_MAX + 4u];
-    const int pn = snprintf(prefix, sizeof prefix, "- %s: ", slug);
-    if (pn <= 0 || (size_t)pn >= sizeof prefix) {
+    /* frontmatter: "name: <slug>\ndescription: <text>\n" — description is never
+     * the first line, so a leading-newline match is unambiguous. */
+    const char *key = strstr(content, "\ndescription: ");
+    if (key == nullptr) {
         return 0u;
     }
-    const char *line = index;
-    while (*line != '\0') {
-        const char *eol = strchr(line, '\n');
-        const size_t line_n = eol != nullptr ? (size_t)(eol - line) : strlen(line);
-        if (strncmp(line, prefix, (size_t)pn) == 0) {
-            const char  *desc   = line + pn;
-            const size_t desc_n = line_n - (size_t)pn;
-            const size_t budget =
-                budget_bytes > 0u ? budget_bytes : SPG_MEM_DESC_MAX;
-            if (desc_n == 0u || desc_n > budget || desc_n + 1u > dst_cap) {
-                return 0u; /* one slot, description-only, budget-capped */
-            }
-            memcpy(dst, desc, desc_n);
-            dst[desc_n] = '\0';
-            return desc_n;
-        }
-        if (eol == nullptr) {
-            break;
-        }
-        line = eol + 1u;
+    const char  *desc   = key + strlen("\ndescription: ");
+    const char  *eol    = strchr(desc, '\n');
+    const size_t desc_n = eol != nullptr ? (size_t)(eol - desc) : strlen(desc);
+    const size_t budget = budget_bytes > 0u ? budget_bytes : SPG_MEM_DESC_MAX;
+    if (desc_n == 0u || desc_n > budget || desc_n + 1u > dst_cap) {
+        return 0u; /* one slot, description-only, budget-capped */
     }
-    return 0u;
+    memcpy(dst, desc, desc_n);
+    dst[desc_n] = '\0';
+    return desc_n;
 }

--- a/test/test_mem_store.c
+++ b/test/test_mem_store.c
@@ -96,6 +96,24 @@ static int test_directive(void) {
         spg_mem_directive(&store, nullptr, 0u, sizeof out, out) != 0u) {
         return 1;
     }
+
+    /* a slug BEYOND the index cap (SPG_MEM_INDEX_TOPK) still yields its
+     * directive: the description is read from the file, not the capped index
+     * (regression from the #25 benchmark, which showed 0 bytes at 32 slugs). */
+    for (unsigned i = 0u; i < SPG_MEM_INDEX_TOPK + 8u; i++) {
+        char slug[32];
+        char desc[64];
+        (void)snprintf(slug, sizeof slug, "zzz-beyond-%02u", i);
+        (void)snprintf(desc, sizeof desc, "directive number %u", i);
+        if (spg_mem_save(&store, slug, desc, "b") != SPG_OK) {
+            return 1;
+        }
+    }
+    /* "zzz-beyond-31" sorts last, well past the 24-line index cap */
+    if (spg_mem_directive(&store, "zzz-beyond-31", 0u, sizeof out, out) == 0u ||
+        strcmp(out, "directive number 31") != 0) {
+        return 1;
+    }
     return 0;
 }
 


### PR DESCRIPTION
Implements the load-bearing, **model-free** half of #25: the context cost of learning per tick as the lesson set grows.

| lessons | geistshell | full-index RAG |
|---|---|---|
| 1 | 72 B | 90 B |
| 8 | 72 B | 720 B |
| 32 | 72 B | 2233 B |

geistshell's per-tick learning cost is **flat**; the index approach grows linearly (31× at 32 lessons). This substantiates the *denominator* of the SOTA claim (context-invariant learning). It does **not** measure success lift — the numerator needs a model-completable corpus + real inference, which stays open in #25.

**Real bug found and fixed:** `spg_mem_directive` read the *capped* index (`SPG_MEM_INDEX_TOPK`), so a slug beyond the cap injected nothing (0 B at 32 slugs, first run). It now reads the description from the memory file — available for any slug. Regression test added.

- `eval/bench_context.sh` — the table, model-free and deterministic.
- `memory directive <slug>` — CLI verb exposing the P6 injection line.

Full suite green (21 CLI + all unit).