### PR TITLE
feat(decode): allow parens in constrained string values (#1)

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -448,6 +448,25 @@ it moved the number, and this time the number holds up.
 Dev-env note: the Mac's deps/geist pointed at a newer checkout lacking
 geist_util.h; switched to the pinned v0.2.1 via `make sync-engine`.
 
+## Extending constrained decoding (#1): parens in string values; full acceptor deferred
+
+The per-kind scaffold already takes valid emission from 0 to 100% on the
+recommendation DSL, so a general **token-level grammar acceptor** — masking every
+token against a live parser state — is deferred as YAGNI: its only benefit is
+generality for a *second* grammar (the natural place is the geistagent
+tool-calling path, if/when the two runtimes unify), and it is a large,
+subword-boundary-hard rewrite for no gain on the DSL we have.
+
+The concrete extension that *does* add capability: `decode_string_slot` used to
+stop a string value at `"`, newline, **or a paren**. But inside an s-expr string
+parens are literal (sexpr.c only forbids raw `"`, newline, and stray
+backslash-escapes), so stopping at parens needlessly banned real commands —
+`awk '{print}'`, `grep (x)`. Relaxed the stop set to `"`/newline only; the whole
+string-slot family (command, target, reason, slug, description, body) now admits
+parens. `test_valid_command_with_parens` confirms such a form parses VALID, so
+the relaxation cannot emit an unparseable value. Raw `"` inside a value still
+ends the slot (the model would need `\"`); auto-escaping is a further step.
+
 ## Real-model completion: exemplars are necessary but not sufficient (2026-08-02)
 
 Path B added an `(examples ...)` context slot so a small model gets concrete

--- a/src/model/model_adapter.c
+++ b/src/model/model_adapter.c
@@ -161,9 +161,12 @@ static enum spg_status emit_literal(struct spg_model_adapter *adapter,
 }
 
 /* Free-decode one scaffold string value (#34): the model fills the slot, but we
- * stop at the first character that would close or corrupt the string — the
- * closing quote, a newline, or a paren — so the surrounding scaffold literal
- * supplies the delimiter. Bounded so a runaway slot cannot eat the budget. */
+ * stop at the first character that would close or corrupt the STRING — the
+ * closing quote or a newline (a newline is a hard error inside an s-expr string;
+ * see sexpr.c). Parens are NOT stops: inside a quoted string they are literal,
+ * so the model may emit commands like `awk '{print}'` or `grep (x)`. The
+ * surrounding scaffold literal supplies the closing quote. Bounded so a runaway
+ * slot cannot eat the budget. */
 static enum spg_status decode_string_slot(struct spg_model_adapter *adapter,
                                           struct spg_model_generate_result *result) {
     for (size_t j = 0u; j < 64u; j += 1u) {
@@ -177,7 +180,7 @@ static enum spg_status decode_string_slot(struct spg_model_adapter *adapter,
         if (piece == nullptr || piece[0] == '\0') {
             return SPG_OK; /* eos ends the slot */
         }
-        const size_t stop = strcspn(piece, "\"\n\r()");
+        const size_t stop = strcspn(piece, "\"\n\r");
         if (piece[stop] != '\0') {
             return append_bytes(result, stop, piece); /* delimiter reached */
         }

--- a/test/test_recommendation.c
+++ b/test/test_recommendation.c
@@ -53,6 +53,25 @@ static int test_valid_local_shell(void) {
     return 0;
 }
 
+/* A command value with parens parses (parens are literal inside an s-expr
+ * string) — this is why the constrained decoder may leave them unstopped. */
+static int test_valid_command_with_parens(void) {
+    const char text[] =
+        "(recommend (kind local_shell) (capability \"local\") (cost 1) "
+        "(uses_network false) (confidence_bp 5000) "
+        "(reason \"filter\") (command \"awk '{print (1+2)}' (file)\"))";
+    struct spg_recommendation       rec = {};
+    struct spg_recommendation_error err = {};
+    if (parse_text(text, &rec, &err) != SPG_OK) {
+        return 1;
+    }
+    return (rec.state == SPG_RECOMMENDATION_VALID &&
+            rec.action_kind == SPG_ACTION_LOCAL_SHELL && rec.has_command &&
+            rec.command.length == strlen("awk '{print (1+2)}' (file)"))
+               ? 0
+               : 1;
+}
+
 static int test_valid_ssh_probe(void) {
     const char text[] =
         "(recommend (kind ssh_auth_probe) (capability \"ssh\") (cost 1) "
@@ -250,6 +269,10 @@ int main(void) {
     }
     if (test_valid_local_shell() != 0) {
         fprintf(stderr, "test_valid_local_shell failed\n");
+        return 1;
+    }
+    if (test_valid_command_with_parens() != 0) {
+        fprintf(stderr, "test_valid_command_with_parens failed\n");
         return 1;
     }
     if (test_valid_ssh_probe() != 0) {


### PR DESCRIPTION
First increment of 'extend constrained decoding' (#1).

`decode_string_slot` stopped a string value at `"`, newline, **or a paren** — but inside an s-expr string parens are literal (sexpr.c forbids only raw quote, newline, bad escape). So it needlessly banned real commands: `awk '{print}'`, `grep (x)`. Relaxed to quote+newline; all string slots (command/target/reason/slug/description/body) now admit parens. `test_valid_command_with_parens` confirms such a form parses VALID.

**Scope:** the full token-level grammar acceptor is deferred as YAGNI — the per-kind scaffold already yields 0→100% valid on this DSL; a general acceptor only pays off for a second grammar (the geistagent tool-calling path). Recorded in docs/LEARNING.md.

Full suite green.