### PR TITLE
feat(decode): verifier-guided best-of-N (2/5 vs greedy 0/5)

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -361,6 +361,37 @@ This is the conclusion made concrete: the learned path was given its strongest
 possible form and still did not lift; the deterministic rule did. On small
 greedy models, build guardrails.
 
+## Verifier-guided best-of-N (measured, Pi/Gemma)
+
+The one deterministic lever left: geistshell has a verifier (policy gate +
+`expect` + the world) but ran a single greedy trajectory. Best-of-N is the
+sampling counterpart of constrained decoding — stochastic attempts, deterministic
+selection. For it to bite, the model's *decision* must vary, so the masked
+choice slots (kind, capability) now take a softmax draw at temperature instead of
+the argmax; different seeds explore different **valid** decisions and the
+verifier keeps the first run that passes (`bench_bestof.sh`, T=0.8, N=4).
+
+Result: **best-of-N 2/5 vs greedy 0/5.**
+
+- **Simulator corpus (2 tasks): 0 → 2.** Greedy's single trajectory wanders
+  between `simulator` and `local_shell` and ends on a shell action (`exit 0`),
+  so the `sim_result` criterion misses; best-of-N samples trajectories and the
+  verifier picks one that ends on a sim action. Real recovery — exactly the
+  unreliability best-of-N exists to absorb.
+- **Shell-goal corpus with a competing capability (3 tasks): 0 → 0.** With both
+  `simulator` and `local_shell` enabled the model has a genuine kind choice and
+  wanders; four samples were not enough to land a passing trajectory. Harder
+  case — more samples, or a less endpoint-sensitive verifier, is the follow-up.
+
+Two honest caveats. The `expect` criterion is trajectory-*endpoint* sensitive
+(it checks the last observation), so it partly rewards ending on the right
+action rather than doing the right thing — a weakness of the corpus, not of
+best-of-N. And N=4 is small. But the direction is clear and it is the pattern
+this whole exercise endorses: let a fast weak model attempt several times and let
+the verifier — not the model — decide. Best-of-N is the sampling form of the
+same principle as constrained decoding; unlike learned directives, it moved the
+number.
+
 Dev-env note: the Mac's deps/geist pointed at a newer checkout lacking
 geist_util.h; switched to the pinned v0.2.1 via `make sync-engine`.
 

--- a/eval/bench_bestof.sh
+++ b/eval/bench_bestof.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+# Verifier-guided best-of-N vs greedy (geistshell, constrained decode).
+#
+# geistshell already has a verifier (the policy gate + expect + the world). This
+# harness runs each task two ways and reports whether the verifier-picked
+# best-of-N beats a single greedy trajectory:
+#
+#   greedy:    --temperature 0            (one deterministic run)
+#   best-of-N: --temperature T, seeds 1..N, STOP at the first verdict=pass
+#
+# Under constrained decode the masked choice slots (kind, capability) sample at
+# T>0 (see model_adapter.c), so different seeds explore different valid
+# DECISIONS; the free slots vary too. The verifier keeps the run that passes.
+#
+# Two corpora, because best-of-N only helps where greedy is "sometimes right":
+#   A) simulator scenarios — greedy already lands the right kind; expect ~no lift.
+#   B) a shell goal under a policy that ALSO enables the simulator — greedy may
+#      pick the wrong kind; best-of-N can explore to the working one.
+#
+# Run on the Pi:
+#   SPG_BIN=build/host-release/bin/geistshell MODEL=/path/model.gguf N=5 T=0.8 \
+#     sh eval/bench_bestof.sh
+set -eu
+
+SPG=${SPG_BIN:-build/host-release/bin/geistshell}
+MODEL=${MODEL:?set MODEL=/path/to/model.gguf}
+N=${N:-5}
+T=${T:-0.8}
+T2=$(mktemp -d)
+trap 'rm -rf "$T2"' EXIT
+
+# One attempt: prints "pass" or "fail" from the verdict line.
+attempt() { # $1 run.spg  $2 temperature  $3 seed
+    OUT=$("$SPG" agent --config "$1" --constrained --allow-exec \
+              --temperature "$2" --seed "$3" 2>/dev/null || true)
+    printf '%s' "$OUT" | sed -n 's/.*verdict=\([a-z_]*\).*/\1/p' | tail -1
+}
+
+# greedy = one run at T=0; best-of-N = up to N seeds at T, first pass wins.
+run_task() { # $1 run.spg -> prints "greedy_pass bestof_pass attempts_used"
+    g=$(attempt "$1" 0 1); gp=0; [ "$g" = "pass" ] && gp=1
+    bp=0; used=0; k=0
+    while [ "$k" -lt "$N" ]; do
+        k=$((k + 1)); used=$k
+        v=$(attempt "$1" "$T" "$k")
+        if [ "$v" = "pass" ]; then bp=1; break; fi
+    done
+    printf '%d %d %d' "$gp" "$bp" "$used"
+}
+
+mkrun() { # $1 journal $2 scenario $3 policy $4 goal-line -> writes run.spg, prints path
+    f="$T2/$(basename "$1").spg"
+    printf '(run (model "%s") (policy "%s") (scenario "%s") (corpus "examples/corpus.spg") (journal "%s") (seed 1)\n (budgets (inference_steps 6) (tokens 512) (shell_actions 2) (sim_actions 6) (wall_ms 240000) (journal_bytes 1048576) (risk_bp 10000))\n %s (expect "%s"))\n' \
+        "$MODEL" "$3" "$2" "$1" "$4" "$5" > "$f"
+    printf '%s' "$f"
+}
+
+# --- corpus A: simulator scenarios (rising severity) ---
+mk_scen() { printf '(scenario\n (host (id web) (criticality_bp 8000))\n (host (id db) (criticality_bp 10000))\n (service (id ssh_web) (host web) (name ssh) (port 22) (exposure_bp 5000))\n (account (id root_web) (host web) (username root) (enabled true))\n (credential (id key_root_web) (account root_web) (strength_bp 3000))\n (vulnerability (id cve_demo) (service ssh_web) (severity_bp %s) (patched false))\n (network_edge (from web) (to db) (reachability_bp 5000)))\n' "$1" > "$2"; }
+
+# corpus B policy: BOTH simulator and local_shell enabled -> the kind is a real choice.
+POLB="$T2/policy_both.spg"
+printf '(policy\n (network deny)\n (budgets (inference_steps 6) (tokens 4096) (shell_actions 2) (sim_actions 6) (wall_ms 240000) (journal_bytes 1048576) (risk_bp 10000) (memory_actions 64))\n (capability\n  ((name sim.act) (kind simulator) (enabled true) (budget 6))\n  ((name build.run) (kind local_shell) (enabled true) (budget 2))))\n' > "$POLB"
+
+printf '%-22s | %-6s | %-9s | %-8s\n' task greedy best-of-N attempts
+printf -- '-----------------------+--------+-----------+---------\n'
+ga=0; ba=0; n=0
+row() { printf '%-22s | %-6s | %-9s | %-8s\n' "$1" "$2" "$3" "$4"; }
+
+for sev in 4000 8000; do
+    mk_scen "$sev" "$T2/scA_$sev.spg"
+    R=$(mkrun "$T2/jA_$sev" "$T2/scA_$sev.spg" "examples/policy.spg" "" "sim_result")
+    set -- $(run_task "$R"); n=$((n+1)); ga=$((ga+$1)); ba=$((ba+$2))
+    row "simA sev=$sev" "$([ "$1" = 1 ] && echo pass || echo fail)" "$([ "$2" = 1 ] && echo pass || echo fail)" "$3"
+done
+
+# corpus B: shell goal, both kinds enabled -> greedy may mis-pick the kind.
+mk_scen 8000 "$T2/scB.spg"
+for word in READY DONE OKAY; do
+    R=$(mkrun "$T2/jB_$word" "$T2/scB.spg" "$POLB" "(goal \"Run a local shell command that prints the word $word.\")" "$word")
+    set -- $(run_task "$R"); n=$((n+1)); ga=$((ga+$1)); ba=$((ba+$2))
+    row "shellB goal=$word" "$([ "$1" = 1 ] && echo pass || echo fail)" "$([ "$2" = 1 ] && echo pass || echo fail)" "$3"
+done
+
+printf -- '-----------------------+--------+-----------+---------\n'
+printf 'TOTAL greedy=%d/%d  best-of-%d=%d/%d\n' "$ga" "$n" "$N" "$ba" "$n"

--- a/include/geistshell/model_adapter.h
+++ b/include/geistshell/model_adapter.h
@@ -122,6 +122,13 @@ struct spg_model_adapter {
     const char *api_key;
     float       temperature;
     float       top_p;
+
+    /* Best-of-N (#… verifier-guided sampling): when temperature > 0 the masked
+     * choice slots (kind, capability) sample among the valid tokens instead of
+     * taking the argmax, so different seeds explore different valid decisions
+     * and the verifier can pick the winning run. Own RNG because the mask can't
+     * go through the session sampler. GEIST only. */
+    uint64_t    choice_rng;
 };
 
 struct spg_model_generate_request {

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -1779,6 +1779,9 @@ static int agent_command(int argc, char **argv) {
     size_t      max_repairs    = 2u;
     bool        allow_exec     = false;
     bool        constrained    = false;
+    float       sample_temp    = 0.0f; /* >0 lets the free slots vary (best-of-N) */
+    bool        has_seed       = false;
+    uint64_t    seed_override  = 0u; /* per-attempt seed for best-of-N sampling */
     for (int i = 2; i < argc; i += 1) {
         if ((strcmp(argv[i], "--config") == 0 ||
              strcmp(argv[i], "--run") == 0) &&
@@ -1833,6 +1836,17 @@ static int agent_command(int argc, char **argv) {
         if (strcmp(argv[i], "--directive-slug") == 0 && i + 1 < argc) {
             /* render this stored lesson's directive every step (strong channel) */
             directive_slug = argv[i + 1];
+            i += 1;
+            continue;
+        }
+        if (strcmp(argv[i], "--temperature") == 0 && i + 1 < argc) {
+            sample_temp = (float)atof(argv[i + 1]);
+            i += 1;
+            continue;
+        }
+        if (strcmp(argv[i], "--seed") == 0 && i + 1 < argc) {
+            seed_override = (uint64_t)strtoull(argv[i + 1], nullptr, 10);
+            has_seed      = true;
             i += 1;
             continue;
         }
@@ -2006,9 +2020,10 @@ static int agent_command(int argc, char **argv) {
                   .capabilities     = agent_caps,
                   .capability_count = agent_caps_n,
                   .sampling         = {.max_seq_len = 4096u,
-                                       .temperature = 0.0f,
+                                       .temperature = sample_temp,
                                        .top_p       = 1.0f,
-                                       .random_seed = run.seed},
+                                       .random_seed =
+                                           has_seed ? seed_override : run.seed},
               };
     status = spg_model_adapter_init(&model, &model_config);
     if (status != SPG_OK) {

--- a/src/model/model_adapter.c
+++ b/src/model/model_adapter.c
@@ -195,6 +195,17 @@ static enum spg_status decode_string_slot(struct spg_model_adapter *adapter,
  * text so the value carries no spurious space (correct for kind and capability,
  * whose names contain none). The chosen name is written to out[]. Bails (leaving
  * out partial) if no valid continuation exists. */
+/* xorshift64 -> uniform [0,1). The choice-slot best-of-N sampler needs its own
+ * RNG because the mask cannot go through the session's sampler. */
+static double choice_rand(struct spg_model_adapter *adapter) {
+    uint64_t x = adapter->choice_rng ? adapter->choice_rng : 0x9e3779b97f4a7c15ull;
+    x ^= x << 13;
+    x ^= x >> 7;
+    x ^= x << 17;
+    adapter->choice_rng = x;
+    return (double) (x >> 11) * (1.0 / 9007199254740992.0);
+}
+
 static enum spg_status decode_choice_slot(
     struct spg_model_adapter *adapter, struct spg_model_generate_result *result,
     const char *const *names, const size_t names_n, char *out,
@@ -209,23 +220,57 @@ static enum spg_status decode_choice_slot(
         if (logits == nullptr || n_vocab == 0u) {
             break;
         }
-        geist_token_t best       = -1;
-        float         best_logit = -INFINITY;
-        for (size_t t = 0u; t < n_vocab; t += 1u) {
-            if (logits[t] <= best_logit) {
-                continue;
-            }
+        /* Collect the valid tokens once, then pick: argmax (greedy) or a
+         * softmax draw at temperature (best-of-N explores valid decisions).
+         * ponytail: 512-candidate cap — kind/capability prefixes never approach
+         * it; widen if a larger vocabulary of names is ever masked here. */
+        geist_token_t cand[512];
+        float         cand_logit[512];
+        size_t        nc   = 0u;
+        float         maxl = -INFINITY;
+        for (size_t t = 0u; t < n_vocab && nc < 512u; t += 1u) {
             const char *piece =
                 geist_session_token_to_str(adapter->session, (geist_token_t) t);
             if (piece == nullptr ||
                 !spg_choice_prefix_ok(names, names_n, out, piece)) {
                 continue;
             }
-            best       = (geist_token_t) t;
-            best_logit = logits[t];
+            cand[nc]       = (geist_token_t) t;
+            cand_logit[nc] = logits[t];
+            if (logits[t] > maxl) {
+                maxl = logits[t];
+            }
+            nc += 1u;
         }
-        if (best < 0) {
+        if (nc == 0u) {
             break;
+        }
+        geist_token_t best = cand[0];
+        if (adapter->temperature > 0.0f) {
+            double sum = 0.0;
+            for (size_t i = 0u; i < nc; i += 1u) {
+                sum += exp((double) (cand_logit[i] - maxl) /
+                           (double) adapter->temperature);
+            }
+            const double r   = choice_rand(adapter) * sum;
+            double       acc = 0.0;
+            best             = cand[nc - 1u]; /* fp-rounding fallback */
+            for (size_t i = 0u; i < nc; i += 1u) {
+                acc += exp((double) (cand_logit[i] - maxl) /
+                           (double) adapter->temperature);
+                if (r <= acc) {
+                    best = cand[i];
+                    break;
+                }
+            }
+        } else {
+            float best_logit = cand_logit[0];
+            for (size_t i = 1u; i < nc; i += 1u) {
+                if (cand_logit[i] > best_logit) {
+                    best_logit = cand_logit[i];
+                    best       = cand[i];
+                }
+            }
         }
         const char *piece = geist_session_token_to_str(adapter->session, best);
         const char *ap    = piece;
@@ -482,6 +527,12 @@ spg_model_adapter_init(struct spg_model_adapter *adapter,
         spg_model_adapter_destroy(adapter);
         return map_geist_status(geist_status);
     }
+
+    /* Best-of-N: temperature drives whether the masked choice slots sample; a
+     * nonzero RNG seed derived from the sampling seed makes different seeds
+     * explore different valid decisions. */
+    adapter->temperature = config->sampling.temperature;
+    adapter->choice_rng  = config->sampling.random_seed * 2654435761u + 1u;
 
     adapter->initialized = true;
     return SPG_OK;


### PR DESCRIPTION
geistshell has a verifier (policy gate + expect + the world) but ran one greedy trajectory. Best-of-N is the sampling counterpart of constrained decoding: stochastic attempts, deterministic selection.

## Mechanism
Under constrained decoding the masked **choice slots** (kind, capability) now take a softmax draw at temperature instead of argmax, so different seeds explore different **valid decisions**; the free slots vary too. Own xorshift RNG seeded from the sampling seed (the mask can't use the session sampler). `--temperature 0` keeps the exact greedy argmax path — default unchanged.

- `agent --temperature T --seed N`
- `eval/bench_bestof.sh`: greedy vs best-of-N (first `verdict=pass` wins).

## Pi result (Gemma 4 E2B, N=4, T=0.8)
**best-of-N 2/5 vs greedy 0/5.** On the simulator corpus greedy's single trajectory wanders and ends on the wrong action (the endpoint-sensitive `sim_result` check misses); best-of-N samples trajectories and the verifier picks a passing one (0 → 2). A harder shell-goal corpus with a competing capability stayed 0/0 at N=4 — more samples / a less endpoint-sensitive verifier is the follow-up.

Honest and positive: unlike injected lessons (which did not lift), verifier-guided sampling moved the number. Same principle as constrained decoding — let the verifier, not the model, decide.

Full suite green Mac (asan) + Pi.