### PR TITLE
fix(shape): exclude the universal finish token from the capability shape

### DIFF
--- a/eval/bench_skills.sh
+++ b/eval/bench_skills.sh
@@ -12,7 +12,7 @@
 set -eu
 
 SPG=${SPG_BIN:-build/host-debug/bin/geistshell}
-SKILL_SLUG="skill-finish-local-shell-build-run" # the shape of a shell+finish run
+SKILL_SLUG="skill-local-shell-build-run" # the shape of a shell+finish run
 T=$(mktemp -d)
 trap 'rm -rf "$T"' EXIT
 

--- a/src/eval/eval.c
+++ b/src/eval/eval.c
@@ -184,6 +184,14 @@ enum spg_status spg_shape_from_script(const struct spg_fake_response responses[]
         }
         char token[SPG_SHAPE_TOKEN_MAX + 1u];
         const char *kind = spg_action_kind_to_string(rec.action_kind);
+        /* `finish` ends every successful run, so it carries no discriminative
+         * information — excluding it lets a trajectory shape match the shape
+         * derivable upfront from the policy's enabled capabilities (there is
+         * no `finish` capability). Guard/skill shapes lose only the universal
+         * token, not any discrimination. */
+        if (rec.action_kind == SPG_ACTION_FINISH) {
+            continue;
+        }
         if (rec.capability.length > 0u) {
             (void)snprintf(token, sizeof token, "%s:%.*s", kind,
                            (int)rec.capability.length,

--- a/test/test_guard_ring.c
+++ b/test/test_guard_ring.c
@@ -27,8 +27,8 @@ static int test_shape_key(void) {
     if (spg_shape_from_script(a, 3u, sizeof shape, shape, &len) != SPG_OK) {
         return 1;
     }
-    /* sorted set: finish, local_shell:fs.write, local_shell:proc.exec */
-    if (strcmp(shape, "finish+local_shell:fs.write+local_shell:proc.exec") != 0) {
+    /* sorted set (finish excluded — universal): local_shell:fs.write, local_shell:proc.exec */
+    if (strcmp(shape, "local_shell:fs.write+local_shell:proc.exec") != 0) {
         fprintf(stderr, "shape=%s\n", shape);
         return 1;
     }


### PR DESCRIPTION
`finish` ends every successful run, so it carries no discriminative info in a shape — but it blocked a trajectory shape from matching the shape derivable upfront from the policy's enabled capabilities (no `finish` capability exists). Shape-triggered single-skill injection (#26 follow-up) needs that match. Guard/skill shapes lose only the universal token.

P4 shape test + #26 before/after harness updated (skill slug is now `skill-<caps>`). Full suite green.