### PR TITLE
feat(decode): forced-prefix constrained decoding, first cut (#34)

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -89,6 +89,31 @@ is the honest place to build "learns from use."
   success`) verifying world state, for tasks that produce files rather than
   stdout.
 
+## Constrained decoding, forced-prefix first cut (geistshell#34, 2026-08-02)
+
+The exemplar finding pointed to grammar-constrained decoding as the real
+unblock. First cut: force the GEIST model's output to BEGIN with a fixed
+literal (`(recommend (kind `), then decode freely — using the engine hooks
+the #34 pre-clarification found (`geist_session_tokenize` +
+`geist_session_prefill_tokens`, v0.2.1 `geist_util.h`, no engine fork).
+
+Measured on the Pi against Gemma 4 E2B, the reject reason MOVED:
+
+- free decode / exemplars only: `REJECT_SYNTAX` — not even a parseable form.
+- **forced prefix (`--constrained`): `REJECT_UNKNOWN_KIND`** — the output now
+  parses as a recommendation up to the kind field; Gemma only picks an invalid
+  kind name after the forced `(recommend (kind `.
+
+That is real, measured forward progress: forcing the opening carries the model
+past the structure it could not start, and pinpoints the exact next
+constraint. The immediate follow-up is to constrain the KIND token to the enum
+(peek_logits + a mask over the valid kind names) — the first piece of the full
+token-level grammar acceptor (geistagent `agent.h` as reference). A fully valid
+form is expected once the kind is constrained too.
+
+Dev-env note: the Mac's deps/geist pointed at a newer checkout lacking
+geist_util.h; switched to the pinned v0.2.1 via `make sync-engine`.
+
 ## Real-model completion: exemplars are necessary but not sufficient (2026-08-02)
 
 Path B added an `(examples ...)` context slot so a small model gets concrete

--- a/include/geistshell/model_adapter.h
+++ b/include/geistshell/model_adapter.h
@@ -69,6 +69,14 @@ struct spg_model_adapter_config {
      * emits an invalid form (the loop rejects it); once present, the script
      * runs. Null disables gating. */
     const char *fake_gate_marker;
+
+    /* Constrained decoding (geistshell#34, first cut): a literal the GEIST
+     * model's output is FORCED to begin with, then it decodes freely. Forcing
+     * the recommendation opening (e.g. "(recommend (kind ") past the hardest
+     * part lifts a small model over the structure it cannot reliably produce
+     * from a grammar description alone. Null = free decode (default). GEIST
+     * only; ignored by fake/remote. */
+    const char *force_prefix;
 };
 
 struct spg_model_adapter {
@@ -86,6 +94,7 @@ struct spg_model_adapter {
     const struct spg_fake_response *fake_responses;
     size_t                          fake_index; /* next scripted reply */
     const char                     *fake_gate_marker;
+    const char                     *force_prefix; /* constrained decode (#34) */
 
     /* REMOTE transport state: opaque CURL handle, borrowed config strings, and
      * the sampling values forwarded to the chat/completions request. */

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -1777,6 +1777,7 @@ static int agent_command(int argc, char **argv) {
     size_t      max_steps      = 8u;
     size_t      max_repairs    = 2u;
     bool        allow_exec     = false;
+    bool        constrained    = false;
     for (int i = 2; i < argc; i += 1) {
         if ((strcmp(argv[i], "--config") == 0 ||
              strcmp(argv[i], "--run") == 0) &&
@@ -1820,6 +1821,12 @@ static int agent_command(int argc, char **argv) {
         }
         if (strcmp(argv[i], "--allow-exec") == 0) {
             allow_exec = true;
+            continue;
+        }
+        if (strcmp(argv[i], "--constrained") == 0) {
+            /* #34: force the real model's output to begin with the
+             * recommendation opening, then decode freely. */
+            constrained = true;
             continue;
         }
         fprintf(stderr, "agent: unknown or incomplete argument: %s\n", argv[i]);
@@ -1940,12 +1947,13 @@ static int agent_command(int argc, char **argv) {
                   .fake_responses      = script,
               }
             : (struct spg_model_adapter_config){
-                  .kind       = SPG_MODEL_ADAPTER_GEIST,
-                  .model_path = model_path,
-                  .sampling   = {.max_seq_len  = 4096u,
-                                 .temperature = 0.0f,
-                                 .top_p       = 1.0f,
-                                 .random_seed = run.seed},
+                  .kind         = SPG_MODEL_ADAPTER_GEIST,
+                  .model_path   = model_path,
+                  .force_prefix = constrained ? "(recommend (kind " : nullptr,
+                  .sampling     = {.max_seq_len  = 4096u,
+                                   .temperature = 0.0f,
+                                   .top_p       = 1.0f,
+                                   .random_seed = run.seed},
               };
     status = spg_model_adapter_init(&model, &model_config);
     if (status != SPG_OK) {

--- a/src/model/model_adapter.c
+++ b/src/model/model_adapter.c
@@ -1,6 +1,7 @@
 #include "geistshell/model_adapter.h"
 
 #include <geist.h>
+#include <geist_util.h> /* #34: tokenize + prefill_tokens for forced-prefix decode */
 
 #include <math.h>
 #include <string.h>
@@ -148,6 +149,41 @@ static enum spg_status generate_geist(
         return map_geist_status(status);
     }
 
+    /* Constrained decode (#34): force the output to begin with a fixed literal
+     * (the recommendation opening), then decode freely. Tokenize the prefix,
+     * feed it into the KV as if the model had produced it, and append its text
+     * to the output — the model then continues past the structure it cannot
+     * reliably start on its own. */
+    if (adapter->force_prefix != nullptr && adapter->force_prefix[0] != '\0') {
+        geist_token_t prefix_ids[256];
+        size_t        prefix_n = 0u;
+        status                 = geist_session_tokenize(
+            adapter->session, adapter->force_prefix,
+            sizeof prefix_ids / sizeof prefix_ids[0], prefix_ids, &prefix_n);
+        if (status != GEIST_OK) {
+            return map_geist_status(status);
+        }
+        for (size_t i = 0u; i < prefix_n; i += 1u) {
+            const char *piece =
+                geist_session_token_to_str(adapter->session, prefix_ids[i]);
+            if (piece != nullptr && piece[0] != '\0') {
+                const enum spg_status as =
+                    append_bytes(result, strlen(piece), piece);
+                if (as != SPG_OK) {
+                    return as;
+                }
+            }
+        }
+        if (prefix_n > 0u) {
+            status =
+                geist_session_prefill_tokens(adapter->session, prefix_n, prefix_ids);
+            if (status != GEIST_OK) {
+                return map_geist_status(status);
+            }
+            result->tokens_decoded += prefix_n;
+        }
+    }
+
     for (size_t i = 0u; i < request->max_decode_tokens; i += 1u) {
         geist_token_t token = 0;
         status = geist_session_decode_step(adapter->session, &token);
@@ -181,7 +217,8 @@ spg_model_adapter_init(struct spg_model_adapter *adapter,
         return SPG_E_INVALID_ARG;
     }
     *adapter = (struct spg_model_adapter){
-        .kind = config->kind,
+        .kind         = config->kind,
+        .force_prefix = config->force_prefix, /* #34: GEIST-only, borrowed */
     };
 
     if (config->kind == SPG_MODEL_ADAPTER_FAKE) {


### PR DESCRIPTION
First cut of grammar-constrained decoding (#34): force the GEIST model's output to begin with `(recommend (kind `, then decode freely. Uses geist v0.2.1 `geist_util.h` (tokenize + prefill_tokens) — no engine fork.

## Pi result (Gemma 4 E2B) — the reject reason MOVED
- free decode / exemplars only: `REJECT_SYNTAX` (not even parseable)
- **`--constrained`: `REJECT_UNKNOWN_KIND`** — output now parses as a recommendation up to the kind field; Gemma only picks an invalid kind name after the forced opening.

Real, measured forward progress: forcing the opening carries the model past the structure it can't start, and pinpoints the exact next constraint (the kind enum).

## Follow-up (this cut deliberately stops short)
Constrain the KIND token to the valid enum (peek_logits + mask) — the first piece of the full token-level grammar acceptor (geistagent `agent.h` reference). A fully valid form is expected once the kind is constrained too. Tracked in #34.

Suite: 21 CLI + all unit green against pinned v0.2.1.