### PR TITLE
fix(eval): correct best-of-N measurement (5/5 vs 2/5, reproducible)

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -371,26 +371,50 @@ choice slots (kind, capability) now take a softmax draw at temperature instead o
 the argmax; different seeds explore different **valid** decisions and the
 verifier keeps the first run that passes (`bench_bestof.sh`, T=0.8, N=4).
 
-Result: **best-of-N 2/5 vs greedy 0/5.**
+**First measurement was contaminated — corrected below.** The initial run
+reported best-of-N 2/5 vs greedy 0/5, but two confounds invalidated it:
+1. **A harness bug.** The competing-capability policy for the shell corpus used
+   `(network deny)` (not `network_default`) and a wrong `budgets` order →
+   `SPG_E_SCHEMA`, so every shell run instant-failed at policy load in ~4 ms.
+   The "shell 0/N" was a broken policy, not a model result.
+2. **A non-quiesced box.** The Pi ran the always-on `geist --serve` home daemon
+   the whole time (the [quiesce-the-box] lesson, ignored). Greedy's outcome on
+   the borderline tasks turned out to depend on the OMP thread count — with the
+   daemon holding a core, geistshell got a different thread count, a different
+   fp reduction order, a different argmax, a different trajectory. Greedy flipped
+   pass↔fail across sessions on identical config.
 
-- **Simulator corpus (2 tasks): 0 → 2.** Greedy's single trajectory wanders
-  between `simulator` and `local_shell` and ends on a shell action (`exit 0`),
-  so the `sim_result` criterion misses; best-of-N samples trajectories and the
-  verifier picks one that ends on a sim action. Real recovery — exactly the
-  unreliability best-of-N exists to absorb.
-- **Shell-goal corpus with a competing capability (3 tasks): 0 → 0.** With both
-  `simulator` and `local_shell` enabled the model has a genuine kind choice and
-  wanders; four samples were not enough to land a passing trajectory. Harder
-  case — more samples, or a less endpoint-sensitive verifier, is the follow-up.
+Fixed both: `examples/policy.spg` already enables both kinds (it *is* the
+competing-capability policy), and the home daemon was stopped and disabled.
+Re-run three times on the quiesced box (`bench_bestof.sh`, N=6, T=0.9):
 
-Two honest caveats. The `expect` criterion is trajectory-*endpoint* sensitive
-(it checks the last observation), so it partly rewards ending on the right
-action rather than doing the right thing — a weakness of the corpus, not of
-best-of-N. And N=4 is small. But the direction is clear and it is the pattern
-this whole exercise endorses: let a fast weak model attempt several times and let
-the verifier — not the model — decide. Best-of-N is the sampling form of the
-same principle as constrained decoding; unlike learned directives, it moved the
-number.
+| | greedy | best-of-6 |
+|---|---|---|
+| simA sev=4000 | fail | pass (attempt 2) |
+| simA sev=8000 | fail | pass (attempt 1) |
+| shellB READY | pass | pass |
+| shellB DONE | pass | pass |
+| shellB OKAY | fail | pass (attempt 2) |
+| **total** | **2/5** | **5/5** |
+
+**Reproducible — three runs byte-identical.** Best-of-N recovers all three greedy
+failures within 1–2 attempts. This is the clean, positive result; the earlier
+number was noise.
+
+Two properties worth stating. (a) The engine's greedy decode is **not
+deterministic across thread counts** — argmax depends on the fp reduction order,
+which depends on how many OMP threads run. It is deterministic within a fixed
+quiesced box (hence the 3× identical runs), which is now the canonical
+measurement state. (b) The `expect` criterion is trajectory-*endpoint* sensitive
+(checks the last observation), so the two simulator failures are partly greedy
+ending on the wrong action, not doing the wrong thing — a corpus weakness, not a
+best-of-N one. The shell `OKAY` failure is a genuine task miss that best-of-N
+recovers.
+
+The direction is clear and reproducible: let a fast weak model attempt several
+times and let the verifier — not the model — decide. Best-of-N is the sampling
+form of the same principle as constrained decoding; unlike learned directives,
+it moved the number, and this time the number holds up.
 
 Dev-env note: the Mac's deps/geist pointed at a newer checkout lacking
 geist_util.h; switched to the pinned v0.2.1 via `make sync-engine`.

--- a/eval/bench_bestof.sh
+++ b/eval/bench_bestof.sh
@@ -58,9 +58,10 @@ mkrun() { # $1 journal $2 scenario $3 policy $4 goal-line -> writes run.spg, pri
 # --- corpus A: simulator scenarios (rising severity) ---
 mk_scen() { printf '(scenario\n (host (id web) (criticality_bp 8000))\n (host (id db) (criticality_bp 10000))\n (service (id ssh_web) (host web) (name ssh) (port 22) (exposure_bp 5000))\n (account (id root_web) (host web) (username root) (enabled true))\n (credential (id key_root_web) (account root_web) (strength_bp 3000))\n (vulnerability (id cve_demo) (service ssh_web) (severity_bp %s) (patched false))\n (network_edge (from web) (to db) (reachability_bp 5000)))\n' "$1" > "$2"; }
 
-# corpus B policy: BOTH simulator and local_shell enabled -> the kind is a real choice.
-POLB="$T2/policy_both.spg"
-printf '(policy\n (network deny)\n (budgets (inference_steps 6) (tokens 4096) (shell_actions 2) (sim_actions 6) (wall_ms 240000) (journal_bytes 1048576) (risk_bp 10000) (memory_actions 64))\n (capability\n  ((name sim.act) (kind simulator) (enabled true) (budget 6))\n  ((name build.run) (kind local_shell) (enabled true) (budget 2))))\n' > "$POLB"
+# corpus B: examples/policy.spg already enables BOTH simulator and local_shell,
+# so it is the competing-capability policy (an earlier custom one had a schema
+# error and instant-failed every run -> a false 0/N).
+POLB=examples/policy.spg
 
 printf '%-22s | %-6s | %-9s | %-8s\n' task greedy best-of-N attempts
 printf -- '-----------------------+--------+-----------+---------\n'

--- a/eval/bench_sticky.sh
+++ b/eval/bench_sticky.sh
@@ -25,14 +25,15 @@ D=$(mktemp -d); trap 'rm -rf "$D"' EXIT
 
 mk_scen() { printf '(scenario\n (host (id web) (criticality_bp 8000))\n (host (id db) (criticality_bp 10000))\n (service (id ssh_web) (host web) (name ssh) (port 22) (exposure_bp 5000))\n (account (id root_web) (host web) (username root) (enabled true))\n (credential (id key_root_web) (account root_web) (strength_bp 3000))\n (vulnerability (id cve_demo) (service ssh_web) (severity_bp 8000) (patched false))\n (network_edge (from web) (to db) (reachability_bp 5000)))\n' > "$1"; }
 mk_scen "$D/sc.spg"
-# both simulator and local_shell enabled -> the kind is a real choice
-printf '(policy\n (network deny)\n (budgets (inference_steps 6) (tokens 4096) (shell_actions 2) (sim_actions 6) (wall_ms 240000) (journal_bytes 1048576) (risk_bp 10000) (memory_actions 64))\n (capability\n  ((name sim.act) (kind simulator) (enabled true) (budget 6))\n  ((name build.run) (kind local_shell) (enabled true) (budget 2))))\n' > "$D/pol.spg"
+# examples/policy.spg already enables BOTH simulator (sim.act) and local_shell
+# (build.run) -> the kind is a real choice, no custom (broken) policy needed.
+POL=examples/policy.spg
 
 # one attempt: prints "<endpoint> <sticky>" as 0/1, where sticky = word in journal
 attempt() { # $1 goalword $2 temp $3 seed
     J="$D/j.sgj"
     printf '(run (model "%s") (policy "%s") (scenario "%s") (corpus "examples/corpus.spg") (journal "%s") (seed 1)\n (budgets (inference_steps 6) (tokens 512) (shell_actions 2) (sim_actions 6) (wall_ms 240000) (journal_bytes 1048576) (risk_bp 10000))\n (goal "Run a local shell command that prints the word %s.") (expect "%s"))\n' \
-        "$MODEL" "$D/pol.spg" "$D/sc.spg" "$J" "$1" "$1" > "$D/run.spg"
+        "$MODEL" "$POL" "$D/sc.spg" "$J" "$1" "$1" > "$D/run.spg"
     V=$("$SPG" agent --config "$D/run.spg" --constrained --allow-exec \
             --temperature "$2" --seed "$3" 2>/dev/null | sed -n 's/.*verdict=\([a-z_]*\).*/\1/p' | tail -1 || true)
     ep=0; [ "$V" = "pass" ] && ep=1

--- a/eval/bench_sticky.sh
+++ b/eval/bench_sticky.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# Does the endpoint-sensitive verifier cause the shell corpus 0/N, or the model?
+#
+# bench_bestof.sh judged pass = the FINAL observation contains the expect word.
+# The shell-goal corpus stayed 0/N even at N=8. This harness re-judges the same
+# runs with a STICKY criterion: pass = the word appears in ANY observation in the
+# journal (the model produced it at some step), not only the last. It prints both
+# so the gap is visible:
+#
+#   endpoint: verdict=pass from the CLI (last observation contains the word)
+#   sticky:   the word appears anywhere in the run's journal
+#
+# If sticky passes where endpoint fails -> the criterion was the culprit, and a
+# less endpoint-sensitive verifier is the fix (not more samples). If sticky also
+# fails -> the model never does the shell action; the competing capability is.
+#
+#   SPG_BIN=... MODEL=... N=8 T=0.9 sh eval/bench_sticky.sh
+set -eu
+
+SPG=${SPG_BIN:-build/host-release/bin/geistshell}
+MODEL=${MODEL:?set MODEL=/path/to/model.gguf}
+N=${N:-8}
+T=${T:-0.9}
+D=$(mktemp -d); trap 'rm -rf "$D"' EXIT
+
+mk_scen() { printf '(scenario\n (host (id web) (criticality_bp 8000))\n (host (id db) (criticality_bp 10000))\n (service (id ssh_web) (host web) (name ssh) (port 22) (exposure_bp 5000))\n (account (id root_web) (host web) (username root) (enabled true))\n (credential (id key_root_web) (account root_web) (strength_bp 3000))\n (vulnerability (id cve_demo) (service ssh_web) (severity_bp 8000) (patched false))\n (network_edge (from web) (to db) (reachability_bp 5000)))\n' > "$1"; }
+mk_scen "$D/sc.spg"
+# both simulator and local_shell enabled -> the kind is a real choice
+printf '(policy\n (network deny)\n (budgets (inference_steps 6) (tokens 4096) (shell_actions 2) (sim_actions 6) (wall_ms 240000) (journal_bytes 1048576) (risk_bp 10000) (memory_actions 64))\n (capability\n  ((name sim.act) (kind simulator) (enabled true) (budget 6))\n  ((name build.run) (kind local_shell) (enabled true) (budget 2))))\n' > "$D/pol.spg"
+
+# one attempt: prints "<endpoint> <sticky>" as 0/1, where sticky = word in journal
+attempt() { # $1 goalword $2 temp $3 seed
+    J="$D/j.sgj"
+    printf '(run (model "%s") (policy "%s") (scenario "%s") (corpus "examples/corpus.spg") (journal "%s") (seed 1)\n (budgets (inference_steps 6) (tokens 512) (shell_actions 2) (sim_actions 6) (wall_ms 240000) (journal_bytes 1048576) (risk_bp 10000))\n (goal "Run a local shell command that prints the word %s.") (expect "%s"))\n' \
+        "$MODEL" "$D/pol.spg" "$D/sc.spg" "$J" "$1" "$1" > "$D/run.spg"
+    V=$("$SPG" agent --config "$D/run.spg" --constrained --allow-exec \
+            --temperature "$2" --seed "$3" 2>/dev/null | sed -n 's/.*verdict=\([a-z_]*\).*/\1/p' | tail -1 || true)
+    ep=0; [ "$V" = "pass" ] && ep=1
+    st=0; strings "$J" 2>/dev/null | grep -q "$1" && st=1
+    printf '%d %d' "$ep" "$st"
+}
+
+printf '%-14s | %-16s | %-18s | %-8s\n' goal "greedy ep/sticky" "best-of-N ep/sticky" attempts
+printf -- '---------------+------------------+--------------------+---------\n'
+gep=0; gst=0; bep=0; bst=0; n=0
+for w in READY DONE OKAY; do
+    n=$((n+1))
+    set -- $(attempt "$w" 0 1); GEP=$1; GST=$2
+    # best-of-N: stop at the first STICKY pass (word produced anywhere)
+    BEP=0; BST=0; used=0; k=0
+    while [ "$k" -lt "$N" ]; do
+        k=$((k+1)); used=$k
+        set -- $(attempt "$w" "$T" "$k")
+        [ "$1" = 1 ] && BEP=1
+        if [ "$2" = 1 ]; then BST=1; break; fi
+    done
+    gep=$((gep+GEP)); gst=$((gst+GST)); bep=$((bep+BEP)); bst=$((bst+BST))
+    printf '%-14s | %-16s | %-18s | %-8d\n' "$w" "$GEP/$GST" "$BEP/$BST" "$used"
+done
+printf -- '---------------+------------------+--------------------+---------\n'
+printf 'TOTAL  greedy ep=%d/%d sticky=%d/%d   best-of-%d ep=%d/%d sticky=%d/%d\n' \
+    "$gep" "$n" "$gst" "$n" "$N" "$bep" "$n" "$bst" "$n"


### PR DESCRIPTION
Two harness fixes + the corrected, clean best-of-N result.

## The confounds (why the first 2/5 vs 0/5 was wrong)
1. **Policy schema bug** — the competing-capability policy used `(network deny)` + wrong `budgets` order → `SPG_E_SCHEMA`; every shell run instant-failed at load (~4 ms). The 'shell 0/N' was a broken policy. Fixed: use `examples/policy.spg` (already enables both kinds).
2. **Non-quiesced box** — the always-on `geist --serve` home daemon held a core; greedy's argmax depends on the OMP thread count (fp reduction order), so greedy flipped pass↔fail across sessions. Fixed: daemon stopped + disabled.

## Clean result (quiesced box, N=6, 3× identical)
| | greedy | best-of-6 |
|---|---|---|
| **total (5 tasks)** | **2/5** | **5/5** |

Best-of-N recovers every greedy miss in 1–2 attempts, reproducibly.

Properties recorded honestly in docs/LEARNING.md: greedy decode is deterministic only at a fixed thread count; the `expect` check is endpoint-sensitive (two sim misses are greedy ending on the wrong action). Adds `bench_sticky.sh`; fixes `bench_bestof.sh`.