### PR TITLE
feat(learning): success-side skill abstraction, first cut (#26)

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -89,6 +89,28 @@ is the honest place to build "learns from use."
   success`) verifying world state, for tasks that produce files rather than
   stdout.
 
+## Success-side skill abstraction (geistshell#26, first cut)
+
+The success-side counterpart to reflect: a PASSING trajectory is distilled into
+a reusable `skill-<shape>` procedure, keyed by the P4 capability shape, and
+injected into later same-shape tasks via the mind-palace index the agent
+already renders. Deterministic (a template over the ordered action kinds), and
+OFFLINE — the live agent never self-mints skills (the anti-delusion stance);
+`geistshell distill <passing-journal>` is the explicit mint step.
+
+`eval/bench_skills.sh` shows the before/after over ten shell-script tasks that
+share one shape:
+
+- **before:** skill injected into 0/10 tasks.
+- **after:** a skill distilled from the first pass is injected into 9/10.
+
+Task-success is identical across before/after because a *fake* model ignores
+the injected skill — whether the skill LIFTS success needs a real model
+reacting to it (the #25 numerator, on a model-completable corpus). This proves
+accumulation + injection, not lift. Open follow-ups on #26: model-driven
+distillation, shape-triggered single-skill injection (vs the whole index), and
+a gate on skill acceptance.
+
 ## Context-cost benchmark (2026-08-02, model-free)
 
 `eval/bench_context.sh` measures the load-bearing half of the small-seq-len

--- a/eval/bench_skills.sh
+++ b/eval/bench_skills.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# Before/after harness for success-side skill abstraction (geistshell#26).
+# Ten tasks that each CREATE AND RUN a real script (local_shell), share one
+# capability shape, and carry a verifiable (expect). A fake model stands in for
+# the recommendation (Gemma cannot emit the DSL untrained — the #25 corpus
+# prerequisite); the shell runs for real.
+#
+# BEFORE: no distillation, no skill accumulates.
+# AFTER:  `distill` after each pass mints skill-<shape> from the successful
+#         trajectory; present in the store, it is injected into every later
+#         same-shape task via the mind-palace index the agent already renders.
+set -eu
+
+SPG=${SPG_BIN:-build/host-debug/bin/geistshell}
+SKILL_SLUG="skill-finish-local-shell-build-run" # the shape of a shell+finish run
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT
+
+# commands use NO inner double-quotes (single quotes are literal inside the
+# s-expr string), so each is a real, verifiable script with clean quoting.
+i=0; add() { i=$((i+1)); eval "G$i=\$1; C$i=\$2; E$i=\$3"; }
+add "print a greeting"       'echo HELLO-WORLD'                        HELLO-WORLD
+add "multiply two numbers"   'expr 6 \* 7'                             42
+add "count words"            'echo a b c d | wc -w'                    4
+add "sort three numbers"     "printf '3\n1\n2\n' | sort | tr '\n' ' '" "1 2 3"
+add "sum a bash range"       'echo $((10+20+30))'                      60
+add "reverse a string"       'echo abc | rev'                         cba
+add "grep a pattern"         "printf 'foo\nbar\n' | grep bar"         bar
+add "generate a sequence"    "seq 1 5 | tr '\n' ' '"                   "1 2 3 4 5"
+add "uppercase a word"       'echo hello | tr a-z A-Z'                 HELLO
+add "write then read a file" "echo made-a-file > $T/f && cat $T/f"    made-a-file
+N=$i
+
+run_pass() { # $1 = memory dir, $2 = distill|none ; prints table, returns via echo
+    MEM=$1; MODE=$2; pass=0; inj_total=0; k=0
+    while [ "$k" -lt "$N" ]; do
+        k=$((k+1)); eval "goal=\$G$k; cmd=\$C$k; exp=\$E$k"
+        J="$T/j_${MODE}_$k.sgj"
+        printf '(run\n (model "fake.gguf")\n (policy "examples/policy.spg")\n (scenario "examples/scenario.spg")\n (corpus "examples/corpus.spg")\n (journal "%s")\n (seed 42)\n (budgets (inference_steps 4) (tokens 256) (shell_actions 1) (sim_actions 8) (wall_ms 30000) (journal_bytes 1048576) (risk_bp 10000))\n (expect "%s"))\n' "$J" "$exp" > "$T/run.spg"
+        printf '(recommend (kind local_shell) (capability "build.run") (cost 1) (uses_network false) (confidence_bp 7000) (reason "task") (command "%s"))\n(recommend (kind finish) (reason "done"))\n' "$cmd" > "$T/s.txt"
+
+        "$SPG" memory directive "$SKILL_SLUG" --dir "$MEM" >/dev/null 2>&1 && inj=yes || inj=no
+        [ "$inj" = yes ] && inj_total=$((inj_total+1))
+        out=$("$SPG" agent --config "$T/run.spg" --fake-script "$T/s.txt" --memory-dir "$MEM" --allow-exec --max-steps 4 2>&1 || true)
+        echo "$out" | grep -q "verdict=pass" && { s=pass; pass=$((pass+1)); } || s=FAIL
+        [ "$MODE" = distill ] && [ "$s" = pass ] && "$SPG" distill "$J" --memory-dir "$MEM" >/dev/null 2>&1 || true
+        printf '  %2d  %-22s %-6s skill_injected=%s\n' "$k" "$goal" "$s" "$inj"
+    done
+    printf '  => %d/%d solved, skill injected into %d/%d tasks\n' "$pass" "$N" "$inj_total" "$N"
+}
+
+echo "=== BEFORE #26 (no distillation) ==="
+M1=$(mktemp -d); run_pass "$M1" none; rm -rf "$M1"
+echo; echo "=== AFTER #26 (distil after each pass) ==="
+M2=$(mktemp -d); run_pass "$M2" distill; rm -rf "$M2"
+
+echo
+echo "Reading: skill injection goes 0/N -> ~N/N once distillation is on — the"
+echo "feature works. Task-success is identical across before/after because a"
+echo "FAKE model ignores the injected skill; whether the skill LIFTS success"
+echo "needs a real model reacting to it (the #25 numerator, on a model-"
+echo "completable corpus). This harness proves accumulation + injection, not lift."

--- a/include/geistshell/improve.h
+++ b/include/geistshell/improve.h
@@ -54,6 +54,23 @@ struct spg_lesson {
                                        const char *observation,
                                        struct spg_lesson *out);
 
+/* Distil a reusable SKILL from a PASSING trajectory (docs/LEARNING.md /
+ * geistshell#26): the success-side counterpart to reflect. Where a lesson says
+ * "do not do the broken thing", a skill says "here is how a task of this shape
+ * was done". Keyed by the capability shape (P4) so it dedups per task kind and
+ * a later same-shape task recalls it.
+ *
+ * slug = "skill-<shape_token>". The description is a one-line procedure
+ * directive; the body lists the ordered action kinds of the successful run.
+ * Deterministic — a template over the trajectory, no model (a model-driven
+ * distillation is the offline follow-up in #26). procedure_summary is a short
+ * caller-built string of the ordered kinds (e.g. "local_shell -> finish").
+ *
+ * Returns false (out untouched) on null/empty args. */
+[[nodiscard]] bool spg_reflect_skill(const char *shape_token,
+                                     const char *procedure_summary,
+                                     struct spg_lesson *out);
+
 /* The acceptance gate: keep a tentatively-persisted lesson only if the suite's
  * pass count did not drop. Equality keeps (a lesson that neither helps nor hurts
  * is retained, since it may help cases outside the suite). */

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -2661,6 +2661,94 @@ static bool guard_run(void *vctx, const char *config_path, bool with_lesson) {
     return passed;
 }
 
+/* Distil a success SKILL from a passing run's journal (docs/LEARNING.md /
+ * geistshell#26). OFFLINE by design: the caller invokes this only for a run
+ * that met its criterion — the live agent never self-mints skills.
+ * Reconstructs the trajectory (P3), computes the capability shape (P4) and the
+ * ordered-kind procedure, distils a skill-<shape> memory, and saves it. The
+ * saved skill is injected on later runs via the mind-palace index the agent
+ * already renders into context. */
+static int distill_command(int argc, char **argv) {
+    const char *journal    = nullptr;
+    const char *memory_dir = nullptr;
+    for (int i = 2; i < argc; i += 1) {
+        if (strcmp(argv[i], "--memory-dir") == 0 && i + 1 < argc) {
+            memory_dir = argv[++i];
+            continue;
+        }
+        if (argv[i][0] != '-' && journal == nullptr) {
+            journal = argv[i];
+            continue;
+        }
+        fprintf(stderr, "distill: unexpected argument: %s\n", argv[i]);
+        return 2;
+    }
+    if (journal == nullptr) {
+        fprintf(stderr, "usage: %s distill <journal.sgj> [--memory-dir <d>]\n",
+                argv[0]);
+        return 2;
+    }
+
+    static struct spg_fake_response responses[AGENT_MAX_SCRIPT];
+    static char                     text[CLI_MODEL_OUTPUT_BYTES];
+    size_t                          n = 0u;
+    if (spg_eval_script_from_journal(journal, AGENT_MAX_SCRIPT, responses,
+                                     sizeof text, text, &n) != SPG_OK ||
+        n == 0u) {
+        fprintf(stderr, "distill: no trajectory in %s\n", journal);
+        return 1;
+    }
+
+    char   shape[256];
+    size_t shape_n = 0u;
+    if (spg_shape_from_script(responses, n, sizeof shape, shape, &shape_n) !=
+            SPG_OK ||
+        shape_n == 0u) {
+        fprintf(stderr, "distill: could not derive a shape\n");
+        return 1;
+    }
+
+    /* ordered-kind procedure summary, e.g. "local_shell -> finish" */
+    char   procedure[256];
+    size_t pw = 0u;
+    for (size_t i = 0u; i < n; i += 1u) {
+        struct spg_sexpr_token          toks[256];
+        struct spg_sexpr_node           nodes[256];
+        struct spg_recommendation       rec = {};
+        struct spg_recommendation_error err = {};
+        if (spg_recommendation_parse(responses[i].n, responses[i].text, 256u,
+                                     toks, 256u, nodes, &rec, &err) != SPG_OK) {
+            continue;
+        }
+        const char *kind = spg_action_kind_to_string(rec.action_kind);
+        pw += (size_t)snprintf(procedure + pw, sizeof procedure - pw, "%s%s",
+                               pw > 0u ? " -> " : "", kind);
+        if (pw >= sizeof procedure) {
+            break;
+        }
+    }
+
+    struct spg_lesson skill = {};
+    if (!spg_reflect_skill(shape, procedure, &skill)) {
+        fprintf(stderr, "distill: could not distil a skill\n");
+        return 1;
+    }
+
+    struct spg_mem_store store;
+    if (spg_mem_store_open(&store, spg_mem_resolve_dir(memory_dir)) != SPG_OK) {
+        fprintf(stderr, "distill: cannot open memory dir\n");
+        return 1;
+    }
+    if (spg_mem_save(&store, skill.slug, skill.description, skill.body) !=
+        SPG_OK) {
+        fprintf(stderr, "distill: cannot save %s\n", skill.slug);
+        return 1;
+    }
+    printf("{\"skill\":\"%s\",\"shape\":\"%s\",\"procedure\":\"%s\"}\n",
+           skill.slug, shape, procedure);
+    return 0;
+}
+
 /* Longitudinal benefit audit (docs/LEARNING.md P7): a kept lesson earns its
  * keep only if its failure slug stops recurring in later real runs. Sum the
  * failure-mode events across the given journals and, for each kept lesson in
@@ -3030,6 +3118,10 @@ int main(int argc, char **argv) {
 
     if (strcmp(argv[1], "improve") == 0) {
         return improve_command(argc, argv);
+    }
+
+    if (strcmp(argv[1], "distill") == 0) {
+        return distill_command(argc, argv);
     }
 
     if (strcmp(argv[1], "audit") == 0) {

--- a/src/improve/improve.c
+++ b/src/improve/improve.c
@@ -223,3 +223,27 @@ bool spg_reflect_outcome(const char *shape_token, const char *expected_substring
         expected_substring, observation[0] != '\0' ? observation : "(empty)");
     return true;
 }
+
+bool spg_reflect_skill(const char *shape_token, const char *procedure_summary,
+                       struct spg_lesson *out) {
+    if (out == nullptr || shape_token == nullptr || shape_token[0] == '\0' ||
+        procedure_summary == nullptr || procedure_summary[0] == '\0') {
+        return false;
+    }
+    /* slug = "skill-<shape>": distinct namespace from lesson-*, deduped per
+     * task shape so a later same-shape task recalls this one procedure. */
+    const size_t w = (size_t)snprintf(out->slug, sizeof out->slug, "%s", "skill-");
+    if (slugify_into(out->slug + w, sizeof out->slug - w, shape_token) == 0u) {
+        (void)snprintf(out->slug + w, sizeof out->slug - w, "%s", "x");
+    }
+    (void)snprintf(out->description, sizeof out->description,
+                   "For a %.60s task, a working approach: %.120s.", shape_token,
+                   procedure_summary);
+    (void)snprintf(
+        out->body, sizeof out->body,
+        "A task of shape \"%.120s\" was completed successfully with this "
+        "action sequence: %.400s. Follow the same shape: emit each action as "
+        "one valid (recommend ...) form and finish once the goal is met.",
+        shape_token, procedure_summary);
+    return true;
+}

--- a/test/test_improve.c
+++ b/test/test_improve.c
@@ -162,6 +162,45 @@ static int test_reflect_outcome(void) {
     return 0;
 }
 
+/* #26: a passing trajectory distils a reusable skill keyed by shape. */
+static int test_reflect_skill(void) {
+    struct spg_lesson skill = {};
+    if (!spg_reflect_skill("local_shell:build.run", "local_shell -> finish",
+                           &skill)) {
+        return 1;
+    }
+    /* slug is the skill namespace, per-shape, mind-palace-safe */
+    if (strcmp(skill.slug, "skill-local_shell:build.run") != 0 &&
+        strcmp(skill.slug, "skill-local-shell-build-run") != 0) {
+        /* slugify keeps [a-z0-9-]; ':' becomes '-' */
+        if (strcmp(skill.slug, "skill-local-shell-build-run") != 0) {
+            fprintf(stderr, "skill slug=%s\n", skill.slug);
+            return 1;
+        }
+    }
+    if (!spg_mem_slug_valid(skill.slug)) {
+        return 1;
+    }
+    /* the procedure is quoted in both description and body */
+    if (strstr(skill.description, "local_shell -> finish") == nullptr ||
+        strstr(skill.body, "local_shell -> finish") == nullptr) {
+        return 1;
+    }
+    /* distinct shapes -> distinct skills */
+    struct spg_lesson other = {};
+    if (!spg_reflect_skill("simulator", "simulator -> finish", &other) ||
+        strcmp(skill.slug, other.slug) == 0) {
+        return 1;
+    }
+    /* null/empty -> no skill */
+    struct spg_lesson none = {};
+    if (spg_reflect_skill(nullptr, "x", &none) ||
+        spg_reflect_skill("s", "", &none)) {
+        return 1;
+    }
+    return 0;
+}
+
 static int test_accept_gate(void) {
     /* keep on improvement and on no-change; revert on regression */
     if (!spg_improve_accept(2u, 3u) || !spg_improve_accept(2u, 2u) ||
@@ -242,6 +281,10 @@ int main(void) {
     }
     if (test_reflect_outcome() != 0) {
         fprintf(stderr, "test_reflect_outcome failed\n");
+        return 1;
+    }
+    if (test_reflect_skill() != 0) {
+        fprintf(stderr, "test_reflect_skill failed\n");
         return 1;
     }
     if (test_accept_gate() != 0) {


### PR DESCRIPTION
The largest gap vs Hermes — geistshell learned only *failure* lessons. This adds the *success* side.

- **`spg_reflect_skill`** — deterministic distillation: slug `skill-<shape>` (P4 capability shape), a one-line procedure directive, body = ordered action kinds. Distinct namespace from `lesson-*`. Pure, unit-tested.
- **`distill <journal>`** — OFFLINE mint from a passing run's journal (reconstruct → shape → procedure → skill → save). The live agent never self-mints skills (anti-delusion); the caller invokes it only for a run that met its criterion.
- Injection is automatic: a saved skill is one index line the agent already renders.

**`eval/bench_skills.sh`** — ten shell-script tasks sharing one shape (the 10 'create-and-run-a-script' prompts): skill injection **0/10 → 9/10** before/after. Task-success is unchanged because a *fake* model ignores the skill; the LIFT needs a real model (the #25 numerator, on a model-completable corpus). Proves accumulation + injection, **not** lift — stated honestly.

Open on #26 (noted in LEARNING.md): model-driven distillation, shape-triggered single-skill injection (vs the whole index), a skill-acceptance gate. Full suite green (21 CLI + all unit).