### PR TITLE
feat(decode): field scaffold — valid form by construction (#34 stage 2)

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -127,10 +127,40 @@ word-boundary to a leading ASCII space/tab, so the first kind token reads
 in the output, valid in the s-expression). Without that, every candidate was
 rejected and the loop emitted `(recommend (kind ))`.
 
-Next: **Stage 2 — field scaffold.** Machine-emit the required-field skeleton
-for the chosen kind (source: `kind_fields_match`) via `prefill_tokens`, letting
-the model free-decode only the leaf string/number slots. That closes
-`MISSING_FIELD` and yields a full schema-valid form by construction.
+**Stage 2 — field scaffold (merged).** Once the kind resolves, the rest of a
+valid form is deterministic structure with a few free leaf values, so the
+adapter emits that structure itself (`emit_literal` → `prefill_tokens`) and lets
+the model free-decode only the string slots (`decode_string_slot`, stopped at
+the closing quote). The bureaucratic fields (`cost`, `uses_network`,
+`confidence_bp`) are baked into the scaffold literals with defaults —
+deterministic per kind, not a decision a 2B model should have to land. The
+per-kind field sets mirror `required_fields_seen` + `kind_fields_match`, so a
+scaffold is valid by construction; `test_grammar_mask` builds each of the seven
+kinds' forms and parses them through the real `recommendation.c` — all VALID,
+no GGUF.
+
+On the Pi the whole reject chain is now resolved:
+
+`SYNTAX` (free) → `UNKNOWN_KIND` (prefix) → `MISSING_FIELD` (kind mask) →
+**a valid form** (scaffold). Gemma emitted, in **one step / ~22 s** (vs ~2m20
+of repair loops before):
+
+    (recommend (kind simulator) (capability "read") (cost 1)
+      (uses_network false) (confidence_bp 5000)
+      (reason "Simulate a general system behavior"))
+
+Parses and matches the schema — the model now emits the DSL. `termination`
+is `denied`, not a decode failure: the form reached the **policy gate**, which
+denied capability `"read"` (the policy allows `sim.act` / `build.run`). That is
+acceptance criterion #1 met — a valid, schema-matching form where free decoding
+gave SYNTAX.
+
+Remaining for criterion #3 (verdict=pass): the model free-picked a capability
+the policy does not grant. The next piece is a **capability mask** — constrain
+the capability slot to the policy's enabled capabilities for the chosen kind,
+exactly as stage 1 masked the kind. It needs the policy capabilities plumbed
+into the adapter. Then a simple task can actually pass, and the LIFT
+experiments (#25/#26) can run on a model that acts.
 
 Dev-env note: the Mac's deps/geist pointed at a newer checkout lacking
 geist_util.h; switched to the pinned v0.2.1 via `make sync-engine`.

--- a/include/geistshell/grammar_mask.h
+++ b/include/geistshell/grammar_mask.h
@@ -1,7 +1,10 @@
 #ifndef GEISTSHELL_GRAMMAR_MASK_H
 #define GEISTSHELL_GRAMMAR_MASK_H
 
+#include "geistshell/policy.h" /* enum spg_action_kind */
+
 #include <stdbool.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,6 +28,30 @@ extern "C" {
 /* Is `emitted` exactly one valid kind name? True terminates the kind slot (no
  * valid kind name is a prefix of another, so completion is unambiguous). */
 [[nodiscard]] bool spg_kind_complete(const char *emitted);
+
+/* Resolve a decoded kind name (leading detok whitespace tolerated) to its enum.
+ * Returns false if it is not a valid kind. */
+[[nodiscard]] bool spg_kind_from_text(const char *emitted,
+                                      enum spg_action_kind *out);
+
+/* Field scaffold (geistshell#34 stage 2). Once the kind is fixed, the rest of a
+ * valid (recommend ...) form is deterministic structure with a few free leaf
+ * values. A scaffold is that structure as an ordered segment list: a LITERAL
+ * segment is emitted verbatim (via prefill_tokens); a model-string segment
+ * (literal == nullptr) is one free-decoded string value, stopped at the closing
+ * quote. Emitting the literals with the model filling the string slots yields a
+ * schema-valid form by construction. The bureaucratic fields (cost,
+ * uses_network, confidence_bp) are baked into the literals with sane defaults —
+ * they are deterministic per kind, not a decision the small model must make. */
+struct spg_scaffold_seg {
+    const char *literal; /* verbatim text, or nullptr for a free string slot */
+};
+
+/* The scaffold for `kind`, to emit right after the kind name (the caller has
+ * already emitted "(recommend (kind <name>"). Writes the segment array to
+ * *out and returns its length (0 for an unknown kind). */
+[[nodiscard]] size_t spg_scaffold_for_kind(enum spg_action_kind kind,
+                                           const struct spg_scaffold_seg **out);
 
 #ifdef __cplusplus
 }

--- a/src/model/grammar_mask.c
+++ b/src/model/grammar_mask.c
@@ -68,3 +68,74 @@ bool spg_kind_complete(const char *emitted) {
     }
     return false;
 }
+
+bool spg_kind_from_text(const char *emitted, enum spg_action_kind *out) {
+    if (emitted == nullptr || out == nullptr) {
+        return false;
+    }
+    const char *cmp = skip_spaces(emitted);
+    for (size_t i = 0u; i < KIND_COUNT; i += 1u) {
+        if (strcmp(spg_action_kind_to_string(ALL_KINDS[i]), cmp) == 0) {
+            *out = ALL_KINDS[i];
+            return true;
+        }
+    }
+    return false;
+}
+
+/* Scaffolds, positioned right after "(recommend (kind <name>". A nullptr
+ * literal is a free-decoded string value. The cost/uses_network/confidence_bp
+ * defaults are baked in; uses_network is fixed per kind by kind_fields_match
+ * (true only for ssh_auth_probe). Field sets mirror required_fields_seen +
+ * kind_fields_match in recommendation.c. */
+#define MS {.literal = nullptr}
+#define BUREAU_OK ") (cost 1) (uses_network false) (confidence_bp 5000) "
+#define BUREAU_NET ") (cost 1) (uses_network true) (confidence_bp 5000) "
+
+static const struct spg_scaffold_seg SEG_FINISH[] = {
+    {") (reason \""}, MS, {"\"))"}};
+static const struct spg_scaffold_seg SEG_SIMULATOR[] = {
+    {") (capability \""}, MS, {"\"" BUREAU_OK "(reason \""}, MS, {"\"))"}};
+static const struct spg_scaffold_seg SEG_LOCAL_SHELL[] = {
+    {") (capability \""},         MS, {"\"" BUREAU_OK "(command \""}, MS,
+    {"\") (reason \""}, MS, {"\"))"}};
+static const struct spg_scaffold_seg SEG_SSH[] = {
+    {") (capability \""},        MS, {"\"" BUREAU_NET "(target \""}, MS,
+    {"\") (reason \""}, MS, {"\"))"}};
+static const struct spg_scaffold_seg SEG_MEM_SAVE[] = {
+    {") (capability \""},        MS, {"\"" BUREAU_OK "(slug \""},     MS,
+    {"\") (description \""},      MS, {"\") (body \""},               MS,
+    {"\") (reason \""},          MS, {"\"))"}};
+static const struct spg_scaffold_seg SEG_MEM_SLUG[] = {
+    {") (capability \""}, MS, {"\"" BUREAU_OK "(slug \""}, MS,
+    {"\") (reason \""}, MS, {"\"))"}};
+
+size_t spg_scaffold_for_kind(enum spg_action_kind kind,
+                             const struct spg_scaffold_seg **out) {
+    if (out == nullptr) {
+        return 0u;
+    }
+#define RET(arr)                                                               \
+    do {                                                                       \
+        *out = (arr);                                                          \
+        return sizeof(arr) / sizeof(arr)[0];                                   \
+    } while (0)
+    switch (kind) {
+    case SPG_ACTION_FINISH:
+        RET(SEG_FINISH);
+    case SPG_ACTION_SIMULATOR:
+        RET(SEG_SIMULATOR);
+    case SPG_ACTION_LOCAL_SHELL:
+        RET(SEG_LOCAL_SHELL);
+    case SPG_ACTION_SSH_AUTH_PROBE:
+        RET(SEG_SSH);
+    case SPG_ACTION_MEMORY_SAVE:
+        RET(SEG_MEM_SAVE);
+    case SPG_ACTION_MEMORY_DELETE:
+    case SPG_ACTION_MEMORY_READ:
+        RET(SEG_MEM_SLUG);
+    }
+#undef RET
+    *out = nullptr;
+    return 0u;
+}

--- a/src/model/model_adapter.c
+++ b/src/model/model_adapter.c
@@ -133,6 +133,61 @@ static enum spg_status generate_fake(struct spg_model_adapter *adapter,
     return append_bytes(result, n, resp);
 }
 
+/* Emit a scaffold literal (#34): append its exact bytes to the output and feed
+ * its tokens into the KV so the model's next prediction is grounded on it. */
+static enum spg_status emit_literal(struct spg_model_adapter *adapter,
+                                    struct spg_model_generate_result *result,
+                                    const char *text) {
+    geist_token_t     ids[256];
+    size_t            n      = 0u;
+    enum geist_status status = geist_session_tokenize(
+        adapter->session, text, sizeof ids / sizeof ids[0], ids, &n);
+    if (status != GEIST_OK) {
+        return map_geist_status(status);
+    }
+    const enum spg_status as = append_bytes(result, strlen(text), text);
+    if (as != SPG_OK) {
+        return as;
+    }
+    if (n > 0u) {
+        status = geist_session_prefill_tokens(adapter->session, n, ids);
+        if (status != GEIST_OK) {
+            return map_geist_status(status);
+        }
+        result->tokens_decoded += n;
+    }
+    return SPG_OK;
+}
+
+/* Free-decode one scaffold string value (#34): the model fills the slot, but we
+ * stop at the first character that would close or corrupt the string — the
+ * closing quote, a newline, or a paren — so the surrounding scaffold literal
+ * supplies the delimiter. Bounded so a runaway slot cannot eat the budget. */
+static enum spg_status decode_string_slot(struct spg_model_adapter *adapter,
+                                          struct spg_model_generate_result *result) {
+    for (size_t j = 0u; j < 64u; j += 1u) {
+        geist_token_t     token  = 0;
+        enum geist_status status = geist_session_decode_step(adapter->session, &token);
+        if (status != GEIST_OK) {
+            return map_geist_status(status);
+        }
+        result->tokens_decoded += 1u;
+        const char *piece = geist_session_token_to_str(adapter->session, token);
+        if (piece == nullptr || piece[0] == '\0') {
+            return SPG_OK; /* eos ends the slot */
+        }
+        const size_t stop = strcspn(piece, "\"\n\r()");
+        if (piece[stop] != '\0') {
+            return append_bytes(result, stop, piece); /* delimiter reached */
+        }
+        const enum spg_status as = append_bytes(result, strlen(piece), piece);
+        if (as != SPG_OK) {
+            return as;
+        }
+    }
+    return SPG_OK; /* length cap */
+}
+
 static enum spg_status generate_geist(
     struct spg_model_adapter *adapter,
     const struct spg_model_generate_request *request,
@@ -151,47 +206,23 @@ static enum spg_status generate_geist(
         return map_geist_status(status);
     }
 
-    /* Constrained decode (#34): force the output to begin with a fixed literal
-     * (the recommendation opening), then decode freely. Tokenize the prefix,
-     * feed it into the KV as if the model had produced it, and append its text
-     * to the output — the model then continues past the structure it cannot
-     * reliably start on its own. */
-    if (adapter->force_prefix != nullptr && adapter->force_prefix[0] != '\0') {
-        geist_token_t prefix_ids[256];
-        size_t        prefix_n = 0u;
-        status                 = geist_session_tokenize(
-            adapter->session, adapter->force_prefix,
-            sizeof prefix_ids / sizeof prefix_ids[0], prefix_ids, &prefix_n);
-        if (status != GEIST_OK) {
-            return map_geist_status(status);
-        }
-        for (size_t i = 0u; i < prefix_n; i += 1u) {
-            const char *piece =
-                geist_session_token_to_str(adapter->session, prefix_ids[i]);
-            if (piece != nullptr && piece[0] != '\0') {
-                const enum spg_status as =
-                    append_bytes(result, strlen(piece), piece);
-                if (as != SPG_OK) {
-                    return as;
-                }
-            }
-        }
-        if (prefix_n > 0u) {
-            status =
-                geist_session_prefill_tokens(adapter->session, prefix_n, prefix_ids);
-            if (status != GEIST_OK) {
-                return map_geist_status(status);
-            }
-            result->tokens_decoded += prefix_n;
+    /* Constrained structural decode (#34): build a valid (recommend ...) form
+     * by construction. (1) force the fixed opening the model cannot reliably
+     * start; (2) mask the kind slot to a valid enum name; (3) emit the field
+     * scaffold for that kind, letting the model free-decode only the leaf
+     * string values. The free decode loop below is skipped entirely. */
+    const bool constrained =
+        adapter->force_prefix != nullptr && adapter->force_prefix[0] != '\0';
+    if (constrained) {
+        /* 1. forced opening "(recommend (kind " */
+        const enum spg_status prefix_as =
+            emit_literal(adapter, result, adapter->force_prefix);
+        if (prefix_as != SPG_OK) {
+            return prefix_as;
         }
 
-        /* Kind-slot mask (#34 stage 1): the forced prefix ends at "(kind ", so
-         * the next tokens name the action kind. Constrain them to a valid enum
-         * name by masking peek_logits to tokens that keep the emitted text a
-         * live prefix, greedily, until a complete kind name is reached. This
-         * flips the free-decode REJECT_UNKNOWN_KIND to a valid kind; the field
-         * scaffold (stage 2) will take over from here. Bails to free decode if
-         * the tokenizer offers no valid continuation. */
+        /* 2. kind-slot mask: greedily keep only tokens that leave the emitted
+         * text a live prefix of a valid kind name, until one is complete. */
         char   kindbuf[64];
         size_t kind_used = 0u;
         kindbuf[0]       = '\0';
@@ -238,6 +269,25 @@ static enum spg_status generate_geist(
             }
             result->tokens_decoded += 1u;
         }
+
+        /* 3. field scaffold: emit the deterministic structure for the chosen
+         * kind, free-decoding only the leaf string slots. If the kind never
+         * resolved the partial output is left for the repair loop. */
+        enum spg_action_kind kind;
+        if (spg_kind_from_text(kindbuf, &kind)) {
+            const struct spg_scaffold_seg *segs = nullptr;
+            const size_t nseg = spg_scaffold_for_kind(kind, &segs);
+            for (size_t s = 0u; s < nseg; s += 1u) {
+                const enum spg_status ss =
+                    segs[s].literal != nullptr
+                        ? emit_literal(adapter, result, segs[s].literal)
+                        : decode_string_slot(adapter, result);
+                if (ss != SPG_OK) {
+                    return ss;
+                }
+            }
+        }
+        return SPG_OK;
     }
 
     for (size_t i = 0u; i < request->max_decode_tokens; i += 1u) {

--- a/test/test_grammar_mask.c
+++ b/test/test_grammar_mask.c
@@ -1,10 +1,48 @@
 #include "geistshell/grammar_mask.h"
 
+#include "geistshell/recommendation.h"
+
 #include <stdio.h>
 
 static int fail(const char *m) {
     fprintf(stderr, "FAIL: %s\n", m);
     return 1;
+}
+
+/* Concatenate (recommend (kind <name> + the scaffold, with a placeholder in
+ * each free string slot, and assert the real parser accepts it as VALID. This
+ * is stage 2's core claim — schema-valid by construction — checked without a
+ * GGUF, straight against recommendation.c. */
+static int check_scaffold_valid(enum spg_action_kind kind) {
+    const struct spg_scaffold_seg *segs = nullptr;
+    const size_t                   n     = spg_scaffold_for_kind(kind, &segs);
+    if (n == 0u) {
+        return fail("scaffold is empty for a known kind");
+    }
+    char   form[512];
+    size_t len =
+        (size_t) snprintf(form, sizeof form, "(recommend (kind %s",
+                          spg_action_kind_to_string(kind));
+    for (size_t i = 0u; i < n && len < sizeof form; i += 1u) {
+        const char *seg = segs[i].literal != nullptr ? segs[i].literal : "value";
+        len += (size_t) snprintf(form + len, sizeof form - len, "%s", seg);
+    }
+
+    struct spg_sexpr_token    toks[128];
+    struct spg_sexpr_node     nodes[128];
+    struct spg_recommendation rec;
+    struct spg_recommendation_error err;
+    const enum spg_status     st = spg_recommendation_parse(
+        len, form, 128u, toks, 128u, nodes, &rec, &err);
+    if (st != SPG_OK || rec.state != SPG_RECOMMENDATION_VALID) {
+        fprintf(stderr, "not VALID (reason %d): %s\n", (int) rec.reject_reason,
+                form);
+        return fail("scaffold form did not parse as a valid recommendation");
+    }
+    if (rec.action_kind != kind) {
+        return fail("scaffold parsed to the wrong kind");
+    }
+    return 0;
 }
 
 int main(void) {
@@ -65,6 +103,30 @@ int main(void) {
     if (spg_kind_complete("memory") || spg_kind_complete("local") ||
         spg_kind_complete("") || spg_kind_complete("finishx")) {
         return fail("partials/overshoot are not complete");
+    }
+
+    /* text -> enum, tolerating the leading detok whitespace. */
+    enum spg_action_kind k;
+    if (!spg_kind_from_text(" simulator", &k) || k != SPG_ACTION_SIMULATOR) {
+        return fail("' simulator' resolves to SPG_ACTION_SIMULATOR");
+    }
+    if (!spg_kind_from_text("\tfinish", &k) || k != SPG_ACTION_FINISH) {
+        return fail("tab + finish resolves");
+    }
+    if (spg_kind_from_text("nope", &k)) {
+        return fail("unknown kind does not resolve");
+    }
+
+    /* Every kind's scaffold parses as a valid recommendation by construction. */
+    const enum spg_action_kind kinds[] = {
+        SPG_ACTION_LOCAL_SHELL, SPG_ACTION_SSH_AUTH_PROBE, SPG_ACTION_SIMULATOR,
+        SPG_ACTION_MEMORY_SAVE, SPG_ACTION_MEMORY_DELETE, SPG_ACTION_MEMORY_READ,
+        SPG_ACTION_FINISH,
+    };
+    for (size_t i = 0u; i < sizeof kinds / sizeof kinds[0]; i += 1u) {
+        if (check_scaffold_valid(kinds[i]) != 0) {
+            return 1;
+        }
     }
 
     printf("test_grammar_mask ok\n");


### PR DESCRIPTION
Stage 2 closes the reject chain. Once the kind slot resolves, the rest of a valid `(recommend ...)` form is deterministic structure with a few free leaf values, so the adapter emits that structure and lets the model free-decode only the string slots. Bureaucratic fields (cost, uses_network, confidence_bp) are baked in with sane defaults.

- `grammar_mask.c`: `spg_kind_from_text` + a per-kind scaffold table (segment = verbatim literal, or free string slot), mirroring `required_fields_seen` + `kind_fields_match`. `test_grammar_mask` builds each of the 7 kinds' forms and parses them through the real `recommendation.c` — **all VALID, no GGUF**.
- `model_adapter.c`: `emit_literal` (prefill + exact bytes) and `decode_string_slot` (free decode, stop at closing quote/newline/paren). Constrained path owns generation end to end; free decode unchanged & default.

## Pi result (Gemma 4 E2B) — the reject chain is resolved
`SYNTAX` (free) → `UNKNOWN_KIND` (prefix) → `MISSING_FIELD` (kind mask) → **valid form** (scaffold), in **1 step / ~22 s** (vs ~2m20 of repair loops):
```
(recommend (kind simulator) (capability "read") (cost 1) (uses_network false) (confidence_bp 5000) (reason "Simulate a general system behavior"))
```
Parses + schema-valid — the model now emits the DSL. `termination=denied`: the form reached the **policy gate**, denied for capability `read` (policy grants `sim.act`/`build.run`). **Acceptance criterion #1 met.**

Remaining for criterion #3 (verdict=pass): a **capability mask** constraining the capability slot to the policy's enabled capabilities for the kind — same shape as the kind mask, needs policy plumbed into the adapter. Tracked in #34.

Suite: grammar_mask (incl. parser-backed scaffold check) + full suite green, Mac (asan) + Pi.