### PR TITLE
feat(decode): constrain the kind slot to the enum (#34 stage 1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ SPG_SOURCES := \
     src/memory/mem_executor.c \
     src/memory/mem_store.c \
     src/memory/memory.c \
+    src/model/grammar_mask.c \
     src/model/model_adapter.c \
     src/model/model_remote_codec.c \
     src/model/model_resolve.c \

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -106,10 +106,31 @@ Measured on the Pi against Gemma 4 E2B, the reject reason MOVED:
 
 That is real, measured forward progress: forcing the opening carries the model
 past the structure it could not start, and pinpoints the exact next
-constraint. The immediate follow-up is to constrain the KIND token to the enum
-(peek_logits + a mask over the valid kind names) — the first piece of the full
-token-level grammar acceptor (geistagent `agent.h` as reference). A fully valid
-form is expected once the kind is constrained too.
+constraint.
+
+**Stage 1 — kind-enum mask (merged).** After the forced prefix ends at
+`(kind `, a greedy `peek_logits` loop masks the next tokens to only those that
+keep the emitted text a live prefix of a valid kind name
+(`spg_action_kind_to_string` is the source of truth, so the mask cannot drift
+from `parse_action_kind`), until a complete name is reached. Pure predicates in
+`grammar_mask.c`, unit-tested without a GGUF. On the Pi the reject moved again:
+
+- forced prefix only → `REJECT_UNKNOWN_KIND` (Gemma picks an invalid kind).
+- **+ kind mask → `REJECT_MISSING_FIELD`** — output `(recommend (kind
+  simulator))`: a *valid kind by construction*, now missing the required
+  fields. `termination=finished`, not `budget` — the model lands a parseable
+  form immediately.
+
+Subtlety found on hardware: `token_to_str` detokenizes the SentencePiece
+word-boundary to a leading ASCII space/tab, so the first kind token reads
+`" simulator"`; the mask compares past leading whitespace (the separator stays
+in the output, valid in the s-expression). Without that, every candidate was
+rejected and the loop emitted `(recommend (kind ))`.
+
+Next: **Stage 2 — field scaffold.** Machine-emit the required-field skeleton
+for the chosen kind (source: `kind_fields_match`) via `prefill_tokens`, letting
+the model free-decode only the leaf string/number slots. That closes
+`MISSING_FIELD` and yields a full schema-valid form by construction.
 
 Dev-env note: the Mac's deps/geist pointed at a newer checkout lacking
 geist_util.h; switched to the pinned v0.2.1 via `make sync-engine`.

--- a/include/geistshell/grammar_mask.h
+++ b/include/geistshell/grammar_mask.h
@@ -1,0 +1,33 @@
+#ifndef GEISTSHELL_GRAMMAR_MASK_H
+#define GEISTSHELL_GRAMMAR_MASK_H
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Constrained decoding of the (recommend (kind X)) slot (geistshell#34).
+ *
+ * The valid kind names are the canonical strings of spg_action_kind (via
+ * spg_action_kind_to_string) — the parser's own source of truth, so the mask
+ * cannot drift from what parse_action_kind accepts. These predicates are pure
+ * (no engine, no session) so the mask logic is unit-tested without a GGUF; the
+ * model adapter drives the token loop around them. */
+
+/* Would `emitted` immediately followed by `piece` still be a prefix of at
+ * least one valid kind name, without overshooting it? An empty piece asks
+ * whether `emitted` itself is a live prefix. This is the per-token gate: at the
+ * kind slot, only tokens for which this holds may be sampled, so the decoded
+ * kind is valid by construction. piece may be null (treated as ""). */
+[[nodiscard]] bool spg_kind_prefix_ok(const char *emitted, const char *piece);
+
+/* Is `emitted` exactly one valid kind name? True terminates the kind slot (no
+ * valid kind name is a prefix of another, so completion is unambiguous). */
+[[nodiscard]] bool spg_kind_complete(const char *emitted);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/model/grammar_mask.c
+++ b/src/model/grammar_mask.c
@@ -14,6 +14,17 @@ static const enum spg_action_kind ALL_KINDS[] = {
 };
 static const size_t KIND_COUNT = sizeof ALL_KINDS / sizeof ALL_KINDS[0];
 
+/* The tokenizer detokenizes a SentencePiece word-boundary (U+2581) to a leading
+ * ASCII space, so the first kind token reads as " local", not "local". Kind
+ * names never start with space and the s-expression tolerates the separator, so
+ * we compare against the text past any leading spaces. */
+static const char *skip_spaces(const char *s) {
+    while (*s == ' ' || *s == '\t') {
+        s += 1;
+    }
+    return s;
+}
+
 bool spg_kind_prefix_ok(const char *emitted, const char *piece) {
     if (emitted == nullptr) {
         return false;
@@ -26,14 +37,16 @@ bool spg_kind_prefix_ok(const char *emitted, const char *piece) {
     }
     memcpy(buf, emitted, el);
     memcpy(buf + el, piece == nullptr ? "" : piece, pl);
-    const size_t len = el + pl;
-    buf[len]         = '\0';
+    buf[el + pl]     = '\0';
+    const char  *cmp = skip_spaces(buf);
+    const size_t len = strlen(cmp);
     for (size_t i = 0u; i < KIND_COUNT; i += 1u) {
         const char *name = spg_action_kind_to_string(ALL_KINDS[i]);
-        /* buf is a prefix of name iff their first `len` bytes match; a name
-         * shorter than `len` has its '\0' compared against buf's byte and
-         * mismatches, which correctly rejects overshoot. */
-        if (strncmp(name, buf, len) == 0) {
+        /* cmp is a prefix of name iff their first `len` bytes match; a name
+         * shorter than `len` has its '\0' compared against cmp's byte and
+         * mismatches, which correctly rejects overshoot. An all-space buffer
+         * (len 0) matches every name — still a live prefix. */
+        if (strncmp(name, cmp, len) == 0) {
             return true;
         }
     }
@@ -41,11 +54,15 @@ bool spg_kind_prefix_ok(const char *emitted, const char *piece) {
 }
 
 bool spg_kind_complete(const char *emitted) {
-    if (emitted == nullptr || emitted[0] == '\0') {
+    if (emitted == nullptr) {
+        return false;
+    }
+    const char *cmp = skip_spaces(emitted);
+    if (cmp[0] == '\0') {
         return false;
     }
     for (size_t i = 0u; i < KIND_COUNT; i += 1u) {
-        if (strcmp(spg_action_kind_to_string(ALL_KINDS[i]), emitted) == 0) {
+        if (strcmp(spg_action_kind_to_string(ALL_KINDS[i]), cmp) == 0) {
             return true;
         }
     }

--- a/src/model/grammar_mask.c
+++ b/src/model/grammar_mask.c
@@ -1,0 +1,53 @@
+#include "geistshell/grammar_mask.h"
+
+#include "geistshell/policy.h"
+
+#include <string.h>
+
+/* Every action kind that parse_action_kind accepts. Their canonical names come
+ * from spg_action_kind_to_string, so this list is the enum, not a second copy
+ * of the strings. */
+static const enum spg_action_kind ALL_KINDS[] = {
+    SPG_ACTION_LOCAL_SHELL, SPG_ACTION_SSH_AUTH_PROBE, SPG_ACTION_SIMULATOR,
+    SPG_ACTION_MEMORY_SAVE, SPG_ACTION_MEMORY_DELETE, SPG_ACTION_MEMORY_READ,
+    SPG_ACTION_FINISH,
+};
+static const size_t KIND_COUNT = sizeof ALL_KINDS / sizeof ALL_KINDS[0];
+
+bool spg_kind_prefix_ok(const char *emitted, const char *piece) {
+    if (emitted == nullptr) {
+        return false;
+    }
+    char         buf[64];
+    const size_t el = strlen(emitted);
+    const size_t pl = piece == nullptr ? 0u : strlen(piece);
+    if (el + pl >= sizeof buf) {
+        return false;
+    }
+    memcpy(buf, emitted, el);
+    memcpy(buf + el, piece == nullptr ? "" : piece, pl);
+    const size_t len = el + pl;
+    buf[len]         = '\0';
+    for (size_t i = 0u; i < KIND_COUNT; i += 1u) {
+        const char *name = spg_action_kind_to_string(ALL_KINDS[i]);
+        /* buf is a prefix of name iff their first `len` bytes match; a name
+         * shorter than `len` has its '\0' compared against buf's byte and
+         * mismatches, which correctly rejects overshoot. */
+        if (strncmp(name, buf, len) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool spg_kind_complete(const char *emitted) {
+    if (emitted == nullptr || emitted[0] == '\0') {
+        return false;
+    }
+    for (size_t i = 0u; i < KIND_COUNT; i += 1u) {
+        if (strcmp(spg_action_kind_to_string(ALL_KINDS[i]), emitted) == 0) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/model/model_adapter.c
+++ b/src/model/model_adapter.c
@@ -1,7 +1,9 @@
 #include "geistshell/model_adapter.h"
 
+#include "geistshell/grammar_mask.h" /* #34: kind-slot mask */
+
 #include <geist.h>
-#include <geist_util.h> /* #34: tokenize + prefill_tokens for forced-prefix decode */
+#include <geist_util.h> /* #34: tokenize + prefill_tokens + peek_logits */
 
 #include <math.h>
 #include <string.h>
@@ -181,6 +183,60 @@ static enum spg_status generate_geist(
                 return map_geist_status(status);
             }
             result->tokens_decoded += prefix_n;
+        }
+
+        /* Kind-slot mask (#34 stage 1): the forced prefix ends at "(kind ", so
+         * the next tokens name the action kind. Constrain them to a valid enum
+         * name by masking peek_logits to tokens that keep the emitted text a
+         * live prefix, greedily, until a complete kind name is reached. This
+         * flips the free-decode REJECT_UNKNOWN_KIND to a valid kind; the field
+         * scaffold (stage 2) will take over from here. Bails to free decode if
+         * the tokenizer offers no valid continuation. */
+        char   kindbuf[64];
+        size_t kind_used = 0u;
+        kindbuf[0]       = '\0';
+        for (size_t step = 0u; step < 16u && !spg_kind_complete(kindbuf);
+             step += 1u) {
+            size_t       n_vocab = 0u;
+            const float *logits =
+                geist_session_peek_logits(adapter->session, &n_vocab);
+            if (logits == nullptr || n_vocab == 0u) {
+                break;
+            }
+            geist_token_t best       = -1;
+            float         best_logit = -INFINITY;
+            for (size_t t = 0u; t < n_vocab; t += 1u) {
+                if (logits[t] <= best_logit) {
+                    continue; /* cannot beat the best valid token so far */
+                }
+                const char *piece = geist_session_token_to_str(
+                    adapter->session, (geist_token_t) t);
+                if (piece == nullptr || !spg_kind_prefix_ok(kindbuf, piece)) {
+                    continue;
+                }
+                best       = (geist_token_t) t;
+                best_logit = logits[t];
+            }
+            if (best < 0) {
+                break; /* dead end: no token keeps a valid kind prefix */
+            }
+            const char  *piece = geist_session_token_to_str(adapter->session, best);
+            const size_t pl    = strlen(piece);
+            if (kind_used + pl >= sizeof kindbuf) {
+                break;
+            }
+            const enum spg_status as = append_bytes(result, pl, piece);
+            if (as != SPG_OK) {
+                return as;
+            }
+            memcpy(kindbuf + kind_used, piece, pl);
+            kind_used += pl;
+            kindbuf[kind_used] = '\0';
+            status = geist_session_prefill_tokens(adapter->session, 1u, &best);
+            if (status != GEIST_OK) {
+                return map_geist_status(status);
+            }
+            result->tokens_decoded += 1u;
         }
     }
 

--- a/test/test_grammar_mask.c
+++ b/test/test_grammar_mask.c
@@ -33,6 +33,19 @@ int main(void) {
         return fail("completing exactly is still a live prefix");
     }
 
+    /* Leading spaces from SentencePiece detokenization are ignored: the first
+     * kind token reads as " local", must still match local_shell. */
+    if (!spg_kind_prefix_ok("", " local")) {
+        return fail("' local' (leading space) is a live prefix");
+    }
+    if (!spg_kind_prefix_ok(" ", "local")) {
+        return fail("space then local is a live prefix");
+    }
+    if (!spg_kind_prefix_ok(" local", "_shell") ||
+        !spg_kind_complete(" local_shell")) {
+        return fail("leading-space name completes");
+    }
+
     /* Rejections: unknown text and overshoot past a complete name. */
     if (spg_kind_prefix_ok("", "xyz")) {
         return fail("'xyz' is not any kind prefix");

--- a/test/test_grammar_mask.c
+++ b/test/test_grammar_mask.c
@@ -1,0 +1,59 @@
+#include "geistshell/grammar_mask.h"
+
+#include <stdio.h>
+
+static int fail(const char *m) {
+    fprintf(stderr, "FAIL: %s\n", m);
+    return 1;
+}
+
+int main(void) {
+    /* Live prefixes: empty + partial that extend a real kind name. */
+    if (!spg_kind_prefix_ok("", "local")) {
+        return fail("'local' is a live prefix of local_shell");
+    }
+    if (!spg_kind_prefix_ok("local", "_shell")) {
+        return fail("local + _shell stays valid");
+    }
+    if (!spg_kind_prefix_ok("", "finish")) {
+        return fail("'finish' is a live prefix");
+    }
+    if (!spg_kind_prefix_ok("memory", "_save")) {
+        return fail("memory + _save stays valid");
+    }
+    /* Ambiguous stem shared by three kinds stays open. */
+    if (!spg_kind_prefix_ok("", "memory")) {
+        return fail("'memory' stem is a live prefix");
+    }
+    if (!spg_kind_prefix_ok("memory_", "read")) {
+        return fail("memory_ + read stays valid");
+    }
+    /* Reaching a full name is itself a live prefix (len == name length). */
+    if (!spg_kind_prefix_ok("", "finish") || !spg_kind_prefix_ok("finis", "h")) {
+        return fail("completing exactly is still a live prefix");
+    }
+
+    /* Rejections: unknown text and overshoot past a complete name. */
+    if (spg_kind_prefix_ok("", "xyz")) {
+        return fail("'xyz' is not any kind prefix");
+    }
+    if (spg_kind_prefix_ok("local_shell", "x")) {
+        return fail("overshooting local_shell is rejected");
+    }
+    if (spg_kind_prefix_ok("memory_s", "x")) {
+        return fail("memory_sx is not a prefix");
+    }
+
+    /* Completion: exact names only, no partials. */
+    if (!spg_kind_complete("local_shell") || !spg_kind_complete("finish") ||
+        !spg_kind_complete("memory_read") || !spg_kind_complete("ssh_auth_probe")) {
+        return fail("full names are complete");
+    }
+    if (spg_kind_complete("memory") || spg_kind_complete("local") ||
+        spg_kind_complete("") || spg_kind_complete("finishx")) {
+        return fail("partials/overshoot are not complete");
+    }
+
+    printf("test_grammar_mask ok\n");
+    return 0;
+}


### PR DESCRIPTION
Stage 1 of the token-level acceptor. After the forced prefix ends at `(kind `, a greedy `peek_logits` loop masks the next tokens to only those that keep the emitted text a live prefix of a valid kind name, until a complete name is reached. Valid kind **by construction**.

- `grammar_mask.{c,h}`: pure predicates (`spg_kind_prefix_ok`/`spg_kind_complete`) keyed off `spg_action_kind_to_string` — the parser's own source of truth, so the mask can't drift from `parse_action_kind`. Unit-tested without a GGUF.
- adapter drives the loop via `peek_logits` + `prefill_tokens` (v0.2.1 `geist_util.h`, CPU/transformer). Free decode unchanged & default.

## Pi result (Gemma 4 E2B) — reject moved forward again
| decode | reject | output |
|---|---|---|
| forced prefix only | `UNKNOWN_KIND` | invalid kind name |
| **+ kind mask** | `MISSING_FIELD` | `(recommend (kind simulator))` — valid kind, no fields |

`termination=finished` (not budget) — the model lands a parseable form immediately.

Hardware subtlety: `token_to_str` detokenizes the SentencePiece boundary to a leading space/tab, so the first kind token reads " simulator"; the mask compares past leading whitespace (separator stays in the output). Fixed after a first Pi run emitted `(recommend (kind ))`.

Next (this PR stops short): **stage 2 field scaffold** — machine-emit the required-field skeleton per kind, model free-decodes only leaf slots → full schema-valid form. Tracked in #34.

Suite: grammar_mask unit + full suite green on Mac (asan) and Pi.