### PR TITLE
feat(decode): mask the capability slot to the policy caps (#34 stage 2b)

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -155,12 +155,35 @@ denied capability `"read"` (the policy allows `sim.act` / `build.run`). That is
 acceptance criterion #1 met — a valid, schema-matching form where free decoding
 gave SYNTAX.
 
-Remaining for criterion #3 (verdict=pass): the model free-picked a capability
-the policy does not grant. The next piece is a **capability mask** — constrain
-the capability slot to the policy's enabled capabilities for the chosen kind,
-exactly as stage 1 masked the kind. It needs the policy capabilities plumbed
-into the adapter. Then a simple task can actually pass, and the LIFT
-experiments (#25/#26) can run on a model that acts.
+**Stage 2b — capability mask (merged).** The kind mask generalized to a choice
+mask over any candidate list (`spg_choice_*`); the capability slot is now masked
+to the policy's enabled capabilities for the chosen kind (the adapter is handed
+the enabled caps, memory expanded to each `memory_*` kind). Inside a quoted
+string whitespace is literal, so `decode_choice_slot` strips the leading detok
+space — the value is emitted exactly (`"sim.act"`, not `" sim.act"`, which the
+policy would not match).
+
+On the Pi the deny cleared and the action executed end to end:
+
+    (recommend (kind simulator) (capability "sim.act") (cost 1)
+      (uses_network false) (confidence_bp 5000) (reason "Simulate a scenario"))
+    (policy_decision (decision allow) (deny_reason SPG_POLICY_DENY_NONE) ...)
+    (sim_result (action patch_vulnerability) (mutated true)
+      (risk_before 35300) (risk_after 32100))
+
+The policy **allowed** the action and the simulator **ran**, dropping risk — a
+real effect from a model that could not emit the DSL at all before constrained
+decoding. The full chain is resolved: `SYNTAX → UNKNOWN_KIND → MISSING_FIELD →
+valid form → denied → allowed + executed`.
+
+That is the decoder complete: a small model reliably emits a valid,
+policy-grantable, executable recommendation under `--constrained`. `termination`
+was `max_steps` (Gemma kept choosing simulator actions rather than `finish`) —
+a behaviour/corpus matter, not a decode gap. What remains is the **LIFT
+measurement** (#25 numerator, #26 benefit): a corpus with an `expect` criterion
+where control (free decode, scores ~0) vs constrained can be compared for
+success rate and gain-per-token. That is the payoff the whole decoder was built
+to unblock, and it is now unblocked.
 
 Dev-env note: the Mac's deps/geist pointed at a newer checkout lacking
 geist_util.h; switched to the pinned v0.2.1 via `make sync-engine`.

--- a/include/geistshell/grammar_mask.h
+++ b/include/geistshell/grammar_mask.h
@@ -34,6 +34,24 @@ extern "C" {
 [[nodiscard]] bool spg_kind_from_text(const char *emitted,
                                       enum spg_action_kind *out);
 
+/* Fill `out` (capacity `cap`, need >= 7) with the valid kind names and return
+ * the count, so the caller can drive the kind slot through the general choice
+ * mask below. */
+size_t spg_kind_names(const char **out, size_t cap);
+
+/* General choice mask (kind is the special case above). Would `emitted` + `piece`
+ * still be a live prefix of at least one of the `n` candidate names, without
+ * overshooting? Leading whitespace in the comparison is ignored, so a
+ * detokenized " sim.act" matches "sim.act". Used to constrain a value slot
+ * (e.g. capability) to a fixed vocabulary. */
+[[nodiscard]] bool spg_choice_prefix_ok(const char *const *names, size_t n,
+                                        const char *emitted, const char *piece);
+
+/* Is `emitted` exactly one of the `n` candidate names? Assumes no candidate is a
+ * prefix of another (true for policy capability names). */
+[[nodiscard]] bool spg_choice_complete(const char *const *names, size_t n,
+                                       const char *emitted);
+
 /* Field scaffold (geistshell#34 stage 2). Once the kind is fixed, the rest of a
  * valid (recommend ...) form is deterministic structure with a few free leaf
  * values. A scaffold is that structure as an ordered segment list: a LITERAL
@@ -43,8 +61,15 @@ extern "C" {
  * schema-valid form by construction. The bureaucratic fields (cost,
  * uses_network, confidence_bp) are baked into the literals with sane defaults —
  * they are deterministic per kind, not a decision the small model must make. */
+enum spg_scaffold_seg_kind {
+    SPG_SCAFFOLD_LITERAL = 0, /* emit `literal` verbatim */
+    SPG_SCAFFOLD_STRING,      /* one free-decoded string value */
+    SPG_SCAFFOLD_CAPABILITY,  /* one string value masked to the policy caps */
+};
+
 struct spg_scaffold_seg {
-    const char *literal; /* verbatim text, or nullptr for a free string slot */
+    enum spg_scaffold_seg_kind kind;
+    const char *literal; /* set for SPG_SCAFFOLD_LITERAL, else nullptr */
 };
 
 /* The scaffold for `kind`, to emit right after the kind name (the caller has

--- a/include/geistshell/model_adapter.h
+++ b/include/geistshell/model_adapter.h
@@ -1,6 +1,7 @@
 #ifndef GEISTSHELL_MODEL_ADAPTER_H
 #define GEISTSHELL_MODEL_ADAPTER_H
 
+#include "geistshell/policy.h" /* enum spg_action_kind (constrained decode caps) */
 #include "geistshell/status.h"
 
 #include <stdbool.h>
@@ -14,6 +15,15 @@ extern "C" {
 struct geist_backend;
 struct geist_model;
 struct geist_session;
+
+/* A policy capability the constrained decoder may put in the capability slot,
+ * tagged with the action kind it applies to (memory capabilities are expanded
+ * to one entry per memory_* kind by the caller). name is borrowed and must be
+ * null-terminated. #34. */
+struct spg_model_capability {
+    const char          *name;
+    enum spg_action_kind kind;
+};
 
 enum spg_model_adapter_kind {
     SPG_MODEL_ADAPTER_FAKE = 0,
@@ -77,6 +87,12 @@ struct spg_model_adapter_config {
      * from a grammar description alone. Null = free decode (default). GEIST
      * only; ignored by fake/remote. */
     const char *force_prefix;
+
+    /* Capabilities the constrained decoder may emit in the capability slot,
+     * masked per chosen kind. Borrowed; must outlive the adapter. Empty → the
+     * capability slot free-decodes (valid form, but may be policy-denied). */
+    const struct spg_model_capability *capabilities;
+    size_t                             capability_count;
 };
 
 struct spg_model_adapter {
@@ -95,6 +111,8 @@ struct spg_model_adapter {
     size_t                          fake_index; /* next scripted reply */
     const char                     *fake_gate_marker;
     const char                     *force_prefix; /* constrained decode (#34) */
+    const struct spg_model_capability *capabilities; /* #34 capability mask */
+    size_t                             capability_count;
 
     /* REMOTE transport state: opaque CURL handle, borrowed config strings, and
      * the sampling values forwarded to the chat/completions request. */

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -1935,6 +1935,52 @@ static int agent_command(int argc, char **argv) {
     }
     journal_open = true;
 
+    /* Constrained-decode capability table (#34): enabled policy caps only,
+     * names materialized to cstrings (heap, outlive the adapter), memory caps
+     * expanded to one entry per memory_* action kind. Empty unless --constrained. */
+    static struct spg_model_capability agent_caps[SPG_POLICY_MAX_CAPABILITIES *
+                                                  3u];
+    size_t agent_caps_n = 0u;
+    if (constrained) {
+        for (size_t i = 0u; i < policy.capability_count; i += 1u) {
+            const struct spg_policy_capability *cap = &policy.capabilities[i];
+            if (!cap->enabled) {
+                continue;
+            }
+            char *name = nullptr;
+            if (span_to_cstr(policy_text.n, policy_text.data, cap->name,
+                             &name) != SPG_OK) {
+                continue;
+            }
+            enum spg_action_kind kinds[3];
+            size_t               nk = 0u;
+            switch (cap->kind) {
+            case SPG_POLICY_CAP_LOCAL_SHELL:
+                kinds[nk++] = SPG_ACTION_LOCAL_SHELL;
+                break;
+            case SPG_POLICY_CAP_SSH_AUTH_PROBE:
+                kinds[nk++] = SPG_ACTION_SSH_AUTH_PROBE;
+                break;
+            case SPG_POLICY_CAP_SIMULATOR:
+                kinds[nk++] = SPG_ACTION_SIMULATOR;
+                break;
+            case SPG_POLICY_CAP_MEMORY:
+                kinds[nk++] = SPG_ACTION_MEMORY_SAVE;
+                kinds[nk++] = SPG_ACTION_MEMORY_DELETE;
+                kinds[nk++] = SPG_ACTION_MEMORY_READ;
+                break;
+            }
+            for (size_t k = 0u;
+                 k < nk &&
+                 agent_caps_n < sizeof agent_caps / sizeof agent_caps[0];
+                 k += 1u) {
+                agent_caps[agent_caps_n].name = name;
+                agent_caps[agent_caps_n].kind = kinds[k];
+                agent_caps_n += 1u;
+            }
+        }
+    }
+
     /* --fake-script -> the scripted fake; otherwise the real model at the
      * config's (model ...) path, run and JOURNALED — the production path P6
      * (directive injection) and P7 (recurrence audit) read. */
@@ -1947,13 +1993,15 @@ static int agent_command(int argc, char **argv) {
                   .fake_responses      = script,
               }
             : (struct spg_model_adapter_config){
-                  .kind         = SPG_MODEL_ADAPTER_GEIST,
-                  .model_path   = model_path,
-                  .force_prefix = constrained ? "(recommend (kind " : nullptr,
-                  .sampling     = {.max_seq_len  = 4096u,
-                                   .temperature = 0.0f,
-                                   .top_p       = 1.0f,
-                                   .random_seed = run.seed},
+                  .kind             = SPG_MODEL_ADAPTER_GEIST,
+                  .model_path       = model_path,
+                  .force_prefix     = constrained ? "(recommend (kind " : nullptr,
+                  .capabilities     = agent_caps,
+                  .capability_count = agent_caps_n,
+                  .sampling         = {.max_seq_len = 4096u,
+                                       .temperature = 0.0f,
+                                       .top_p       = 1.0f,
+                                       .random_seed = run.seed},
               };
     status = spg_model_adapter_init(&model, &model_config);
     if (status != SPG_OK) {

--- a/src/model/grammar_mask.c
+++ b/src/model/grammar_mask.c
@@ -25,11 +25,12 @@ static const char *skip_spaces(const char *s) {
     return s;
 }
 
-bool spg_kind_prefix_ok(const char *emitted, const char *piece) {
-    if (emitted == nullptr) {
+bool spg_choice_prefix_ok(const char *const *names, const size_t n,
+                          const char *emitted, const char *piece) {
+    if (names == nullptr || emitted == nullptr) {
         return false;
     }
-    char         buf[64];
+    char         buf[128];
     const size_t el = strlen(emitted);
     const size_t pl = piece == nullptr ? 0u : strlen(piece);
     if (el + pl >= sizeof buf) {
@@ -40,33 +41,56 @@ bool spg_kind_prefix_ok(const char *emitted, const char *piece) {
     buf[el + pl]     = '\0';
     const char  *cmp = skip_spaces(buf);
     const size_t len = strlen(cmp);
-    for (size_t i = 0u; i < KIND_COUNT; i += 1u) {
-        const char *name = spg_action_kind_to_string(ALL_KINDS[i]);
-        /* cmp is a prefix of name iff their first `len` bytes match; a name
+    for (size_t i = 0u; i < n; i += 1u) {
+        if (names[i] == nullptr) {
+            continue;
+        }
+        /* cmp is a prefix of names[i] iff their first `len` bytes match; a name
          * shorter than `len` has its '\0' compared against cmp's byte and
          * mismatches, which correctly rejects overshoot. An all-space buffer
          * (len 0) matches every name — still a live prefix. */
-        if (strncmp(name, cmp, len) == 0) {
+        if (strncmp(names[i], cmp, len) == 0) {
             return true;
         }
     }
     return false;
 }
 
-bool spg_kind_complete(const char *emitted) {
-    if (emitted == nullptr) {
+bool spg_choice_complete(const char *const *names, const size_t n,
+                         const char *emitted) {
+    if (names == nullptr || emitted == nullptr) {
         return false;
     }
     const char *cmp = skip_spaces(emitted);
     if (cmp[0] == '\0') {
         return false;
     }
-    for (size_t i = 0u; i < KIND_COUNT; i += 1u) {
-        if (strcmp(spg_action_kind_to_string(ALL_KINDS[i]), cmp) == 0) {
+    for (size_t i = 0u; i < n; i += 1u) {
+        if (names[i] != nullptr && strcmp(names[i], cmp) == 0) {
             return true;
         }
     }
     return false;
+}
+
+size_t spg_kind_names(const char **out, const size_t cap) {
+    size_t n = 0u;
+    for (size_t i = 0u; i < KIND_COUNT && n < cap; i += 1u) {
+        out[n] = spg_action_kind_to_string(ALL_KINDS[i]);
+        n += 1u;
+    }
+    return n;
+}
+
+bool spg_kind_prefix_ok(const char *emitted, const char *piece) {
+    const char *names[KIND_COUNT];
+    return spg_choice_prefix_ok(names, spg_kind_names(names, KIND_COUNT),
+                                emitted, piece);
+}
+
+bool spg_kind_complete(const char *emitted) {
+    const char *names[KIND_COUNT];
+    return spg_choice_complete(names, spg_kind_names(names, KIND_COUNT), emitted);
 }
 
 bool spg_kind_from_text(const char *emitted, enum spg_action_kind *out) {
@@ -88,27 +112,30 @@ bool spg_kind_from_text(const char *emitted, enum spg_action_kind *out) {
  * defaults are baked in; uses_network is fixed per kind by kind_fields_match
  * (true only for ssh_auth_probe). Field sets mirror required_fields_seen +
  * kind_fields_match in recommendation.c. */
-#define MS {.literal = nullptr}
+#define LIT(s) {.kind = SPG_SCAFFOLD_LITERAL, .literal = (s)}
+#define STR {.kind = SPG_SCAFFOLD_STRING}
+#define CAP {.kind = SPG_SCAFFOLD_CAPABILITY}
 #define BUREAU_OK ") (cost 1) (uses_network false) (confidence_bp 5000) "
 #define BUREAU_NET ") (cost 1) (uses_network true) (confidence_bp 5000) "
 
 static const struct spg_scaffold_seg SEG_FINISH[] = {
-    {") (reason \""}, MS, {"\"))"}};
+    LIT(") (reason \""), STR, LIT("\"))")};
 static const struct spg_scaffold_seg SEG_SIMULATOR[] = {
-    {") (capability \""}, MS, {"\"" BUREAU_OK "(reason \""}, MS, {"\"))"}};
+    LIT(") (capability \""), CAP, LIT("\"" BUREAU_OK "(reason \""), STR,
+    LIT("\"))")};
 static const struct spg_scaffold_seg SEG_LOCAL_SHELL[] = {
-    {") (capability \""},         MS, {"\"" BUREAU_OK "(command \""}, MS,
-    {"\") (reason \""}, MS, {"\"))"}};
+    LIT(") (capability \""), CAP, LIT("\"" BUREAU_OK "(command \""), STR,
+    LIT("\") (reason \""), STR, LIT("\"))")};
 static const struct spg_scaffold_seg SEG_SSH[] = {
-    {") (capability \""},        MS, {"\"" BUREAU_NET "(target \""}, MS,
-    {"\") (reason \""}, MS, {"\"))"}};
+    LIT(") (capability \""), CAP, LIT("\"" BUREAU_NET "(target \""), STR,
+    LIT("\") (reason \""), STR, LIT("\"))")};
 static const struct spg_scaffold_seg SEG_MEM_SAVE[] = {
-    {") (capability \""},        MS, {"\"" BUREAU_OK "(slug \""},     MS,
-    {"\") (description \""},      MS, {"\") (body \""},               MS,
-    {"\") (reason \""},          MS, {"\"))"}};
+    LIT(") (capability \""), CAP, LIT("\"" BUREAU_OK "(slug \""), STR,
+    LIT("\") (description \""), STR, LIT("\") (body \""), STR,
+    LIT("\") (reason \""), STR, LIT("\"))")};
 static const struct spg_scaffold_seg SEG_MEM_SLUG[] = {
-    {") (capability \""}, MS, {"\"" BUREAU_OK "(slug \""}, MS,
-    {"\") (reason \""}, MS, {"\"))"}};
+    LIT(") (capability \""), CAP, LIT("\"" BUREAU_OK "(slug \""), STR,
+    LIT("\") (reason \""), STR, LIT("\"))")};
 
 size_t spg_scaffold_for_kind(enum spg_action_kind kind,
                              const struct spg_scaffold_seg **out) {

--- a/src/model/model_adapter.c
+++ b/src/model/model_adapter.c
@@ -1,6 +1,7 @@
 #include "geistshell/model_adapter.h"
 
-#include "geistshell/grammar_mask.h" /* #34: kind-slot mask */
+#include "geistshell/grammar_mask.h"  /* #34: kind + capability masks */
+#include "geistshell/policy_config.h" /* SPG_POLICY_MAX_CAPABILITIES */
 
 #include <geist.h>
 #include <geist_util.h> /* #34: tokenize + prefill_tokens + peek_logits */
@@ -188,6 +189,97 @@ static enum spg_status decode_string_slot(struct spg_model_adapter *adapter,
     return SPG_OK; /* length cap */
 }
 
+/* Decode one slot constrained to a fixed vocabulary (#34): greedily keep only
+ * tokens that leave the emitted text a live prefix of some candidate name,
+ * until one is complete. Leading detok whitespace is stripped from the appended
+ * text so the value carries no spurious space (correct for kind and capability,
+ * whose names contain none). The chosen name is written to out[]. Bails (leaving
+ * out partial) if no valid continuation exists. */
+static enum spg_status decode_choice_slot(
+    struct spg_model_adapter *adapter, struct spg_model_generate_result *result,
+    const char *const *names, const size_t names_n, char *out,
+    const size_t out_cap) {
+    size_t used = 0u;
+    out[0]      = '\0';
+    for (size_t step = 0u;
+         step < 24u && !spg_choice_complete(names, names_n, out); step += 1u) {
+        size_t       n_vocab = 0u;
+        const float *logits =
+            geist_session_peek_logits(adapter->session, &n_vocab);
+        if (logits == nullptr || n_vocab == 0u) {
+            break;
+        }
+        geist_token_t best       = -1;
+        float         best_logit = -INFINITY;
+        for (size_t t = 0u; t < n_vocab; t += 1u) {
+            if (logits[t] <= best_logit) {
+                continue;
+            }
+            const char *piece =
+                geist_session_token_to_str(adapter->session, (geist_token_t) t);
+            if (piece == nullptr ||
+                !spg_choice_prefix_ok(names, names_n, out, piece)) {
+                continue;
+            }
+            best       = (geist_token_t) t;
+            best_logit = logits[t];
+        }
+        if (best < 0) {
+            break;
+        }
+        const char *piece = geist_session_token_to_str(adapter->session, best);
+        const char *ap    = piece;
+        while (*ap == ' ' || *ap == '\t') {
+            ap += 1;
+        }
+        const size_t pl = strlen(ap);
+        if (used + pl >= out_cap) {
+            break;
+        }
+        if (pl > 0u) {
+            const enum spg_status as = append_bytes(result, pl, ap);
+            if (as != SPG_OK) {
+                return as;
+            }
+            memcpy(out + used, ap, pl);
+            used += pl;
+            out[used] = '\0';
+        }
+        const enum geist_status status =
+            geist_session_prefill_tokens(adapter->session, 1u, &best);
+        if (status != GEIST_OK) {
+            return map_geist_status(status);
+        }
+        result->tokens_decoded += 1u;
+    }
+    return SPG_OK;
+}
+
+/* Free-decode the capability slot masked to the policy capabilities enabled for
+ * `kind` (#34). With no matching capability it falls back to a free string —
+ * the form stays valid, the policy gate then decides. */
+static enum spg_status decode_capability_slot(
+    struct spg_model_adapter *adapter, struct spg_model_generate_result *result,
+    const enum spg_action_kind kind) {
+    const char *names[SPG_POLICY_MAX_CAPABILITIES];
+    size_t      names_n = 0u;
+    for (size_t i = 0u;
+         i < adapter->capability_count && names_n < SPG_POLICY_MAX_CAPABILITIES;
+         i += 1u) {
+        if (adapter->capabilities[i].kind == kind &&
+            adapter->capabilities[i].name != nullptr) {
+            names[names_n] = adapter->capabilities[i].name;
+            names_n += 1u;
+        }
+    }
+    if (names_n == 0u) {
+        return decode_string_slot(adapter, result); /* no mask: free-decode */
+    }
+    char chosen[128];
+    return decode_choice_slot(adapter, result, names, names_n, chosen,
+                              sizeof chosen);
+}
+
 static enum spg_status generate_geist(
     struct spg_model_adapter *adapter,
     const struct spg_model_generate_request *request,
@@ -221,67 +313,38 @@ static enum spg_status generate_geist(
             return prefix_as;
         }
 
-        /* 2. kind-slot mask: greedily keep only tokens that leave the emitted
-         * text a live prefix of a valid kind name, until one is complete. */
-        char   kindbuf[64];
-        size_t kind_used = 0u;
-        kindbuf[0]       = '\0';
-        for (size_t step = 0u; step < 16u && !spg_kind_complete(kindbuf);
-             step += 1u) {
-            size_t       n_vocab = 0u;
-            const float *logits =
-                geist_session_peek_logits(adapter->session, &n_vocab);
-            if (logits == nullptr || n_vocab == 0u) {
-                break;
-            }
-            geist_token_t best       = -1;
-            float         best_logit = -INFINITY;
-            for (size_t t = 0u; t < n_vocab; t += 1u) {
-                if (logits[t] <= best_logit) {
-                    continue; /* cannot beat the best valid token so far */
-                }
-                const char *piece = geist_session_token_to_str(
-                    adapter->session, (geist_token_t) t);
-                if (piece == nullptr || !spg_kind_prefix_ok(kindbuf, piece)) {
-                    continue;
-                }
-                best       = (geist_token_t) t;
-                best_logit = logits[t];
-            }
-            if (best < 0) {
-                break; /* dead end: no token keeps a valid kind prefix */
-            }
-            const char  *piece = geist_session_token_to_str(adapter->session, best);
-            const size_t pl    = strlen(piece);
-            if (kind_used + pl >= sizeof kindbuf) {
-                break;
-            }
-            const enum spg_status as = append_bytes(result, pl, piece);
-            if (as != SPG_OK) {
-                return as;
-            }
-            memcpy(kindbuf + kind_used, piece, pl);
-            kind_used += pl;
-            kindbuf[kind_used] = '\0';
-            status = geist_session_prefill_tokens(adapter->session, 1u, &best);
-            if (status != GEIST_OK) {
-                return map_geist_status(status);
-            }
-            result->tokens_decoded += 1u;
+        /* 2. kind-slot mask: constrain the slot to a valid kind enum name. */
+        char        kindbuf[64];
+        const char *kn[8];
+        const size_t  knn = spg_kind_names(kn, sizeof kn / sizeof kn[0]);
+        const enum spg_status ks =
+            decode_choice_slot(adapter, result, kn, knn, kindbuf, sizeof kindbuf);
+        if (ks != SPG_OK) {
+            return ks;
         }
 
         /* 3. field scaffold: emit the deterministic structure for the chosen
-         * kind, free-decoding only the leaf string slots. If the kind never
-         * resolved the partial output is left for the repair loop. */
+         * kind, decoding only the leaf slots — the capability masked to the
+         * policy's enabled caps, the rest free. If the kind never resolved the
+         * partial output is left for the repair loop. */
         enum spg_action_kind kind;
         if (spg_kind_from_text(kindbuf, &kind)) {
             const struct spg_scaffold_seg *segs = nullptr;
             const size_t nseg = spg_scaffold_for_kind(kind, &segs);
             for (size_t s = 0u; s < nseg; s += 1u) {
-                const enum spg_status ss =
-                    segs[s].literal != nullptr
-                        ? emit_literal(adapter, result, segs[s].literal)
-                        : decode_string_slot(adapter, result);
+                enum spg_status ss;
+                switch (segs[s].kind) {
+                case SPG_SCAFFOLD_LITERAL:
+                    ss = emit_literal(adapter, result, segs[s].literal);
+                    break;
+                case SPG_SCAFFOLD_CAPABILITY:
+                    ss = decode_capability_slot(adapter, result, kind);
+                    break;
+                case SPG_SCAFFOLD_STRING:
+                default:
+                    ss = decode_string_slot(adapter, result);
+                    break;
+                }
                 if (ss != SPG_OK) {
                     return ss;
                 }
@@ -323,8 +386,10 @@ spg_model_adapter_init(struct spg_model_adapter *adapter,
         return SPG_E_INVALID_ARG;
     }
     *adapter = (struct spg_model_adapter){
-        .kind         = config->kind,
-        .force_prefix = config->force_prefix, /* #34: GEIST-only, borrowed */
+        .kind             = config->kind,
+        .force_prefix     = config->force_prefix, /* #34: GEIST-only, borrowed */
+        .capabilities     = config->capabilities,
+        .capability_count = config->capability_count,
     };
 
     if (config->kind == SPG_MODEL_ADAPTER_FAKE) {

--- a/test/test_grammar_mask.c
+++ b/test/test_grammar_mask.c
@@ -117,6 +117,23 @@ int main(void) {
         return fail("unknown kind does not resolve");
     }
 
+    /* General choice mask over an arbitrary vocabulary (capability slot). */
+    const char *const caps[] = {"sim.act", "build.run"};
+    if (!spg_choice_prefix_ok(caps, 2u, "", "sim") ||
+        !spg_choice_prefix_ok(caps, 2u, "sim", ".act") ||
+        !spg_choice_prefix_ok(caps, 2u, "", " build") /* leading detok space */) {
+        return fail("capability live prefixes");
+    }
+    if (spg_choice_prefix_ok(caps, 2u, "", "read") ||
+        spg_choice_prefix_ok(caps, 2u, "sim.act", "x")) {
+        return fail("non-candidate / overshoot rejected");
+    }
+    if (!spg_choice_complete(caps, 2u, "sim.act") ||
+        !spg_choice_complete(caps, 2u, " build.run") ||
+        spg_choice_complete(caps, 2u, "sim")) {
+        return fail("capability completion");
+    }
+
     /* Every kind's scaffold parses as a valid recommendation by construction. */
     const enum spg_action_kind kinds[] = {
         SPG_ACTION_LOCAL_SHELL, SPG_ACTION_SSH_AUTH_PROBE, SPG_ACTION_SIMULATOR,


### PR DESCRIPTION
The last piece: stage 2 produced a valid form but the model free-picked capability `read`, which the policy denied. Stage 2b constrains the capability slot to the policy's enabled capabilities for the chosen kind — grantable by construction.

- `grammar_mask`: kind predicates are now the special case of a general choice mask (`spg_choice_prefix_ok/complete`); `spg_kind_names` exposes the kind vocabulary; scaffold segments tagged LITERAL/STRING/CAPABILITY.
- `model_adapter`: `decode_choice_slot` drives kind + capability alike (strips the leading detok space so the value is exact — critical inside a quoted string); `decode_capability_slot` filters the passed caps to the chosen kind. New `capabilities`/`capability_count` on the config.
- `cli`: build the capability table from the loaded policy (enabled only, names materialized, memory expanded to each `memory_*` kind), passed under `--constrained`.

## Pi result (Gemma 4 E2B) — allowed + executed end to end
```
(recommend (kind simulator) (capability "sim.act") (cost 1) (uses_network false) (confidence_bp 5000) (reason "Simulate a scenario"))
(policy_decision (decision allow) (deny_reason SPG_POLICY_DENY_NONE) ...)
(sim_result (action patch_vulnerability) (mutated true) (risk_before 35300) (risk_after 32100))
```
Deny cleared, the simulator **ran** and dropped risk. Full chain resolved: `SYNTAX → UNKNOWN_KIND → MISSING_FIELD → valid form → denied → allowed + executed`.

**Decoder complete**: a small model reliably emits a valid, policy-grantable, executable recommendation under `--constrained`. Remaining is the LIFT measurement (#25/#26) on an `expect` corpus — now unblocked.

Suite: grammar_mask (choice mask + parser-backed scaffolds) + full suite green, Mac (asan) + Pi.