### PR TITLE
feat: strong directive channel (Weg 1) + budget-denial convergence (Weg 2) (#40)

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -337,6 +337,30 @@ lesson does bite. (The goal-directed shell task above would itself pass with a
 deterministic "budget-denied repeat after a success = converged → finish" rule —
 another guardrail, not a lesson.)
 
+### The two follow-ups, tested (Pi/Gemma)
+
+Both levers the conclusion named were then built and measured on the
+goal-directed shell task (goal "print READY", `build.run` budget 1):
+
+- **Stronger channel (Weg 1) — failed.** A designated lesson's directive is now
+  rendered prominently as `(directive "...")` at the top of the context *every
+  step* (not the mind-palace index). Confirmed in the prompt — and greedy Gemma
+  still does not emit `(kind finish)`: control and learned both end `denied`,
+  both `fail`. A strong, explicit, always-present directive changes nothing. On
+  a 2B greedy model, directive-based steering of high-level behaviour does not
+  work regardless of channel strength. (The channel ships anyway — it is the
+  right mechanism for a model that *does* follow directives.)
+- **Deterministic guardrail (Weg 2) — works.** When a step is budget-denied
+  (capability or global) *after* the agent already executed an allowed action,
+  it has spent its allowance and is repeating completed work — converged, not
+  failed → FINISHED. The goal task now passes with **no lesson**:
+  `termination=finished, verdict=pass` (control). A budget denial with no prior
+  progress stays a real DENIED.
+
+This is the conclusion made concrete: the learned path was given its strongest
+possible form and still did not lift; the deterministic rule did. On small
+greedy models, build guardrails.
+
 Dev-env note: the Mac's deps/geist pointed at a newer checkout lacking
 geist_util.h; switched to the pinned v0.2.1 via `make sync-engine`.
 

--- a/include/geistshell/actor.h
+++ b/include/geistshell/actor.h
@@ -38,6 +38,7 @@ struct spg_actor_state {
     const char *observation;
     const char *exemplars;
     const char *goal;
+    const char *directive;
 };
 
 struct spg_actor_step_config {

--- a/include/geistshell/agent_run.h
+++ b/include/geistshell/agent_run.h
@@ -54,6 +54,10 @@ struct spg_agent_run_config {
     const char *exec_working_dir;
     const char *exec_workdir_prefix;
     size_t      context_refs; /* graph/memory/journal-event context limit */
+    /* Slug of a stored lesson whose directive is rendered every step as
+     * (directive "...") — the strong steering channel (vs the mind-palace
+     * index). Null/absent or missing in the store -> no directive line. */
+    const char *directive_slug;
 };
 
 /* Caller-owned scratch. All buffers must be non-null with non-zero capacity

--- a/include/geistshell/context.h
+++ b/include/geistshell/context.h
@@ -45,6 +45,11 @@ struct spg_context_sources {
     /* Optional free-text task, rendered near the top as (goal "..."). Null =
      * none: the scenario graph is the whole task. */
     const char                        *goal;
+    /* Optional standing directive (a learned lesson) rendered prominently as
+     * (directive "...") every step — a stronger channel than the mind-palace
+     * index for steering a small model's behaviour (geistshell#40 follow-up).
+     * Null = none. */
+    const char                        *directive;
 };
 
 struct spg_context_budget_item {

--- a/include/geistshell/orchestrator.h
+++ b/include/geistshell/orchestrator.h
@@ -60,6 +60,9 @@ struct spg_orchestrator_state {
     const char *exemplars;
     /* Optional free-text task, rendered as (goal "..."). Null = none. */
     const char *goal;
+    /* Optional standing directive (a learned lesson), rendered every step as
+     * (directive "..."). Null = none. */
+    const char *directive;
 };
 
 struct spg_orchestrator_config {

--- a/src/actor/actor.c
+++ b/src/actor/actor.c
@@ -147,6 +147,7 @@ spg_actor_step(struct spg_actor_state *state,
         .observation        = state->observation,
         .exemplars            = state->exemplars,
         .goal                 = state->goal,
+        .directive            = state->directive,
     };
 
     enum spg_status status = spg_context_build(

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -1774,6 +1774,7 @@ static int agent_command(int argc, char **argv) {
     const char *script_path    = nullptr;
     const char *exemplars_path = nullptr;
     const char *memory_dir     = getenv("GEISTSHELL_MEMORY_DIR");
+    const char *directive_slug = nullptr;
     size_t      max_steps      = 8u;
     size_t      max_repairs    = 2u;
     bool        allow_exec     = false;
@@ -1827,6 +1828,12 @@ static int agent_command(int argc, char **argv) {
             /* #34: force the real model's output to begin with the
              * recommendation opening, then decode freely. */
             constrained = true;
+            continue;
+        }
+        if (strcmp(argv[i], "--directive-slug") == 0 && i + 1 < argc) {
+            /* render this stored lesson's directive every step (strong channel) */
+            directive_slug = argv[i + 1];
+            i += 1;
             continue;
         }
         fprintf(stderr, "agent: unknown or incomplete argument: %s\n", argv[i]);
@@ -2087,6 +2094,7 @@ static int agent_command(int argc, char **argv) {
          * run to the step cap; treat a converged (no-progress) run as done so
          * it terminates FINISHED and an expect verdict can pass. */
         .finish_on_no_progress = true,
+        .directive_slug        = directive_slug,
         .execution_enabled     = allow_exec,
         .exec_timeout_ms   = 5000u,
         .exec_stdout_cap   = sizeof shell_stdout,

--- a/src/context/context.c
+++ b/src/context/context.c
@@ -695,6 +695,11 @@ enum spg_status spg_context_render(const struct spg_context_sources *sources,
         .dst      = dst,
     };
     render_contract(&state);
+    if (sources->directive != nullptr && sources->directive[0] != '\0') {
+        append_cstr(&state, "(directive ");
+        append_quoted_cstr(&state, sources->directive);
+        append_cstr(&state, ")\n");
+    }
     if (sources->goal != nullptr && sources->goal[0] != '\0') {
         append_cstr(&state, "(goal ");
         append_quoted_cstr(&state, sources->goal);

--- a/src/run/agent_loop.c
+++ b/src/run/agent_loop.c
@@ -119,6 +119,7 @@ enum spg_status spg_agent_loop_run(
     uint64_t parent_sequence = config->base.parent_sequence;
     uint64_t prev_obs_hash   = 0u;    /* #40: observation after the last */
     bool     have_prev_obs   = false; /* executed step, for stall detection */
+    bool     made_progress   = false; /* an allowed action has executed */
     for (size_t step = 0u; step < config->max_steps; step += 1u) {
         if ((config->token_budget > 0u &&
              usage->consumed.tokens >= config->token_budget) ||
@@ -191,9 +192,23 @@ enum spg_status spg_agent_loop_run(
         if (spg_orchestrator_policy_evaluated(&step_result) &&
             step_result.policy_gate.decision.kind !=
                 SPG_POLICY_DECISION_ALLOW) {
+            /* #40 (Weg 2): a budget denial *after* the agent already made
+             * progress means it has spent its allowance and is repeating a
+             * completed action — converged, not failed. Terminate FINISHED so an
+             * achieved goal (e.g. the command already ran, budget 1 spent) still
+             * passes. A budget denial with no prior progress stays a real DENIED. */
+            const enum spg_policy_deny_reason dr =
+                step_result.policy_gate.decision.deny_reason;
+            if (config->finish_on_no_progress && made_progress &&
+                (dr == SPG_POLICY_DENY_CAPABILITY_BUDGET ||
+                 dr == SPG_POLICY_DENY_GLOBAL_BUDGET)) {
+                result->termination = SPG_AGENT_LOOP_FINISHED;
+                return SPG_OK;
+            }
             result->termination = SPG_AGENT_LOOP_DENIED;
             return SPG_OK;
         }
+        made_progress = true; /* reached only on an allowed, executed step */
 
         /* Convergence stop (#40): the step executed an allowed action but the
          * agent may never emit `finish`. Detect "no progress" and treat it as

--- a/src/run/agent_run.c
+++ b/src/run/agent_run.c
@@ -1,6 +1,7 @@
 #include "geistshell/agent_run.h"
 
 #include "geistshell/graph.h"
+#include "geistshell/mem_store.h" /* #40 follow-up: strong directive channel */
 #include "geistshell/memory.h"
 #include "geistshell/orchestrator.h"
 
@@ -30,6 +31,18 @@ enum spg_status spg_agent_run(const struct spg_agent_run_inputs *inputs,
     spg_memory_init(&memory);
 
     workspace->observation[0] = '\0';
+
+    /* Strong steering channel (#40 follow-up): render a designated lesson's
+     * directive as (directive "...") every step, not buried in the index. Read
+     * once; the state pointer is reused across the loop. */
+    char        directive_buf[SPG_MEM_DESC_MAX + 1u];
+    const char *directive = nullptr;
+    if (config->directive_slug != nullptr && config->directive_slug[0] != '\0' &&
+        inputs->store != nullptr &&
+        spg_mem_directive(inputs->store, config->directive_slug, 0u,
+                          sizeof directive_buf, directive_buf) > 0u) {
+        directive = directive_buf;
+    }
 
     const struct spg_orchestrator_workspace ow = {
         .actor = {.context_capacity      = workspace->context_capacity,
@@ -75,6 +88,7 @@ enum spg_status spg_agent_run(const struct spg_agent_run_inputs *inputs,
         .observation   = workspace->observation,
         .exemplars     = inputs->exemplars,
         .goal          = inputs->goal,
+        .directive     = directive,
     };
 
     const size_t refs = config->context_refs > 0u ? config->context_refs : 8u;

--- a/src/run/orchestrator.c
+++ b/src/run/orchestrator.c
@@ -200,6 +200,7 @@ enum spg_status spg_orchestrator_tick(
         .observation        = state->observation,
         .exemplars            = state->exemplars,
         .goal                 = state->goal,
+        .directive            = state->directive,
     };
     const struct spg_actor_step_config actor_config = {
         .actor_id            = config->actor_id,

--- a/test/test_agent_loop.c
+++ b/test/test_agent_loop.c
@@ -31,7 +31,8 @@ static const char policy_text[] =
     " (capability"
     "  ((name sim.act) (kind simulator) (enabled true) (budget 8))"
     "  ((name build.run) (kind local_shell) (enabled true) (budget 8))"
-    "  ((name mem.write) (kind memory) (enabled true) (budget 8))))";
+    "  ((name mem.write) (kind memory) (enabled true) (budget 8))"
+    "  ((name sim.once) (kind simulator) (enabled true) (budget 1))))";
 
 static const char scenario_text[] =
     "(scenario"
@@ -223,6 +224,32 @@ static int test_finish_terminates(void) {
     const int ok = (out.termination == SPG_AGENT_LOOP_FINISHED &&
                     out.steps_taken == 3u &&
                     strstr(fx.observation, "loop-step-ok") != nullptr)
+                       ? 0
+                       : 1;
+    teardown(&fx);
+    return ok;
+}
+
+static int test_budget_denial_after_progress_finishes(void) {
+    /* #40 (Weg 2): sim.once has budget 1. The first simulator action is allowed
+     * (progress); the second is capability-budget-denied. With
+     * finish_on_no_progress that denial-after-progress is convergence, not
+     * failure -> FINISHED at step 2. A budget denial with no prior progress
+     * would stay DENIED. */
+    static const struct spg_fake_response script[] = {
+        FR("(recommend (kind simulator) (capability \"sim.once\") (cost 1) "
+           "(uses_network false) (confidence_bp 7000) (reason \"a\"))"),
+        FR("(recommend (kind simulator) (capability \"sim.once\") (cost 1) "
+           "(uses_network false) (confidence_bp 7000) (reason \"b\"))"),
+    };
+    struct loop_fixture          fx  = {};
+    struct spg_agent_loop_result out = {};
+    if (run_script(script, 2u, 5u, false, 0u, 0u, true, &fx, &out) != 0) {
+        teardown(&fx);
+        return 1;
+    }
+    const int ok = (out.termination == SPG_AGENT_LOOP_FINISHED &&
+                    out.steps_taken == 2u)
                        ? 0
                        : 1;
     teardown(&fx);
@@ -437,6 +464,10 @@ int main(void) {
     }
     if (test_no_progress_finishes() != 0) {
         fprintf(stderr, "test_no_progress_finishes failed\n");
+        return 1;
+    }
+    if (test_budget_denial_after_progress_finishes() != 0) {
+        fprintf(stderr, "test_budget_denial_after_progress_finishes failed\n");
         return 1;
     }
     if (test_denied() != 0) {

--- a/test/test_context.c
+++ b/test/test_context.c
@@ -413,6 +413,19 @@ static int test_goal_render(void) {
     if (strstr(buf, "(goal ") != nullptr) {
         return 1;
     }
+
+    /* A standing directive renders prominently as (directive "...") every step. */
+    sources.directive = "emit finish once the goal output is produced";
+    if (spg_context_render(&sources, &view, sizeof buf, buf, &req) != SPG_OK ||
+        strstr(buf, "(directive ") == nullptr ||
+        strstr(buf, "emit finish once") == nullptr) {
+        return 1;
+    }
+    sources.directive = nullptr;
+    (void)spg_context_render(&sources, &view, sizeof buf, buf, &req);
+    if (strstr(buf, "(directive ") != nullptr) {
+        return 1;
+    }
     return 0;
 }
 


### PR DESCRIPTION
The learning-LIFT conclusion named two levers; both built and measured on the goal-directed shell task (goal "print READY", `build.run` budget 1).

## Weg 1 — stronger channel (ships, but did not lift)
A designated lesson's directive now renders prominently as `(directive "...")` at the top of context **every step** (not the weak mind-palace index). `agent --directive-slug <slug>`; read once from the store, threaded like `goal`.
**Result:** confirmed in the prompt — and greedy Gemma still won't emit `(kind finish)`. Control == learned, both `denied`/`fail`. A strong, explicit, always-present directive changes nothing on a 2B greedy model.

## Weg 2 — deterministic guardrail (works)
A budget denial (capability/global) **after** the agent already executed an allowed action = spent its allowance, repeating completed work → converged → FINISHED (not DENIED). A budget denial with no prior progress stays DENIED.
**Result (Pi, control, no lesson):** the goal task now `termination=finished, verdict=pass`. The model runs `echo READY`, repeats, hits the build.run budget, and the run finishes cleanly with READY as the final observation.

## Conclusion, concrete
The learned path was given its strongest form and still didn't lift; the deterministic rule did. On small greedy models, build guardrails.

Tests: `test_directive_render`, `test_budget_denial_after_progress_finishes` (sim.once budget 1 → step 2 denied → FINISHED); full suite green Mac (asan) + Pi.