### PR TITLE
Phase 1: Read-only System-Telemetrie als typed Snapshot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,8 @@ SPG_SOURCES := \
     src/memory/mem_executor.c \
     src/memory/mem_store.c \
     src/memory/memory.c \
+    src/machine/telemetry.c \
+    src/machine/telemetry_host.c \
     src/model/grammar_mask.c \
     src/model/model_adapter.c \
     src/model/model_remote_codec.c \

--- a/docs/machine-intelligence/Telemetry.md
+++ b/docs/machine-intelligence/Telemetry.md
@@ -1,0 +1,114 @@
+# Telemetry — Phase 1
+
+Read-only Systemtelemetrie als typed Snapshot. Der Agent kann die Maschine
+**beobachten**, aber nichts verändern — kein Action Kind, keine Verdrahtung in
+den Context (das ist Phase 3, geisten/geistshell#63).
+
+Ticket: geisten/geistshell#61. Baseline: [Baseline.md](Baseline.md).
+
+## Drei Schichten
+
+| Schicht | Datei | Eigenschaft |
+|---------|-------|-------------|
+| 1 — OS lesen | `src/machine/telemetry_host.c` | einzige Stelle mit I/O, Linux-spezifisch |
+| 2 — Normalisieren | `src/machine/telemetry.c` | reine Funktionen über Puffer, kein I/O, keine Uhr |
+| 3 — Serialisieren | `src/machine/telemetry.c` | deterministische S-Expression |
+
+Die Trennung ist der Grund, warum die Tests auf jedem Host laufen: sie füttern
+die Parser mit statischen Fixtures und fassen `/proc` nie an. Kein Testergebnis
+hängt von CPU-Last, Temperatur oder Plattform der CI-Maschine ab.
+
+## Schema
+
+```
+(machine-state (cpu-load-bp 9200) (load-1-cbp 175) (memory-total-bytes 1024)
+ (memory-used-bytes 512) (swap-used-bytes 0) (temperature-mc 78400)
+ (cpu-freq-khz 1500000) (throttle none) (process-count 137))
+```
+
+| Feld | Einheit | Quelle | Fehlt wenn |
+|------|---------|--------|------------|
+| `cpu-load-bp` | Basispunkte 0..10000 | `/proc/stat`, Delta zweier Samples | erster Tick, Δ=0, Counter-Reset |
+| `load-1-cbp` | Load × 100 | `/proc/loadavg` | Datei fehlt/malformed |
+| `memory-total-bytes` | Bytes | `/proc/meminfo` `MemTotal` | Datei fehlt |
+| `memory-used-bytes` | Bytes | `MemTotal − MemAvailable` | `MemAvailable` fehlt |
+| `swap-used-bytes` | Bytes | `SwapTotal − SwapFree` | eines der beiden fehlt |
+| `temperature-mc` | Milligrad Celsius | `/sys/class/thermal/thermal_zone0/temp` | kein Thermal-Zone-Sensor |
+| `cpu-freq-khz` | kHz | `.../cpu0/cpufreq/scaling_cur_freq` | kein cpufreq-Treiber |
+| `throttle` | `none`/`active`/`past`/`unknown` | `.../soc:firmware/get_throttled` | kein Pi-Firmware-Interface |
+| `process-count` | Anzahl | numerische Einträge in `/proc` | `/proc` nicht lesbar |
+
+Alle Werte sind **Ganzzahlen im Fixpunkt**. Keine Floats: deren Formatierung
+hängt von der Locale ab und deren Rundung vom Modus — beides würde
+byte-identische Ausgabe zerstören.
+
+`MemAvailable`, nicht `MemFree`: nur ersteres sagt, was ein Workload
+tatsächlich bekommen kann.
+
+## Unbekannt ist ein Wert, keine Null
+
+Fehlende Werte werden als Symbol `unknown` serialisiert und intern als
+Sentinel (`SPG_MACHINE_UNKNOWN` = `UINT64_MAX`, `SPG_MACHINE_UNKNOWN_S` =
+`INT64_MIN`) geführt.
+
+Das ist keine Kosmetik. Ein fehlender Load Average, der als `0` durchgereicht
+wird, liest sich für ein Modell wie eine vollkommen idle Maschine — und genau
+diesen Fehler hat der Test `render_unknown` während der Entwicklung gefunden:
+Der Snapshot initialisierte den Load nicht auf `unknown`, ein fehlgeschlagener
+`/proc/loadavg`-Parse hätte „Last 0.00" gemeldet.
+
+Der Sentinel-Ansatz hat eine dokumentierte Grenze: ein echter Wert von exakt
+`UINT64_MAX` wäre nicht unterscheidbar. Für Bytes, kHz und Prozentwerte ist das
+physikalisch ausgeschlossen.
+
+## Keine Uhr im Modul
+
+`spg_machine_sample()` bekommt `timestamp_ns` vom Aufrufer und liest **nie**
+`clock_gettime`. Grund steht in [Baseline.md](Baseline.md#2-determinismus-inventar):
+Das Journal hasht seinen Zeitstempel in die Record-Chain, die CLI reicht einen
+synthetischen Tick-Zähler ein, und der einzige Clock-Read der Runtime
+(`cmd_executor.c:50`) verlässt sein Modul nicht. Eine zweite Zeitquelle würde
+den Freeze aus Phase 0 brechen, sobald ein Telemetriewert in Context oder
+Journal landet.
+
+Deshalb ist auch die CPU-Auslastung nicht im Sampler versteckt: sie ist das
+Delta zweier Samples, und der Aufrufer hält das vorherige. `spg_machine_state`
+trägt die rohen Counter mit, damit der nächste Aufruf sie direkt einspeisen
+kann, ohne `/proc/stat` zweimal zu lesen.
+
+## Plattformverhalten
+
+- **Linux:** `spg_machine_sample()` liefert `SPG_OK`. Einzelne fehlende Dateien
+  sind kein Fehler — das jeweilige Feld bleibt `unknown`.
+- **Alles andere** (macOS-Entwicklungsmaschine, BSD): `SPG_E_UNSUPPORTED`, alle
+  Felder `unknown`, `timestamp_ns` gesetzt. Der Aufrufer kann weiterlaufen; ein
+  Agent-Run darf daran nicht scheitern.
+
+Kein `vcgencmd`. Das Throttling-Bit kommt aus dem sysfs-Firmware-Interface, und
+wenn es fehlt, ist der Zustand `unknown` — keine Abhängigkeit von einem
+Raspberry-Pi-Userland-Tool.
+
+## Robustheit der Parser
+
+Jeder Parser nimmt die Länge **vor** dem Puffer und liest höchstens `n` Bytes.
+Keiner verlangt NUL-Terminierung; ein Test übergibt einen exakt passenden
+Puffer, damit ASan jeden Überlauf fängt.
+
+Der Parameter ist `buf[]`, nicht `buf[static n]`: eine leere Datei ist ein
+legitimer Eingabefall, und `[static 0]` ist undefiniertes Verhalten. UBSan hat
+das während der Entwicklung angezeigt — dieselbe Begründung wie beim leeren
+Batch in `cmd_executor.h:88`.
+
+Getestete Grenzfälle: fehlende Datei, leere Datei, Buchstaben im Zahlenfeld,
+zu wenige Spalten in `/proc/stat`, 30-stellige Zahl (Overflow), Puffer ohne
+NUL, `MemAvailable > MemTotal` (Clamp statt Wrap), Δt = 0, rückwärts laufende
+Counter, Load ohne Dezimalpunkt, mehr als zwei Nachkommastellen (Trunkierung,
+keine Rundung), Nicht-Hex im Throttle-Feld, Renderpuffer exakt ein Byte zu
+klein.
+
+## Was Phase 1 nicht tut
+
+Keine Prozessliste (#62), keine Context-Integration (#63), kein History-Fenster
+(#79), keine Action. Der Sampler wird von keinem Agent-Pfad aufgerufen — der
+Journal-Freeze aus Phase 0 bleibt unverändert grün, und genau das belegt, dass
+diese Phase die Runtime nicht angefasst hat.

--- a/include/geistshell/machine_state.h
+++ b/include/geistshell/machine_state.h
@@ -1,0 +1,148 @@
+#ifndef GEISTSHELL_MACHINE_STATE_H
+#define GEISTSHELL_MACHINE_STATE_H
+
+#include "geistshell/status.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Read-only machine telemetry (roadmap phase 1). Three layers, kept apart on
+ * purpose:
+ *   1. OS reading      — spg_machine_sample(), platform-specific, does I/O
+ *   2. normalisation   — the parsers below, pure functions over buffers
+ *   3. serialisation   — spg_machine_state_render(), deterministic s-expression
+ *
+ * The module never reads a clock. Like the journal (spg_journal_writer_append),
+ * it takes timestamp_ns from the caller, so replay stays byte-identical and
+ * tests need no time mocking. See docs/machine-intelligence/Baseline.md.
+ *
+ * All values are integers in fixed-point units — never floats, whose formatting
+ * depends on the locale and whose rounding would break byte-identical output.
+ * Unit suffixes: _bp = basis points (1/10000), _cbp = centi (1/100),
+ * _mc = millidegrees Celsius, _khz, _bytes.
+ */
+
+/* Optional values are explicit, never 0. A field that could not be read holds
+ * the sentinel; every consumer must test for it before using the value. */
+#define SPG_MACHINE_UNKNOWN UINT64_MAX
+#define SPG_MACHINE_UNKNOWN_S INT64_MIN
+
+/* Raw CPU time counters from /proc/stat. Meaningless alone: utilisation is the
+ * delta between two samples, which is why the caller keeps the previous one. */
+struct spg_cpu_sample {
+    uint64_t idle;  /* idle + iowait */
+    uint64_t total; /* all fields summed, including idle */
+};
+
+struct spg_memory_sample {
+    uint64_t total_bytes;
+    uint64_t used_bytes; /* total - available; available, not free */
+    uint64_t swap_used_bytes;
+};
+
+struct spg_load_sample {
+    uint64_t avg_1_cbp; /* load average x100, so 1.75 -> 175 */
+    uint64_t avg_5_cbp;
+    uint64_t avg_15_cbp;
+};
+
+/* Raspberry Pi exposes a throttling bitmask; most hosts expose nothing. */
+enum spg_throttle_state {
+    SPG_THROTTLE_UNKNOWN = 0,
+    SPG_THROTTLE_NONE,
+    SPG_THROTTLE_ACTIVE, /* currently throttled or under-voltage */
+    SPG_THROTTLE_PAST,   /* not now, but it happened since boot */
+};
+
+/* One normalised snapshot. Fixed size, no pointers, no allocation: it can be
+ * copied into a ring buffer (phase 3b) without ownership questions. */
+struct spg_machine_state {
+    uint64_t timestamp_ns; /* injected by the caller, never read from a clock */
+
+    uint64_t cpu_utilisation_bp; /* 0..10000, UNKNOWN on the first sample */
+    struct spg_load_sample   load;
+    struct spg_memory_sample memory;
+    int64_t                  temperature_mc; /* UNKNOWN_S when unavailable */
+    uint64_t                 cpu_freq_khz;
+    enum spg_throttle_state  throttle;
+    uint64_t                 process_count;
+
+    struct spg_cpu_sample cpu; /* raw counters, so the caller can feed the
+                                * next call without re-reading /proc/stat */
+};
+
+/* --- layer 2: parsers, pure, no I/O ------------------------------------- */
+/* Each takes the buffer length before the buffer and reads at most n bytes;
+ * none requires NUL termination. Malformed input yields SPG_E_FORMAT and
+ * leaves *out unknown/zeroed; counter overflow yields SPG_E_OVERFLOW.
+ *
+ * The parameter is `buf[]`, not `buf[static n]`: an empty file is a legitimate
+ * input here (a sysfs file can exist and read back zero bytes), and `[static
+ * 0]` is undefined behaviour. Same reasoning as spg_cmd_executor_run's empty
+ * batch, see cmd_executor.h. */
+
+/* First "cpu " line of /proc/stat. */
+[[nodiscard]] enum spg_status
+spg_telemetry_parse_stat(size_t n, const char buf[],
+                         struct spg_cpu_sample *out);
+
+/* MemTotal/MemAvailable/SwapTotal/SwapFree of /proc/meminfo (kB units). */
+[[nodiscard]] enum spg_status
+spg_telemetry_parse_meminfo(size_t n, const char buf[],
+                            struct spg_memory_sample *out);
+
+/* "0.42 0.31 0.28 1/234 5678" of /proc/loadavg. */
+[[nodiscard]] enum spg_status
+spg_telemetry_parse_loadavg(size_t n, const char buf[],
+                            struct spg_load_sample *out);
+
+/* Single-integer sysfs files (thermal zone temp, scaling_cur_freq). Accepts a
+ * trailing newline and a leading '-'. */
+[[nodiscard]] enum spg_status
+spg_telemetry_parse_int(size_t n, const char buf[], int64_t *out);
+
+/* Pi firmware bitmask, e.g. "0x50005" from get_throttled. */
+[[nodiscard]] enum spg_throttle_state
+spg_telemetry_parse_throttle(size_t n, const char buf[]);
+
+/* Utilisation between two samples. Returns SPG_MACHINE_UNKNOWN when prev is
+ * null, the counters did not advance, or they went backwards (a counter reset
+ * across suspend/resume) — never a wrong number and never a division by zero.
+ */
+[[nodiscard]] uint64_t
+spg_telemetry_utilisation_bp(const struct spg_cpu_sample *prev,
+                             const struct spg_cpu_sample *cur);
+
+/* --- layer 1: OS reading ------------------------------------------------ */
+
+/* Fill out from the host. prev may be null (first tick: utilisation stays
+ * UNKNOWN). Returns SPG_E_UNSUPPORTED on non-Linux hosts with every field set
+ * to unknown — a caller must be able to keep running on such a host.
+ * Individual missing files are not an error; they leave their field unknown. */
+[[nodiscard]] enum spg_status
+spg_machine_sample(uint64_t timestamp_ns, const struct spg_cpu_sample *prev,
+                   struct spg_machine_state *out);
+
+/* --- layer 3: serialisation --------------------------------------------- */
+
+/* Deterministic s-expression: fixed field order, unknown values as the symbol
+ * `unknown`. Identical input always yields identical bytes. Writes at most
+ * dst_capacity bytes including the NUL; on SPG_E_LIMIT *out_required holds the
+ * size needed and dst holds no partial record. */
+[[nodiscard]] enum spg_status
+spg_machine_state_render(const struct spg_machine_state *state,
+                         size_t dst_capacity, char dst[static dst_capacity],
+                         size_t *out_required);
+
+[[nodiscard]] const char *
+spg_throttle_state_to_string(enum spg_throttle_state state);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/machine/telemetry.c
+++ b/src/machine/telemetry.c
@@ -1,0 +1,407 @@
+/* Layer 2 and 3: parsing and serialisation. Pure — no I/O, no clock, no
+ * allocation. Every function reads at most n bytes and tolerates input without
+ * a NUL terminator. */
+
+#include "geistshell/machine_state.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+
+static constexpr uint64_t bp_scale    = 10000u;
+static constexpr uint64_t cbp_scale   = 100u;
+static constexpr uint64_t kb_to_bytes = 1024u;
+/* Guard for the jiffy sums: leaves room to add another field without wrapping,
+ * and no real /proc/stat comes close. */
+static constexpr uint64_t counter_max = UINT64_MAX / 2u;
+
+static bool is_digit(const char c) { return c >= '0' && c <= '9'; }
+
+static bool is_space(const char c) { return c == ' ' || c == '\t'; }
+
+/* Scan a decimal integer starting at *pos. Advances *pos past it. Returns
+ * false on no digits at all or on overflow past counter_max. */
+static bool scan_u64(const size_t n, const char buf[], size_t *pos,
+                     uint64_t *out) {
+    size_t   i     = *pos;
+    uint64_t value = 0u;
+    bool     any   = false;
+    while (i < n && is_digit(buf[i])) {
+        const uint64_t digit = (uint64_t)(buf[i] - '0');
+        if (value > (counter_max - digit) / 10u) {
+            return false;
+        }
+        value = value * 10u + digit;
+        any   = true;
+        i += 1u;
+    }
+    if (!any) {
+        return false;
+    }
+    *pos = i;
+    *out = value;
+    return true;
+}
+
+static void skip_spaces(const size_t n, const char buf[], size_t *pos) {
+    while (*pos < n && is_space(buf[*pos])) {
+        *pos += 1u;
+    }
+}
+
+/* Start offset of the line that begins with key, or n when absent. */
+static size_t find_line(const size_t n, const char buf[], const char *key) {
+    const size_t key_n = strlen(key);
+    size_t       i     = 0u;
+    while (i < n) {
+        if (n - i >= key_n && memcmp(buf + i, key, key_n) == 0) {
+            return i + key_n;
+        }
+        while (i < n && buf[i] != '\n') {
+            i += 1u;
+        }
+        if (i < n) {
+            i += 1u;
+        }
+    }
+    return n;
+}
+
+/* "MemTotal:   16316248 kB" -> bytes. Absent key leaves *out untouched. */
+static bool read_kb_field(const size_t n, const char buf[], const char *key,
+                          uint64_t *out) {
+    size_t pos = find_line(n, buf, key);
+    if (pos >= n) {
+        return false;
+    }
+    skip_spaces(n, buf, &pos);
+    uint64_t kb = 0u;
+    if (!scan_u64(n, buf, &pos, &kb)) {
+        return false;
+    }
+    if (kb > counter_max / kb_to_bytes) {
+        return false;
+    }
+    *out = kb * kb_to_bytes;
+    return true;
+}
+
+enum spg_status spg_telemetry_parse_stat(const size_t n, const char buf[],
+                                         struct spg_cpu_sample *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = (struct spg_cpu_sample){};
+    if (n < 4u || memcmp(buf, "cpu ", 4u) != 0) {
+        return SPG_E_FORMAT;
+    }
+    /* user nice system idle iowait irq softirq steal guest guest_nice */
+    size_t   pos    = 4u;
+    uint64_t total  = 0u;
+    uint64_t idle   = 0u;
+    size_t   fields = 0u;
+    while (pos < n && buf[pos] != '\n') {
+        skip_spaces(n, buf, &pos);
+        if (pos >= n || !is_digit(buf[pos])) {
+            break;
+        }
+        uint64_t value = 0u;
+        if (!scan_u64(n, buf, &pos, &value)) {
+            return SPG_E_OVERFLOW;
+        }
+        if (total > counter_max - value) {
+            return SPG_E_OVERFLOW;
+        }
+        total += value;
+        if (fields == 3u || fields == 4u) { /* idle, iowait */
+            idle += value;
+        }
+        fields += 1u;
+    }
+    /* user..idle is the minimum any kernel emits; fewer means malformed. */
+    if (fields < 4u) {
+        *out = (struct spg_cpu_sample){};
+        return SPG_E_FORMAT;
+    }
+    out->idle  = idle;
+    out->total = total;
+    return SPG_OK;
+}
+
+enum spg_status spg_telemetry_parse_meminfo(const size_t n, const char buf[],
+                                            struct spg_memory_sample *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = (struct spg_memory_sample){
+        .total_bytes     = SPG_MACHINE_UNKNOWN,
+        .used_bytes      = SPG_MACHINE_UNKNOWN,
+        .swap_used_bytes = SPG_MACHINE_UNKNOWN,
+    };
+    uint64_t total = 0u;
+    if (!read_kb_field(n, buf, "MemTotal:", &total)) {
+        return SPG_E_FORMAT;
+    }
+    out->total_bytes = total;
+
+    /* MemAvailable is what a workload can actually get; MemFree is not. */
+    uint64_t available = 0u;
+    if (read_kb_field(n, buf, "MemAvailable:", &available)) {
+        out->used_bytes = available > total ? 0u : total - available;
+    }
+    uint64_t swap_total = 0u;
+    uint64_t swap_free  = 0u;
+    if (read_kb_field(n, buf, "SwapTotal:", &swap_total) &&
+        read_kb_field(n, buf, "SwapFree:", &swap_free)) {
+        out->swap_used_bytes =
+            swap_free > swap_total ? 0u : swap_total - swap_free;
+    }
+    return SPG_OK;
+}
+
+/* "1.75" -> 175 centi-units. Exactly two fractional digits, truncated, so the
+ * result never depends on locale or rounding mode. */
+static bool scan_cbp(const size_t n, const char buf[], size_t *pos,
+                     uint64_t *out) {
+    uint64_t whole = 0u;
+    if (!scan_u64(n, buf, pos, &whole)) {
+        return false;
+    }
+    uint64_t frac = 0u;
+    if (*pos < n && buf[*pos] == '.') {
+        *pos += 1u;
+        uint64_t scale = cbp_scale;
+        while (*pos < n && is_digit(buf[*pos])) {
+            if (scale > 1u) {
+                scale /= 10u;
+                frac += (uint64_t)(buf[*pos] - '0') * scale;
+            }
+            *pos += 1u;
+        }
+    }
+    if (whole > (counter_max - frac) / cbp_scale) {
+        return false;
+    }
+    *out = whole * cbp_scale + frac;
+    return true;
+}
+
+enum spg_status spg_telemetry_parse_loadavg(const size_t n, const char buf[],
+                                            struct spg_load_sample *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = (struct spg_load_sample){
+        .avg_1_cbp  = SPG_MACHINE_UNKNOWN,
+        .avg_5_cbp  = SPG_MACHINE_UNKNOWN,
+        .avg_15_cbp = SPG_MACHINE_UNKNOWN,
+    };
+    size_t   pos  = 0u;
+    uint64_t v[3] = {};
+    for (size_t i = 0u; i < 3u; i += 1u) {
+        skip_spaces(n, buf, &pos);
+        if (!scan_cbp(n, buf, &pos, &v[i])) {
+            return SPG_E_FORMAT; /* fields stay unknown, never 0 */
+        }
+    }
+    out->avg_1_cbp  = v[0];
+    out->avg_5_cbp  = v[1];
+    out->avg_15_cbp = v[2];
+    return SPG_OK;
+}
+
+enum spg_status spg_telemetry_parse_int(const size_t n, const char buf[],
+                                        int64_t *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out             = 0;
+    size_t     pos   = 0u;
+    const bool minus = n > 0u && buf[0] == '-';
+    if (minus) {
+        pos = 1u;
+    }
+    uint64_t magnitude = 0u;
+    if (!scan_u64(n, buf, &pos, &magnitude)) {
+        return SPG_E_FORMAT;
+    }
+    if (magnitude > (uint64_t)INT64_MAX) {
+        return SPG_E_OVERFLOW;
+    }
+    *out = minus ? -(int64_t)magnitude : (int64_t)magnitude;
+    return SPG_OK;
+}
+
+enum spg_throttle_state spg_telemetry_parse_throttle(const size_t n,
+                                                     const char   buf[]) {
+    /* Pi firmware bitmask: bits 0-3 are live conditions, bits 16-19 record
+     * that one occurred since boot. Anything else we cannot interpret. */
+    size_t pos = 0u;
+    if (n < 3u || buf[0] != '0' || (buf[1] != 'x' && buf[1] != 'X')) {
+        return SPG_THROTTLE_UNKNOWN;
+    }
+    pos            = 2u;
+    uint64_t value = 0u;
+    bool     any   = false;
+    for (; pos < n; pos += 1u) {
+        const char c     = buf[pos];
+        uint64_t   digit = 0u;
+        if (is_digit(c)) {
+            digit = (uint64_t)(c - '0');
+        } else if (c >= 'a' && c <= 'f') {
+            digit = (uint64_t)(c - 'a') + 10u;
+        } else if (c >= 'A' && c <= 'F') {
+            digit = (uint64_t)(c - 'A') + 10u;
+        } else {
+            break;
+        }
+        if (value > (counter_max - digit) / 16u) {
+            return SPG_THROTTLE_UNKNOWN;
+        }
+        value = value * 16u + digit;
+        any   = true;
+    }
+    if (!any) {
+        return SPG_THROTTLE_UNKNOWN;
+    }
+    if ((value & 0xfu) != 0u) {
+        return SPG_THROTTLE_ACTIVE;
+    }
+    if ((value & 0xf0000u) != 0u) {
+        return SPG_THROTTLE_PAST;
+    }
+    return SPG_THROTTLE_NONE;
+}
+
+uint64_t spg_telemetry_utilisation_bp(const struct spg_cpu_sample *prev,
+                                      const struct spg_cpu_sample *cur) {
+    if (prev == nullptr || cur == nullptr) {
+        return SPG_MACHINE_UNKNOWN;
+    }
+    /* Counters only ever grow. Backwards means a reset (suspend/resume, CPU
+     * hotplug): report unknown rather than a fabricated spike. */
+    if (cur->total < prev->total || cur->idle < prev->idle) {
+        return SPG_MACHINE_UNKNOWN;
+    }
+    const uint64_t total_delta = cur->total - prev->total;
+    const uint64_t idle_delta  = cur->idle - prev->idle;
+    if (total_delta == 0u) { /* two samples inside one tick */
+        return SPG_MACHINE_UNKNOWN;
+    }
+    if (idle_delta >= total_delta) {
+        return 0u;
+    }
+    const uint64_t busy = total_delta - idle_delta;
+    return busy * bp_scale / total_delta;
+}
+
+const char *spg_throttle_state_to_string(const enum spg_throttle_state state) {
+    switch (state) {
+    case SPG_THROTTLE_UNKNOWN:
+        return "unknown";
+    case SPG_THROTTLE_NONE:
+        return "none";
+    case SPG_THROTTLE_ACTIVE:
+        return "active";
+    case SPG_THROTTLE_PAST:
+        return "past";
+    }
+    return "unknown";
+}
+
+/* --- serialisation ------------------------------------------------------ */
+
+struct writer {
+    size_t capacity;
+    char  *dst;
+    size_t used; /* bytes that would be written, may exceed capacity */
+    bool   overflowed;
+};
+
+static void put(struct writer *w, const char *text) {
+    for (size_t i = 0u; text[i] != '\0'; i += 1u) {
+        if (w->used + 1u < w->capacity) {
+            w->dst[w->used] = text[i];
+        } else {
+            w->overflowed = true;
+        }
+        w->used += 1u;
+    }
+}
+
+static void put_i64(struct writer *w, const int64_t value) {
+    char     tmp[21];
+    size_t   len = 0u;
+    uint64_t magnitude =
+        value < 0 ? (uint64_t)(-(value + 1)) + 1u : (uint64_t)value;
+    do {
+        tmp[len] = (char)('0' + (magnitude % 10u));
+        len += 1u;
+        magnitude /= 10u;
+    } while (magnitude > 0u && len < sizeof tmp);
+    if (value < 0) {
+        put(w, "-");
+    }
+    char out[22];
+    for (size_t i = 0u; i < len; i += 1u) {
+        out[i] = tmp[len - 1u - i];
+    }
+    out[len] = '\0';
+    put(w, out);
+}
+
+static void put_u64(struct writer *w, const uint64_t value) {
+    if (value == SPG_MACHINE_UNKNOWN) {
+        put(w, "unknown");
+        return;
+    }
+    put_i64(w, (int64_t)value);
+}
+
+static void put_field(struct writer *w, const char *name,
+                      const uint64_t value) {
+    put(w, " (");
+    put(w, name);
+    put(w, " ");
+    put_u64(w, value);
+    put(w, ")");
+}
+
+enum spg_status spg_machine_state_render(const struct spg_machine_state *state,
+                                         const size_t dst_capacity,
+                                         char         dst[static dst_capacity],
+                                         size_t      *out_required) {
+    if (state == nullptr || out_required == nullptr || dst_capacity == 0u) {
+        return SPG_E_INVALID_ARG;
+    }
+    struct writer w = {.capacity = dst_capacity, .dst = dst};
+
+    /* Fixed field order — the whole point of this function. */
+    put(&w, "(machine-state");
+    put_field(&w, "cpu-load-bp", state->cpu_utilisation_bp);
+    put_field(&w, "load-1-cbp", state->load.avg_1_cbp);
+    put_field(&w, "memory-total-bytes", state->memory.total_bytes);
+    put_field(&w, "memory-used-bytes", state->memory.used_bytes);
+    put_field(&w, "swap-used-bytes", state->memory.swap_used_bytes);
+    put(&w, " (temperature-mc ");
+    if (state->temperature_mc == SPG_MACHINE_UNKNOWN_S) {
+        put(&w, "unknown");
+    } else {
+        put_i64(&w, state->temperature_mc);
+    }
+    put(&w, ")");
+    put_field(&w, "cpu-freq-khz", state->cpu_freq_khz);
+    put(&w, " (throttle ");
+    put(&w, spg_throttle_state_to_string(state->throttle));
+    put(&w, ")");
+    put_field(&w, "process-count", state->process_count);
+    put(&w, ")");
+
+    *out_required = w.used + 1u;
+    if (w.overflowed) {
+        dst[0] = '\0'; /* no partial record ever escapes */
+        return SPG_E_LIMIT;
+    }
+    dst[w.used] = '\0';
+    return SPG_OK;
+}

--- a/src/machine/telemetry_host.c
+++ b/src/machine/telemetry_host.c
@@ -1,0 +1,139 @@
+/* Layer 1: the only part that touches the OS. Kept separate so the parsers
+ * stay testable on any host with static fixtures — the tests never read /proc.
+ *
+ * Linux only. Elsewhere the sampler reports SPG_E_UNSUPPORTED and every field
+ * stays unknown, so a caller on a developer Mac keeps running. */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include "geistshell/machine_state.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+
+static void state_init(struct spg_machine_state *out,
+                       const uint64_t            timestamp_ns) {
+    *out = (struct spg_machine_state){
+        .timestamp_ns       = timestamp_ns,
+        .cpu_utilisation_bp = SPG_MACHINE_UNKNOWN,
+        .load =
+            {
+                .avg_1_cbp  = SPG_MACHINE_UNKNOWN,
+                .avg_5_cbp  = SPG_MACHINE_UNKNOWN,
+                .avg_15_cbp = SPG_MACHINE_UNKNOWN,
+            },
+        .memory =
+            {
+                .total_bytes     = SPG_MACHINE_UNKNOWN,
+                .used_bytes      = SPG_MACHINE_UNKNOWN,
+                .swap_used_bytes = SPG_MACHINE_UNKNOWN,
+            },
+        .temperature_mc = SPG_MACHINE_UNKNOWN_S,
+        .cpu_freq_khz   = SPG_MACHINE_UNKNOWN,
+        .throttle       = SPG_THROTTLE_UNKNOWN,
+        .process_count  = SPG_MACHINE_UNKNOWN,
+    };
+}
+
+#if defined(__linux__)
+
+#    include <dirent.h>
+
+/* Caller-provided buffer, no allocation. Returns the byte count read, or 0 when
+ * the file is missing — a missing sysfs file is normal, not an error. */
+static size_t read_file(const char *path, const size_t cap, char buf[cap]) {
+    FILE *f = fopen(path, "rbe");
+    if (f == nullptr) {
+        return 0u;
+    }
+    const size_t n = fread(buf, 1u, cap, f);
+    (void)fclose(f);
+    return n;
+}
+
+/* /proc entries whose name is all digits are processes. */
+static uint64_t count_processes(void) {
+    DIR *dir = opendir("/proc");
+    if (dir == nullptr) {
+        return SPG_MACHINE_UNKNOWN;
+    }
+    uint64_t             count = 0u;
+    const struct dirent *entry;
+    while ((entry = readdir(dir)) != nullptr) {
+        bool numeric = entry->d_name[0] != '\0';
+        for (size_t i = 0u; numeric && entry->d_name[i] != '\0'; i += 1u) {
+            numeric = entry->d_name[i] >= '0' && entry->d_name[i] <= '9';
+        }
+        if (numeric) {
+            count += 1u;
+        }
+    }
+    (void)closedir(dir);
+    return count;
+}
+
+enum spg_status spg_machine_sample(const uint64_t               timestamp_ns,
+                                   const struct spg_cpu_sample *prev,
+                                   struct spg_machine_state    *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    state_init(out, timestamp_ns);
+
+    /* One buffer, reused: /proc/meminfo is the largest of these by far. */
+    char   buf[4096];
+    size_t n = read_file("/proc/stat", sizeof buf, buf);
+    if (n > 0u && spg_telemetry_parse_stat(n, buf, &out->cpu) == SPG_OK) {
+        out->cpu_utilisation_bp = spg_telemetry_utilisation_bp(prev, &out->cpu);
+    }
+    n = read_file("/proc/meminfo", sizeof buf, buf);
+    if (n > 0u) {
+        (void)spg_telemetry_parse_meminfo(n, buf, &out->memory);
+    }
+    n = read_file("/proc/loadavg", sizeof buf, buf);
+    if (n > 0u) {
+        (void)spg_telemetry_parse_loadavg(n, buf, &out->load);
+    }
+
+    /* thermal_zone0 is the CPU zone on the Pi and on most ARM boards. A host
+     * without it simply reports unknown. */
+    n = read_file("/sys/class/thermal/thermal_zone0/temp", sizeof buf, buf);
+    if (n > 0u) {
+        int64_t milli = 0;
+        if (spg_telemetry_parse_int(n, buf, &milli) == SPG_OK) {
+            out->temperature_mc = milli;
+        }
+    }
+    n = read_file("/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq",
+                  sizeof buf, buf);
+    if (n > 0u) {
+        int64_t khz = 0;
+        if (spg_telemetry_parse_int(n, buf, &khz) == SPG_OK && khz >= 0) {
+            out->cpu_freq_khz = (uint64_t)khz;
+        }
+    }
+    /* Pi-specific and optional by design: no vcgencmd dependency. */
+    n = read_file("/sys/devices/platform/soc/soc:firmware/get_throttled",
+                  sizeof buf, buf);
+    if (n > 0u) {
+        out->throttle = spg_telemetry_parse_throttle(n, buf);
+    }
+    out->process_count = count_processes();
+    return SPG_OK;
+}
+
+#else /* not Linux */
+
+enum spg_status spg_machine_sample(const uint64_t               timestamp_ns,
+                                   const struct spg_cpu_sample *prev,
+                                   struct spg_machine_state    *out) {
+    (void)prev;
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    state_init(out, timestamp_ns);
+    return SPG_E_UNSUPPORTED;
+}
+
+#endif

--- a/test/test_machine_telemetry.c
+++ b/test/test_machine_telemetry.c
@@ -1,0 +1,439 @@
+/* Phase 1 telemetry: parsers, utilisation, serialisation.
+ *
+ * Every case runs on static fixtures — nothing here reads /proc, so the result
+ * never depends on the CI machine's load, temperature or platform. */
+
+#include "geistshell/machine_state.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define LIT(s) (sizeof(s) - 1u), (s)
+
+static const char stat_ok[] = "cpu  100 20 30 800 40 0 10 0 0 0\n"
+                              "cpu0 50 10 15 400 20 0 5 0 0 0\n";
+
+static const char meminfo_ok[] = "MemTotal:       16316248 kB\n"
+                                 "MemFree:         1000000 kB\n"
+                                 "MemAvailable:    8158124 kB\n"
+                                 "SwapTotal:       2097152 kB\n"
+                                 "SwapFree:        2000000 kB\n";
+
+static int test_stat(void) {
+    struct spg_cpu_sample s = {};
+    if (spg_telemetry_parse_stat(LIT(stat_ok), &s) != SPG_OK) {
+        return 1;
+    }
+    /* total = all ten fields, idle = idle + iowait */
+    if (s.total != 1000u || s.idle != 840u) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_stat_malformed(void) {
+    struct spg_cpu_sample s = {};
+    /* wrong prefix */
+    if (spg_telemetry_parse_stat(LIT("proc 1 2 3 4\n"), &s) != SPG_E_FORMAT) {
+        return 1;
+    }
+    /* too few fields: user..idle is the minimum */
+    if (spg_telemetry_parse_stat(LIT("cpu  1 2 3\n"), &s) != SPG_E_FORMAT) {
+        return 1;
+    }
+    /* letters where digits belong */
+    if (spg_telemetry_parse_stat(LIT("cpu  1 2 x 4 5\n"), &s) != SPG_E_FORMAT) {
+        return 1;
+    }
+    /* empty */
+    if (spg_telemetry_parse_stat(LIT(""), &s) != SPG_E_FORMAT) {
+        return 1;
+    }
+    /* a failed parse must leave the output zeroed, not half-filled */
+    if (s.total != 0u || s.idle != 0u) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_stat_overflow(void) {
+    struct spg_cpu_sample s = {};
+    /* 30 nines exceeds uint64 by a wide margin */
+    const char *huge = "cpu  999999999999999999999999999999 1 2 3 4\n";
+    const enum spg_status status =
+        spg_telemetry_parse_stat(strlen(huge), huge, &s);
+    return status == SPG_E_OVERFLOW ? 0 : 1;
+}
+
+/* The parsers must not read past n even without a NUL — sized exactly so ASan
+ * traps any overrun. */
+static int test_stat_unterminated(void) {
+    const char            src[] = "cpu  1 2 3 4 5";
+    char                  exact[sizeof src - 1u];
+    struct spg_cpu_sample s = {};
+    memcpy(exact, src, sizeof exact);
+    return spg_telemetry_parse_stat(sizeof exact, exact, &s) == SPG_OK ? 0 : 1;
+}
+
+static int test_meminfo(void) {
+    struct spg_memory_sample m = {};
+    if (spg_telemetry_parse_meminfo(LIT(meminfo_ok), &m) != SPG_OK) {
+        return 1;
+    }
+    if (m.total_bytes != 16316248ull * 1024ull) {
+        return 1;
+    }
+    if (m.used_bytes != (16316248ull - 8158124ull) * 1024ull) {
+        return 1;
+    }
+    if (m.swap_used_bytes != (2097152ull - 2000000ull) * 1024ull) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_meminfo_partial(void) {
+    struct spg_memory_sample m = {};
+    /* No MemAvailable and no swap: total known, the rest explicitly unknown. */
+    if (spg_telemetry_parse_meminfo(LIT("MemTotal:  1024 kB\n"), &m) !=
+        SPG_OK) {
+        return 1;
+    }
+    if (m.total_bytes != 1024ull * 1024ull) {
+        return 1;
+    }
+    if (m.used_bytes != SPG_MACHINE_UNKNOWN ||
+        m.swap_used_bytes != SPG_MACHINE_UNKNOWN) {
+        return 1;
+    }
+    /* Missing MemTotal is a format error, not a silent zero. */
+    if (spg_telemetry_parse_meminfo(LIT("MemFree: 12 kB\n"), &m) !=
+        SPG_E_FORMAT) {
+        return 1;
+    }
+    return 0;
+}
+
+/* Available > total happens on odd kernels; used must clamp to 0, not wrap. */
+static int test_meminfo_clamp(void) {
+    struct spg_memory_sample m = {};
+    if (spg_telemetry_parse_meminfo(
+            LIT("MemTotal: 100 kB\nMemAvailable: 200 kB\n"), &m) != SPG_OK) {
+        return 1;
+    }
+    return m.used_bytes == 0u ? 0 : 1;
+}
+
+static int test_loadavg(void) {
+    struct spg_load_sample l = {};
+    if (spg_telemetry_parse_loadavg(LIT("1.75 0.31 0.08 1/234 5678\n"), &l) !=
+        SPG_OK) {
+        return 1;
+    }
+    if (l.avg_1_cbp != 175u || l.avg_5_cbp != 31u || l.avg_15_cbp != 8u) {
+        return 1;
+    }
+    /* More than two fractional digits truncate, never round — byte-identical
+     * output must not depend on rounding mode. */
+    if (spg_telemetry_parse_loadavg(LIT("0.999 0.0 0.0\n"), &l) != SPG_OK) {
+        return 1;
+    }
+    if (l.avg_1_cbp != 99u) {
+        return 1;
+    }
+    /* Integer form without a decimal point is valid. */
+    if (spg_telemetry_parse_loadavg(LIT("2 3 4\n"), &l) != SPG_OK) {
+        return 1;
+    }
+    if (l.avg_1_cbp != 200u) {
+        return 1;
+    }
+    /* Two of three values is malformed. */
+    if (spg_telemetry_parse_loadavg(LIT("1.0 2.0\n"), &l) != SPG_E_FORMAT) {
+        return 1;
+    }
+    /* A failed parse must leave the fields unknown, never 0 — 0 would read as
+     * a perfectly idle machine. */
+    if (l.avg_1_cbp != SPG_MACHINE_UNKNOWN ||
+        l.avg_15_cbp != SPG_MACHINE_UNKNOWN) {
+        return 1;
+    }
+    /* An empty file is a legitimate input, not a crash. */
+    if (spg_telemetry_parse_loadavg(LIT(""), &l) != SPG_E_FORMAT) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_parse_int(void) {
+    int64_t v = 0;
+    if (spg_telemetry_parse_int(LIT("78400\n"), &v) != SPG_OK || v != 78400) {
+        return 1;
+    }
+    /* Below-freezing boards exist; the sign must survive. */
+    if (spg_telemetry_parse_int(LIT("-5000\n"), &v) != SPG_OK || v != -5000) {
+        return 1;
+    }
+    if (spg_telemetry_parse_int(LIT("\n"), &v) != SPG_E_FORMAT) {
+        return 1;
+    }
+    if (spg_telemetry_parse_int(LIT("not a number"), &v) != SPG_E_FORMAT) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_throttle(void) {
+    /* live under-voltage bit */
+    if (spg_telemetry_parse_throttle(LIT("0x50005\n")) != SPG_THROTTLE_ACTIVE) {
+        return 1;
+    }
+    /* only the "happened since boot" bits */
+    if (spg_telemetry_parse_throttle(LIT("0x50000\n")) != SPG_THROTTLE_PAST) {
+        return 1;
+    }
+    if (spg_telemetry_parse_throttle(LIT("0x0\n")) != SPG_THROTTLE_NONE) {
+        return 1;
+    }
+    /* not hex, empty, or garbage: unknown, never a guess */
+    if (spg_telemetry_parse_throttle(LIT("50005\n")) != SPG_THROTTLE_UNKNOWN) {
+        return 1;
+    }
+    if (spg_telemetry_parse_throttle(LIT("")) != SPG_THROTTLE_UNKNOWN) {
+        return 1;
+    }
+    if (spg_telemetry_parse_throttle(LIT("0x\n")) != SPG_THROTTLE_UNKNOWN) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_utilisation(void) {
+    const struct spg_cpu_sample a = {.idle = 800u, .total = 1000u};
+    const struct spg_cpu_sample b = {.idle = 900u, .total = 2000u};
+    /* 1000 total, 100 idle -> 90% busy */
+    if (spg_telemetry_utilisation_bp(&a, &b) != 9000u) {
+        return 1;
+    }
+    /* first tick: no previous sample */
+    if (spg_telemetry_utilisation_bp(nullptr, &b) != SPG_MACHINE_UNKNOWN) {
+        return 1;
+    }
+    /* two samples inside one tick: no division by zero, no fabricated value */
+    if (spg_telemetry_utilisation_bp(&a, &a) != SPG_MACHINE_UNKNOWN) {
+        return 1;
+    }
+    /* counter reset (suspend/resume): unknown, not a spike */
+    if (spg_telemetry_utilisation_bp(&b, &a) != SPG_MACHINE_UNKNOWN) {
+        return 1;
+    }
+    /* fully idle */
+    const struct spg_cpu_sample c = {.idle = 1800u, .total = 2000u};
+    if (spg_telemetry_utilisation_bp(&a, &c) != 0u) {
+        return 1;
+    }
+    return 0;
+}
+
+static struct spg_machine_state sample_state(void) {
+    return (struct spg_machine_state){
+        .timestamp_ns       = 42u,
+        .cpu_utilisation_bp = 9200u,
+        .load               = {.avg_1_cbp = 175u},
+        .memory             = {.total_bytes     = 1024u,
+                               .used_bytes      = 512u,
+                               .swap_used_bytes = 0u},
+        .temperature_mc     = 78400,
+        .cpu_freq_khz       = 1500000u,
+        .throttle           = SPG_THROTTLE_NONE,
+        .process_count      = 137u,
+    };
+}
+
+static int test_render(void) {
+    const struct spg_machine_state s = sample_state();
+    char                           buf[512];
+    size_t                         required = 0u;
+    if (spg_machine_state_render(&s, sizeof buf, buf, &required) != SPG_OK) {
+        return 1;
+    }
+    const char *expected =
+        "(machine-state (cpu-load-bp 9200) (load-1-cbp 175)"
+        " (memory-total-bytes 1024) (memory-used-bytes 512)"
+        " (swap-used-bytes 0) (temperature-mc 78400)"
+        " (cpu-freq-khz 1500000) (throttle none) (process-count 137))";
+    if (strcmp(buf, expected) != 0) {
+        printf("  rendered: %s\n", buf);
+        return 1;
+    }
+    if (required != strlen(expected) + 1u) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_render_unknown(void) {
+    struct spg_machine_state s = {
+        .cpu_utilisation_bp = SPG_MACHINE_UNKNOWN,
+        .load               = {.avg_1_cbp  = SPG_MACHINE_UNKNOWN,
+                               .avg_5_cbp  = SPG_MACHINE_UNKNOWN,
+                               .avg_15_cbp = SPG_MACHINE_UNKNOWN},
+        .memory             = {.total_bytes     = SPG_MACHINE_UNKNOWN,
+                               .used_bytes      = SPG_MACHINE_UNKNOWN,
+                               .swap_used_bytes = SPG_MACHINE_UNKNOWN},
+        .temperature_mc     = SPG_MACHINE_UNKNOWN_S,
+        .cpu_freq_khz       = SPG_MACHINE_UNKNOWN,
+        .throttle           = SPG_THROTTLE_UNKNOWN,
+        .process_count      = SPG_MACHINE_UNKNOWN,
+    };
+    char   buf[512];
+    size_t required = 0u;
+    if (spg_machine_state_render(&s, sizeof buf, buf, &required) != SPG_OK) {
+        return 1;
+    }
+    /* Unknown is a symbol, never 0 — a consumer must not mistake a missing
+     * sensor for an idle machine. */
+    if (strstr(buf, "(cpu-load-bp unknown)") == nullptr ||
+        strstr(buf, "(load-1-cbp unknown)") == nullptr ||
+        strstr(buf, "(temperature-mc unknown)") == nullptr ||
+        strstr(buf, "(throttle unknown)") == nullptr) {
+        printf("  rendered: %s\n", buf);
+        return 1;
+    }
+    if (strstr(buf, " 0)") != nullptr) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_render_deterministic(void) {
+    const struct spg_machine_state s = sample_state();
+    char                           a[512];
+    char                           b[512];
+    size_t                         ra = 0u;
+    size_t                         rb = 0u;
+    if (spg_machine_state_render(&s, sizeof a, a, &ra) != SPG_OK ||
+        spg_machine_state_render(&s, sizeof b, b, &rb) != SPG_OK) {
+        return 1;
+    }
+    return (ra == rb && memcmp(a, b, ra) == 0) ? 0 : 1;
+}
+
+static int test_render_limit(void) {
+    const struct spg_machine_state s = sample_state();
+    char                           full[512];
+    size_t                         required = 0u;
+    if (spg_machine_state_render(&s, sizeof full, full, &required) != SPG_OK) {
+        return 1;
+    }
+    /* Exactly one byte short: the boundary that off-by-ones live at. */
+    char   tight[512];
+    size_t needed = 0u;
+    if (spg_machine_state_render(&s, required - 1u, tight, &needed) !=
+        SPG_E_LIMIT) {
+        return 1;
+    }
+    if (needed != required) {
+        return 1;
+    }
+    /* No partial record may escape — a truncated s-expression would not
+     * parse and could still reach a journal. */
+    if (tight[0] != '\0') {
+        return 1;
+    }
+    /* Exactly enough must succeed. */
+    if (spg_machine_state_render(&s, required, tight, &needed) != SPG_OK) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_null_args(void) {
+    struct spg_cpu_sample s = {};
+    char                  buf[64];
+    size_t                required = 0u;
+    if (spg_telemetry_parse_stat(LIT(stat_ok), nullptr) != SPG_E_INVALID_ARG) {
+        return 1;
+    }
+    if (spg_telemetry_parse_meminfo(LIT(meminfo_ok), nullptr) !=
+        SPG_E_INVALID_ARG) {
+        return 1;
+    }
+    if (spg_machine_state_render(nullptr, sizeof buf, buf, &required) !=
+        SPG_E_INVALID_ARG) {
+        return 1;
+    }
+    (void)s;
+    return 0;
+}
+
+/* The sampler is the only part that touches the OS. On Linux it must succeed;
+ * elsewhere it must degrade to unknown rather than fail the caller's run. */
+static int test_sample_platform(void) {
+    struct spg_machine_state s      = {};
+    const enum spg_status    status = spg_machine_sample(7u, nullptr, &s);
+    if (s.timestamp_ns != 7u) {
+        return 1;
+    }
+    /* No previous sample, so utilisation is unknown on every platform. */
+    if (s.cpu_utilisation_bp != SPG_MACHINE_UNKNOWN) {
+        return 1;
+    }
+#if defined(__linux__)
+    if (status != SPG_OK) {
+        return 1;
+    }
+    if (s.memory.total_bytes == SPG_MACHINE_UNKNOWN) {
+        return 1; /* /proc/meminfo always exists on Linux */
+    }
+#else
+    if (status != SPG_E_UNSUPPORTED) {
+        return 1;
+    }
+    if (s.memory.total_bytes != SPG_MACHINE_UNKNOWN ||
+        s.temperature_mc != SPG_MACHINE_UNKNOWN_S ||
+        s.throttle != SPG_THROTTLE_UNKNOWN) {
+        return 1;
+    }
+#endif
+    if (spg_machine_sample(1u, nullptr, nullptr) != SPG_E_INVALID_ARG) {
+        return 1;
+    }
+    return 0;
+}
+
+int main(void) {
+    const struct {
+        const char *name;
+        int (*fn)(void);
+    } cases[] = {
+        {"stat", test_stat},
+        {"stat_malformed", test_stat_malformed},
+        {"stat_overflow", test_stat_overflow},
+        {"stat_unterminated", test_stat_unterminated},
+        {"meminfo", test_meminfo},
+        {"meminfo_partial", test_meminfo_partial},
+        {"meminfo_clamp", test_meminfo_clamp},
+        {"loadavg", test_loadavg},
+        {"parse_int", test_parse_int},
+        {"throttle", test_throttle},
+        {"utilisation", test_utilisation},
+        {"render", test_render},
+        {"render_unknown", test_render_unknown},
+        {"render_deterministic", test_render_deterministic},
+        {"render_limit", test_render_limit},
+        {"null_args", test_null_args},
+        {"sample_platform", test_sample_platform},
+    };
+    int failures = 0;
+    for (size_t i = 0u; i < sizeof cases / sizeof cases[0]; i += 1u) {
+        if (cases[i].fn() != 0) {
+            printf("test_machine_telemetry: FAIL %s\n", cases[i].name);
+            failures += 1;
+        }
+    }
+    if (failures == 0) {
+        printf("test_machine_telemetry: PASS\n");
+    }
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Phase 1 der Machine-Intelligence-Roadmap (#61). Stapelt auf #81 — Basis ist `phase0-baseline`, der Diff hier ist nur Phase 1.

Der Agent kann die Maschine ab jetzt **beobachten**, sonst nichts. Kein Action Kind, keine Context-Verdrahtung (#63), keine Prozessliste (#62). Der Sampler wird von keinem Agent-Pfad aufgerufen — dass der Journal-Freeze aus Phase 0 unverändert grün bleibt, ist der Beleg dafür.

## Drei Schichten

| Schicht | Datei |
|---------|-------|
| OS lesen (Linux, einzige I/O-Stelle) | `src/machine/telemetry_host.c` |
| Normalisieren (reine Funktionen über Puffer) | `src/machine/telemetry.c` |
| Serialisieren (deterministische S-Expression) | `src/machine/telemetry.c` |

Die Trennung ist der Grund, warum `test_machine_telemetry` auf jedem Host läuft: 17 Fälle über statische Fixtures, kein Zugriff auf `/proc`. Kein Ergebnis hängt von CPU-Last, Temperatur oder Plattform der CI ab.

## Keine Uhr im Modul

`spg_machine_sample()` bekommt `timestamp_ns` vom Aufrufer, genau wie `spg_journal_writer_append()`. Begründung im Determinismus-Inventar aus Phase 0: der Zeitstempel geht in die Record-Hash-Chain, und der einzige Clock-Read der Runtime (`cmd_executor.c:50`) verlässt sein Modul nicht. Eine zweite Zeitquelle würde den Freeze brechen, sobald ein Telemetriewert in Context oder Journal landet.

CPU-Auslastung ist deshalb das Delta zweier Samples, die der Aufrufer hält — kein verborgener Zustand mit eigener Uhr. Der Snapshot trägt die rohen Counter mit, damit der nächste Aufruf sie einspeisen kann.

## Zwei Defekte, die die Tests gefunden haben

- **Fehlender Load Average las sich als `0`** — für ein Modell eine vollkommen idle Maschine. Unbekannt ist jetzt ein Sentinel und rendert als Symbol `unknown`, nie als `0`. Genau der Fehler, den #61 verbietet („kein 0 als unbekannt").
- **`buf[static n]` mit `n == 0` ist UB**, und eine leere sysfs-Datei ist ein legitimer Eingabefall. UBSan hat es angezeigt; die Parser nehmen jetzt `buf[]`, Länge weiterhin zuerst — dieselbe Ausnahme, die `cmd_executor.h:88` dokumentiert.

## Grenzfälle mit Test

Fehlende Datei, leere Datei, Buchstaben im Zahlenfeld, zu wenige Spalten in `/proc/stat`, 30-stellige Zahl (Overflow), Puffer ohne NUL (exakt dimensioniert, damit ASan Überläufe fängt), `MemAvailable > MemTotal` (Clamp statt Wrap), Δt = 0, rückwärts laufende Counter nach Suspend, Load ohne Dezimalpunkt, mehr als zwei Nachkommastellen (Trunkierung statt Rundung), Nicht-Hex im Throttle-Feld, Renderpuffer exakt ein Byte zu klein (kein Teil-Record entkommt), Nicht-Linux-Degradierung.

## Verifikation

`make test`: grün, exit 0, 25 PASS (vorher 24), ASan/UBSan sauber, keine neuen Dependencies. `test_cli_baseline.sh` unverändert grün.

**Nicht verifiziert:** der Linux-Pfad. Diese Maschine ist macOS arm64, dort greift die `SPG_E_UNSUPPORTED`-Degradierung. `/proc`- und `/sys`-Lesen ist durch Fixtures abgedeckt, aber nicht auf echter Hardware gelaufen — das braucht einen Pi oder einen Linux-Runner.

Doku: `docs/machine-intelligence/Telemetry.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
