### PR TITLE
feat(run): free-text (goal) + choice-slot force-complete

### DIFF
--- a/include/geistshell/actor.h
+++ b/include/geistshell/actor.h
@@ -37,6 +37,7 @@ struct spg_actor_state {
     const char *memory_index;
     const char *observation;
     const char *exemplars;
+    const char *goal;
 };
 
 struct spg_actor_step_config {

--- a/include/geistshell/agent_run.h
+++ b/include/geistshell/agent_run.h
@@ -38,6 +38,8 @@ struct spg_agent_run_inputs {
      * in the context's (examples ...) section — few-shot so a small model can
      * imitate the DSL rather than parse the schema grammar. Null = none. */
     const char                     *exemplars;
+    /* Optional free-text task, rendered as (goal "..."). Null = none. */
+    const char                     *goal;
 };
 
 struct spg_agent_run_config {

--- a/include/geistshell/context.h
+++ b/include/geistshell/context.h
@@ -42,6 +42,9 @@ struct spg_context_sources {
      * model imitates filled-in examples far more reliably than it parses a
      * grammar. Null = none (unchanged behaviour). */
     const char                        *exemplars;
+    /* Optional free-text task, rendered near the top as (goal "..."). Null =
+     * none: the scenario graph is the whole task. */
+    const char                        *goal;
 };
 
 struct spg_context_budget_item {

--- a/include/geistshell/orchestrator.h
+++ b/include/geistshell/orchestrator.h
@@ -58,6 +58,8 @@ struct spg_orchestrator_state {
     /* Optional concrete worked examples of the recommendation form (context
      * (examples ...) section) — few-shot for a small model. Null = none. */
     const char *exemplars;
+    /* Optional free-text task, rendered as (goal "..."). Null = none. */
+    const char *goal;
 };
 
 struct spg_orchestrator_config {

--- a/include/geistshell/run_config.h
+++ b/include/geistshell/run_config.h
@@ -41,6 +41,13 @@ struct spg_run_config {
      * zero tokens: the world supplies the ground truth. */
     bool                 has_expect;
     struct spg_text_span expect_observation;
+
+    /* Optional free-text task the agent is to accomplish, rendered into the
+     * context as (goal "..."). geistshell's task is otherwise only the scenario;
+     * a goal lets a run state an objective the model decides how to meet — the
+     * headroom a learning lesson can shape. Absent -> no goal line. */
+    bool                 has_goal;
+    struct spg_text_span goal;
 };
 
 struct spg_run_config_error {

--- a/src/actor/actor.c
+++ b/src/actor/actor.c
@@ -146,6 +146,7 @@ spg_actor_step(struct spg_actor_state *state,
         .memory_index         = state->memory_index,
         .observation        = state->observation,
         .exemplars            = state->exemplars,
+        .goal                 = state->goal,
     };
 
     enum spg_status status = spg_context_build(

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -2064,6 +2064,10 @@ static int agent_command(int argc, char **argv) {
         .memory_index_capacity   = sizeof mem_index,
         .memory_index            = mem_index,
     };
+    char *goal_cstr = nullptr; /* materialized (goal "...") span, or null */
+    if (run.has_goal) {
+        (void)span_to_cstr(run_text.n, run_text.data, run.goal, &goal_cstr);
+    }
     const struct spg_agent_run_inputs inputs = {
         .model         = &model,
         .policy        = &policy,
@@ -2074,6 +2078,7 @@ static int agent_command(int argc, char **argv) {
         .store         = store_open ? &store : nullptr,
         .journal       = &journal,
         .exemplars     = exemplars_text.data, /* null when --exemplars absent */
+        .goal          = goal_cstr,           /* null when (goal ...) absent */
     };
     const struct spg_agent_run_config rcfg = {
         .max_steps         = max_steps,

--- a/src/context/context.c
+++ b/src/context/context.c
@@ -695,6 +695,11 @@ enum spg_status spg_context_render(const struct spg_context_sources *sources,
         .dst      = dst,
     };
     render_contract(&state);
+    if (sources->goal != nullptr && sources->goal[0] != '\0') {
+        append_cstr(&state, "(goal ");
+        append_quoted_cstr(&state, sources->goal);
+        append_cstr(&state, ")\n");
+    }
     if (sources->exemplars != nullptr && sources->exemplars[0] != '\0') {
         append_cstr(&state, "(examples\n");
         append_cstr(&state, sources->exemplars);

--- a/src/core/run_config.c
+++ b/src/core/run_config.c
@@ -57,6 +57,14 @@ static const struct spg_schema_field_rule run_fields[] = {
      .max_values = 1u,
      .required   = false,
      .unique     = true},
+    /* Optional free-text task, rendered as (goal "..."). Absent -> scenario is
+     * the whole task. */
+    {.name       = "goal",
+     .value_kind = SPG_SCHEMA_VALUE_STRING,
+     .min_values = 1u,
+     .max_values = 1u,
+     .required   = false,
+     .unique     = true},
 };
 
 static const struct spg_schema_form_rule run_forms[] = {
@@ -65,7 +73,7 @@ static const struct spg_schema_form_rule run_forms[] = {
      .field_rules          = run_fields,
      .allow_unknown_fields = false,
      .min_fields           = 7u,
-     .max_fields           = 8u},
+     .max_fields           = 9u},
 };
 
 static const struct spg_schema run_schema = {
@@ -258,6 +266,17 @@ enum spg_status spg_run_config_load(
             return status;
         }
         out->has_expect = true;
+    }
+
+    const uint32_t goal_field =
+        find_field(input_n, input, nodes, run_node, "goal");
+    if (goal_field != SPG_SEXPR_INVALID_INDEX) {
+        status = string_value_span(nodes, goal_field, &out->goal);
+        if (status != SPG_OK) {
+            set_error(error, status, goal_field, nodes[goal_field].span.offset);
+            return status;
+        }
+        out->has_goal = true;
     }
 
     return SPG_OK;

--- a/src/model/model_adapter.c
+++ b/src/model/model_adapter.c
@@ -252,6 +252,34 @@ static enum spg_status decode_choice_slot(
         }
         result->tokens_decoded += 1u;
     }
+    /* Force-complete (#34 robustness): greedy token-by-token can dead-end on a
+     * partial (e.g. "buil" of "build.run") when the tokenizer offers no clean
+     * continuation. If what we have is a prefix of exactly one candidate, append
+     * the rest so the emitted value is a valid, complete name; the following
+     * scaffold literal re-anchors the KV, so output correctness is enough. */
+    if (!spg_choice_complete(names, names_n, out)) {
+        const char *trimmed = out;
+        while (*trimmed == ' ' || *trimmed == '\t') {
+            trimmed += 1;
+        }
+        const size_t tl    = strlen(trimmed);
+        int          match = -1;
+        for (size_t i = 0u; i < names_n; i += 1u) {
+            if (names[i] != nullptr && strncmp(names[i], trimmed, tl) == 0) {
+                match = match < 0 ? (int) i : -2; /* -2 = ambiguous, don't force */
+            }
+        }
+        if (match >= 0) {
+            const char  *suffix = names[(size_t) match] + tl;
+            const size_t sl     = strlen(suffix);
+            if (sl > 0u) {
+                const enum spg_status as = append_bytes(result, sl, suffix);
+                if (as != SPG_OK) {
+                    return as;
+                }
+            }
+        }
+    }
     return SPG_OK;
 }
 

--- a/src/run/agent_run.c
+++ b/src/run/agent_run.c
@@ -74,6 +74,7 @@ enum spg_status spg_agent_run(const struct spg_agent_run_inputs *inputs,
         .policy_text   = inputs->policy_text,
         .observation   = workspace->observation,
         .exemplars     = inputs->exemplars,
+        .goal          = inputs->goal,
     };
 
     const size_t refs = config->context_refs > 0u ? config->context_refs : 8u;

--- a/src/run/orchestrator.c
+++ b/src/run/orchestrator.c
@@ -199,6 +199,7 @@ enum spg_status spg_orchestrator_tick(
         .memory_index         = memory_index,
         .observation        = state->observation,
         .exemplars            = state->exemplars,
+        .goal                 = state->goal,
     };
     const struct spg_actor_step_config actor_config = {
         .actor_id            = config->actor_id,

--- a/test/test_context.c
+++ b/test/test_context.c
@@ -376,9 +376,53 @@ static int test_exemplars_render(void) {
     return 0;
 }
 
+/* A free-text goal renders as (goal "...") near the top (after the contract),
+ * so the model reads its objective. Absent -> no goal line. */
+static int test_goal_render(void) {
+    const struct spg_run_config    run   = {.budgets = {.tokens = 100u}};
+    const struct spg_policy_usage  usage = {};
+    struct spg_context_graph_ref   graph_refs[1];
+    struct spg_context_memory_ref  memory_refs[1];
+    struct spg_context_journal_ref journal_refs[1];
+    struct spg_context_view        view = {};
+    spg_context_view_init(&view, 1u, graph_refs, 1u, memory_refs, 1u,
+                          journal_refs);
+    const struct spg_context_limits limits = {
+        .graph_nodes = 1u, .memory_facts = 1u, .journal_events = 1u};
+
+    struct spg_context_sources sources = {
+        .run = &run, .usage = &usage, .goal = "print GOAL-MARK to stdout"};
+    if (spg_context_build(&sources, &limits, &view) != SPG_OK) {
+        return 1;
+    }
+    char   buf[4096];
+    size_t req = 0u;
+    if (spg_context_render(&sources, &view, sizeof buf, buf, &req) != SPG_OK) {
+        return 1;
+    }
+    if (strstr(buf, "(goal ") == nullptr ||
+        strstr(buf, "GOAL-MARK") == nullptr) {
+        return 1;
+    }
+    if (strstr(buf, "(contract") == nullptr ||
+        strstr(buf, "(contract") > strstr(buf, "(goal ")) {
+        return 1; /* goal follows the contract */
+    }
+    sources.goal = nullptr; /* absent -> no goal line */
+    (void)spg_context_render(&sources, &view, sizeof buf, buf, &req);
+    if (strstr(buf, "(goal ") != nullptr) {
+        return 1;
+    }
+    return 0;
+}
+
 int main(void) {
     if (test_exemplars_render() != 0) {
         fprintf(stderr, "test_exemplars_render failed\n");
+        return 1;
+    }
+    if (test_goal_render() != 0) {
+        fprintf(stderr, "test_goal_render failed\n");
         return 1;
     }
     if (test_budget_view() != 0) {


### PR DESCRIPTION
Adds an optional `(goal "...")` to the run config, rendered into the context so the model has an objective it decides how to meet — the model-decision headroom the learning-LIFT needs, and general usefulness beyond security scenarios.

Threaded through the exemplars path (run_config → agent_run → orchestrator/actor → context sources → render); rendered after the contract, before exemplars. Absent → unchanged.

Also a #34 decode-robustness fix the goal exposed: greedy choice-slot masking could dead-end on a partial (`"buil"` of `"build.run"`); now force-completed to the sole matching candidate.

## Pi (Gemma 4 E2B) — the goal steers the model, end to end
Goal *"Run a local shell command that prints the word READY"* →
```
(recommend (kind local_shell) (capability "build.run") (cost 1) (uses_network false)
  (command "echo READY") (reason "The goal is to run a local shell command…"))
(policy_decision (decision allow))   # READY printed to stdout
```
The goal drove the kind choice AND the command; the action was allowed and executed. (The run then does a further denied action rather than finishing — the exact headroom a learning lesson can shape, next.)

Tests: `test_goal_render` (render + placement + absence); full suite green Mac (asan) + Pi.