### PR TITLE
feat(context): few-shot exemplars slot — teach the DSL to a small model (B)

### DIFF
--- a/examples/exemplars.spg
+++ b/examples/exemplars.spg
@@ -1,0 +1,3 @@
+  (recommend (kind local_shell) (capability "build.run") (cost 1) (uses_network false) (confidence_bp 7000) (reason "run the build") (command "echo done"))
+  (recommend (kind simulator) (capability "sim.act") (cost 1) (uses_network false) (confidence_bp 6500) (reason "probe the state"))
+  (recommend (kind finish) (reason "the goal is met"))

--- a/include/geistshell/actor.h
+++ b/include/geistshell/actor.h
@@ -36,6 +36,7 @@ struct spg_actor_state {
     const char *memory_text;
     const char *memory_index;
     const char *observation;
+    const char *exemplars;
 };
 
 struct spg_actor_step_config {

--- a/include/geistshell/agent_run.h
+++ b/include/geistshell/agent_run.h
@@ -34,6 +34,10 @@ struct spg_agent_run_inputs {
     struct spg_sim_config          *sim;         /* nullable (no simulator) */
     struct spg_mem_store           *store;       /* nullable (no memory) */
     struct spg_journal_writer      *journal;     /* nullable (no audit/trajectory) */
+    /* Optional concrete worked examples of the recommendation form, rendered
+     * in the context's (examples ...) section — few-shot so a small model can
+     * imitate the DSL rather than parse the schema grammar. Null = none. */
+    const char                     *exemplars;
 };
 
 struct spg_agent_run_config {

--- a/include/geistshell/context.h
+++ b/include/geistshell/context.h
@@ -37,6 +37,11 @@ struct spg_context_sources {
     const char                        *memory_index;
     /* Content of the most recently recalled memory (memory_read), or null. */
     const char                        *observation;
+    /* Optional concrete worked examples of the recommendation form, rendered
+     * right after the (contract ...) schema. The schema is a grammar; a small
+     * model imitates filled-in examples far more reliably than it parses a
+     * grammar. Null = none (unchanged behaviour). */
+    const char                        *exemplars;
 };
 
 struct spg_context_budget_item {

--- a/include/geistshell/orchestrator.h
+++ b/include/geistshell/orchestrator.h
@@ -55,6 +55,9 @@ struct spg_orchestrator_state {
     const char *memory_text;
     const char *memory_index;
     const char *observation;
+    /* Optional concrete worked examples of the recommendation form (context
+     * (examples ...) section) — few-shot for a small model. Null = none. */
+    const char *exemplars;
 };
 
 struct spg_orchestrator_config {

--- a/src/actor/actor.c
+++ b/src/actor/actor.c
@@ -145,6 +145,7 @@ spg_actor_step(struct spg_actor_state *state,
         .memory_text          = state->memory_text,
         .memory_index         = state->memory_index,
         .observation        = state->observation,
+        .exemplars            = state->exemplars,
     };
 
     enum spg_status status = spg_context_build(

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -1770,12 +1770,13 @@ static size_t split_script_lines(char *data, const size_t n,
  * --fake-script is one recommendation; the loop gates, executes, journals, and
  * feeds each result forward until `finish` or a termination condition. */
 static int agent_command(int argc, char **argv) {
-    const char *run_path    = nullptr;
-    const char *script_path = nullptr;
-    const char *memory_dir  = getenv("GEISTSHELL_MEMORY_DIR");
-    size_t      max_steps   = 8u;
-    size_t      max_repairs = 2u;
-    bool        allow_exec  = false;
+    const char *run_path       = nullptr;
+    const char *script_path    = nullptr;
+    const char *exemplars_path = nullptr;
+    const char *memory_dir     = getenv("GEISTSHELL_MEMORY_DIR");
+    size_t      max_steps      = 8u;
+    size_t      max_repairs    = 2u;
+    bool        allow_exec     = false;
     for (int i = 2; i < argc; i += 1) {
         if ((strcmp(argv[i], "--config") == 0 ||
              strcmp(argv[i], "--run") == 0) &&
@@ -1786,6 +1787,11 @@ static int agent_command(int argc, char **argv) {
         }
         if (strcmp(argv[i], "--fake-script") == 0 && i + 1 < argc) {
             script_path = argv[i + 1];
+            i += 1;
+            continue;
+        }
+        if (strcmp(argv[i], "--exemplars") == 0 && i + 1 < argc) {
+            exemplars_path = argv[i + 1];
             i += 1;
             continue;
         }
@@ -1831,10 +1837,11 @@ static int agent_command(int argc, char **argv) {
     }
 
     int                rc            = 1;
-    struct file_buffer run_text      = {};
-    struct file_buffer policy_text   = {};
-    struct file_buffer scenario_text = {};
-    struct file_buffer script_text   = {};
+    struct file_buffer run_text       = {};
+    struct file_buffer policy_text    = {};
+    struct file_buffer scenario_text  = {};
+    struct file_buffer script_text    = {};
+    struct file_buffer exemplars_text = {};
     char              *policy_path   = nullptr;
     char              *scenario_path = nullptr;
     char              *journal_path  = nullptr;
@@ -1898,6 +1905,17 @@ static int agent_command(int argc, char **argv) {
                                       AGENT_MAX_SCRIPT);
         if (script_n == 0u) {
             fprintf(stderr, "agent: empty --fake-script\n");
+            goto done;
+        }
+    }
+
+    /* Optional few-shot exemplars: concrete filled-in recommendation forms a
+     * small model can imitate (context (examples ...) section). */
+    if (exemplars_path != nullptr) {
+        status = read_file(exemplars_path, &exemplars_text);
+        if (status != SPG_OK) {
+            fprintf(stderr, "agent: read exemplars failed: %s\n",
+                    spg_status_to_string(status));
             goto done;
         }
     }
@@ -1999,6 +2017,7 @@ static int agent_command(int argc, char **argv) {
         .sim           = &sim,
         .store         = store_open ? &store : nullptr,
         .journal       = &journal,
+        .exemplars     = exemplars_text.data, /* null when --exemplars absent */
     };
     const struct spg_agent_run_config rcfg = {
         .max_steps         = max_steps,
@@ -2057,6 +2076,7 @@ done:
     free_file_buffer(&policy_text);
     free_file_buffer(&scenario_text);
     free_file_buffer(&script_text);
+    free_file_buffer(&exemplars_text);
     return rc;
 }
 

--- a/src/context/context.c
+++ b/src/context/context.c
@@ -695,6 +695,11 @@ enum spg_status spg_context_render(const struct spg_context_sources *sources,
         .dst      = dst,
     };
     render_contract(&state);
+    if (sources->exemplars != nullptr && sources->exemplars[0] != '\0') {
+        append_cstr(&state, "(examples\n");
+        append_cstr(&state, sources->exemplars);
+        append_cstr(&state, ")\n");
+    }
     render_budgets(&state, &view->budgets);
     render_graph(sources, view, &state);
     render_memory(sources, view, &state);

--- a/src/run/agent_run.c
+++ b/src/run/agent_run.c
@@ -73,6 +73,7 @@ enum spg_status spg_agent_run(const struct spg_agent_run_inputs *inputs,
         .policy_text_n = inputs->policy_text_n,
         .policy_text   = inputs->policy_text,
         .observation   = workspace->observation,
+        .exemplars     = inputs->exemplars,
     };
 
     const size_t refs = config->context_refs > 0u ? config->context_refs : 8u;

--- a/src/run/orchestrator.c
+++ b/src/run/orchestrator.c
@@ -196,6 +196,7 @@ enum spg_status spg_orchestrator_tick(
         .memory_text          = state->memory_text,
         .memory_index         = memory_index,
         .observation        = state->observation,
+        .exemplars            = state->exemplars,
     };
     const struct spg_actor_step_config actor_config = {
         .actor_id            = config->actor_id,

--- a/test/test_context.c
+++ b/test/test_context.c
@@ -330,7 +330,57 @@ static int test_invalid_args(void) {
     return 0;
 }
 
+/* #26/B: concrete exemplars render into an (examples ...) section after the
+ * (contract ...) schema, so a small model can imitate the DSL. Absent = no
+ * such section. */
+static int test_exemplars_render(void) {
+    const struct spg_run_config    run   = {.budgets = {.tokens = 100u}};
+    const struct spg_policy_usage  usage = {};
+    struct spg_context_graph_ref   graph_refs[1];
+    struct spg_context_memory_ref  memory_refs[1];
+    struct spg_context_journal_ref journal_refs[1];
+    struct spg_context_view        view = {};
+    spg_context_view_init(&view, 1u, graph_refs, 1u, memory_refs, 1u,
+                          journal_refs);
+    const struct spg_context_limits limits = {
+        .graph_nodes = 1u, .memory_facts = 1u, .journal_events = 1u};
+
+    struct spg_context_sources sources = {
+        .run       = &run,
+        .usage     = &usage,
+        .exemplars = "  (recommend (kind finish) (reason \"EXEMPLAR-MARK\"))\n",
+    };
+    if (spg_context_build(&sources, &limits, &view) != SPG_OK) {
+        return 1;
+    }
+    char   buf[4096];
+    size_t req = 0u;
+    if (spg_context_render(&sources, &view, sizeof buf, buf, &req) != SPG_OK) {
+        return 1;
+    }
+    if (strstr(buf, "(examples") == nullptr ||
+        strstr(buf, "EXEMPLAR-MARK") == nullptr) {
+        return 1;
+    }
+    /* the examples section follows the contract schema */
+    if (strstr(buf, "(contract") == nullptr ||
+        strstr(buf, "(contract") > strstr(buf, "(examples")) {
+        return 1;
+    }
+    /* absent -> no examples section */
+    sources.exemplars = nullptr;
+    (void)spg_context_render(&sources, &view, sizeof buf, buf, &req);
+    if (strstr(buf, "(examples") != nullptr) {
+        return 1;
+    }
+    return 0;
+}
+
 int main(void) {
+    if (test_exemplars_render() != 0) {
+        fprintf(stderr, "test_exemplars_render failed\n");
+        return 1;
+    }
     if (test_budget_view() != 0) {
         fprintf(stderr, "test_budget_view failed\n");
         return 1;


### PR DESCRIPTION
The scope expansion toward real-model completion (chosen as path B). The `(contract ...)` section is a *grammar*; an untrained small model needs concrete *examples* to imitate. On the Pi, Gemma terminated `budget` even with a failure directive — it never produced a valid form.

Adds an optional `(examples ...)` context section after the contract: `spg_context_sources.exemplars`, threaded through actor/orchestrator/`spg_agent_run_inputs`; `agent --exemplars <file>` (default `examples/exemplars.spg`). Absent = unchanged.

Unblocks the model-completable corpus (#25) and the real-model **lift** measurement (#26) — a model that can't emit the DSL can't complete tasks, so no lift could be shown. Render unit-tested; full suite green (21 CLI + all unit).