### PR TITLE
Phase 2: Prozess-Telemetrie mit semantischen Rollen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,8 @@ SPG_SOURCES := \
     src/memory/mem_executor.c \
     src/memory/mem_store.c \
     src/memory/memory.c \
+    src/machine/process.c \
+    src/machine/process_profile.c \
     src/machine/telemetry.c \
     src/machine/telemetry_host.c \
     src/model/grammar_mask.c \

--- a/docs/machine-intelligence/Processes.md
+++ b/docs/machine-intelligence/Processes.md
@@ -1,0 +1,155 @@
+# Processes — Phase 2
+
+Prozess-Telemetrie mit semantischen Rollen. Der Agent sieht nicht nur „CPU
+90 %", sondern **wer** verbraucht und **was dieser Prozess bedeutet**.
+
+Ticket: geisten/geistshell#62. Voraussetzung: [Telemetry.md](Telemetry.md).
+Noch keine Aktion — Pausieren und Stoppen ist Phase 6 (#66).
+
+## Was nicht erfasst wird
+
+Keine Command Line, keine Environment-Variablen, kein Benutzername. Diese
+Felder tragen regelmäßig Secrets (`--password=`, `AWS_SECRET_...`) und wären ab
+Phase 3 Prompt-Injection-Fläche im Model-Context. Was nicht erfasst wird, kann
+nicht leaken.
+
+Erfasst werden: PID, Start-Identität, Name, Zustand, Nice, CPU-Zeit, RSS.
+
+## Identität statt PID
+
+`start_identity` ist die Startzeit des Prozesses in Ticks seit Boot
+(`/proc/<pid>/stat` Feld 22). Zusammen mit der PID ist das die
+Prozessidentität.
+
+Der Grund ist Phase 6: PIDs werden wiederverwendet. Ein Agent, der in Tick 1
+„PID 4711 verbraucht 90 % CPU" beobachtet und in Tick 2 `SIGSTOP` an 4711
+schickt, trifft möglicherweise einen völlig anderen Prozess. Deshalb:
+
+- `spg_process_find()` sucht **nur** über PID **und** Start-Identität.
+- `spg_process_utilisation_bp()` liefert `unknown`, wenn die Identität nicht
+  übereinstimmt — lieber kein Wert als ein erfundener.
+- Ein `/proc/<pid>/stat`, das vor Feld 22 abbricht, wird komplett verworfen:
+  ein Sample ohne Identität darf Phase 6 nie erreichen.
+
+## Der Name ist kein Weg
+
+`comm` schreibt der Kernel **unescaped in Klammern**, und er darf Leerzeichen
+und `)` enthalten. `"weird (name) here"` ist ein legaler Prozessname. Der
+Parser verankert sich deshalb an der **letzten** `)` der Zeile, nicht an der
+ersten — der klassische Fehler in selbstgebauten `/proc`-Parsern.
+
+Zusätzlich kürzt der Kernel `comm` auf 15 Zeichen (`TASK_COMM_LEN - 1`). Das
+Profil-Matching berücksichtigt das:
+
+| Profil `match` | `/proc` meldet | Trifft? |
+|---|---|---|
+| `batch-worker` | `batch-worker` | ja (exakt) |
+| `very-long-worker-name` | `very-long-worke` | ja (Kernel-Kürzung) |
+| `batch-worker` | `batch-worker-2` | **nein** (kein Substring-Matching) |
+| `very-long-worker-name` | `very-long` | **nein** (nur zufälliger Präfix) |
+
+Kein Substring-, kein Glob-, kein Regex-Matching. Wenn zwei Einträge denselben
+Namen treffen, gewinnt der **erste** in der Datei — deterministisch und
+dokumentiert.
+
+Steuerzeichen im Namen werden beim Parsen durch `?` ersetzt. Ein Prozessname
+mit `\n` oder `"` würde sonst ab Phase 3 die S-Expression zerlegen, in der der
+Context besteht.
+
+## Process Profile
+
+```
+(process-profile
+  (process "critical_app"
+    (match "critical-worker")
+    (role critical)
+    (may_pause false)
+    (may_stop false))
+  (process "batch_job"
+    (match "batch-worker")
+    (role batch)
+    (may_pause true)
+    (may_stop true)))
+```
+
+Geparst mit dem vorhandenen S-Expression-Reader, in derselben Form wie
+`policy_config.c` — ein DSL, nicht zwei.
+
+`role`, `may_pause` und `may_stop` sind **typed Felder** in
+`struct spg_process_sample`, kein Prompt-Text. Phase 6 liest sie aus der
+Policy-Schicht; das Modell kann sie nicht überreden.
+
+Was der Parser ablehnt, und warum:
+
+| Eingabe | Status | Grund |
+|---|---|---|
+| `(role criticl)` | `SPG_E_SCHEMA` | Ein Tippfehler darf einen kritischen Prozess nicht stillschweigend zu `unknown` degradieren |
+| fehlendes `may_pause` | `SPG_E_SCHEMA` | Berechtigungen sind nie implizit |
+| `role critical` + `may_pause true` | `SPG_E_SCHEMA` | Widerspruch, den der Autor nicht gemeint hat — nicht erst in Phase 6 auflösen |
+| doppelte `id` | `SPG_E_SCHEMA` | Das Action-Target in Phase 6 wäre mehrdeutig |
+| `match` länger als das Feld | `SPG_E_SCHEMA` | Eine still gekürzte Match-String träfe den falschen Prozess |
+| leeres Profil / leere Datei | `SPG_OK` | Nichts gemanagt ist eine gültige Konfiguration |
+
+Ein Prozess ohne Profil-Treffer bekommt `role unknown` und **beide
+Berechtigungen `false`**. Auf dieser Eigenschaft baut Phase 6 auf: unbekannte
+Prozesse sind nie implizit pausierbar.
+
+Die Strings werden in feste Puffer **kopiert**, nicht als Spans in den
+Config-Text gehalten (wie es `policy_config.c` tut). Ein Profil überlebt den
+Puffer, aus dem es geparst wurde, und wird jeden Tick gegen Prozessnamen
+verglichen.
+
+## Auswahl: der Snapshot ist kleiner als die Maschine
+
+Höchstens `SPG_MACHINE_MAX_PROCESSES` (64) Prozesse erreichen den Snapshot.
+`spg_process_select()` entscheidet in fester Reihenfolge:
+
+1. Profil-gemanagte Prozesse
+2. CPU absteigend
+3. RSS absteigend
+4. PID aufsteigend
+
+Betrachtet werden **alle** Prozesse, nicht die ersten 64. Der Enumerator hält
+einen laufenden Best-of-Puffer (`spg_process_offer`) und ersetzt darin den
+schwächsten Eintrag, sobald ein stärkerer auftaucht. Auch das stammt aus dem
+Hardwaretest: die erste Fassung sampelte den Präfix, den `/proc` zufällig
+zuerst auflistete, und füllte den Snapshot auf einem Pi 5 mit 167 Prozessen mit
+Kernel-Threads bei 0 % CPU, während `geist` mit 856 MB RSS nie betrachtet
+wurde. Auf der Entwicklungsmaschine mit Fixtures war das unsichtbar.
+
+Die vierte Stufe ist nicht Kosmetik: `/proc` gibt keine Reihenfolge-Garantie,
+und wenn die Enumerationsreihenfolge ins Ergebnis durchschlüge, unterschiede
+sich der Context zwischen zwei Läufen mit identischem Zustand — Replay wäre
+tot. Ein Test permutiert die Eingabe und verlangt bitgleiche Ausgabe.
+
+`unknown` bei CPU oder RSS sortiert **hinten**, nicht als Riesenwert — sonst
+verdrängte ein Prozess ohne Messwert die tatsächlich heißen.
+
+Wird etwas verworfen, setzt die Auswahl `processes_truncated`. Ab Phase 3 muss
+das im Context sichtbar sein: eine gekürzte Liste, die vollständig aussieht,
+lädt das Modell zu falschen Schlüssen ein.
+
+## Grenzfälle mit Test
+
+PID-Reuse zwischen zwei Ticks, Prozess verschwindet zwischen `readdir` und
+`open` (`ENOENT` → übersprungen), Name mit Klammern und Leerzeichen, Name mit
+Steuerzeichen, Name über Kernel-Länge, `/proc/<pid>/stat` vor Feld 22
+abgeschnitten, keine schließende Klammer, nicht-numerische PID, leere Eingabe,
+Overflow in den Zähler-Feldern, mehr Prozesse als Kapazität, leere
+Prozessliste, unbekannter Prozess, doppelter Profil-Treffer, Multi-Core-Prozess
+über 100 % (auf 10000 bp geclamped).
+
+## Auf Hardware verifiziert
+
+Pi 5 Model B (aarch64, Kernel 6.18): `make test` grün, 26 PASS, warnungsfrei,
+ASan/UBSan sauber. Der gemessene Snapshot enthält nach der Korrektur die
+tatsächlich relevanten Prozesse — nach CPU, dann RSS: der Messprozess selbst
+(5,72 %), `geist` (856 MB), `python3` (360 MB), `dockerd`, `ollama`,
+`containerd` — bei 167 Prozessen insgesamt und gesetztem
+`processes_truncated`.
+
+## Was Phase 2 nicht tut
+
+Keine Aktion, keine Context-Integration (#63), kein History-Fenster (#79). Der
+Journal-Freeze aus Phase 0 bleibt unverändert grün — kein Agent-Pfad ruft die
+Prozess-Telemetrie auf.

--- a/docs/machine-intelligence/Telemetry.md
+++ b/docs/machine-intelligence/Telemetry.md
@@ -35,7 +35,7 @@ hängt von CPU-Last, Temperatur oder Plattform der CI-Maschine ab.
 | `swap-used-bytes` | Bytes | `SwapTotal − SwapFree` | eines der beiden fehlt |
 | `temperature-mc` | Milligrad Celsius | `/sys/class/thermal/thermal_zone0/temp` | kein Thermal-Zone-Sensor |
 | `cpu-freq-khz` | kHz | `.../cpu0/cpufreq/scaling_cur_freq` | kein cpufreq-Treiber |
-| `throttle` | `none`/`active`/`past`/`unknown` | `.../soc:firmware/get_throttled` | kein Pi-Firmware-Interface |
+| `throttle` | `none`/`active`/`past`/`unknown` | hwmon `rpi_volt`, sonst `.../soc:firmware/get_throttled` | weder hwmon-Gerät noch Firmware-Node |
 | `process-count` | Anzahl | numerische Einträge in `/proc` | `/proc` nicht lesbar |
 
 Alle Werte sind **Ganzzahlen im Fixpunkt**. Keine Floats: deren Formatierung
@@ -84,9 +84,15 @@ kann, ohne `/proc/stat` zweimal zu lesen.
   Felder `unknown`, `timestamp_ns` gesetzt. Der Aufrufer kann weiterlaufen; ein
   Agent-Run darf daran nicht scheitern.
 
-Kein `vcgencmd`. Das Throttling-Bit kommt aus dem sysfs-Firmware-Interface, und
-wenn es fehlt, ist der Zustand `unknown` — keine Abhängigkeit von einem
-Raspberry-Pi-Userland-Tool.
+Kein `vcgencmd`. Das Throttling-Bit kommt primär aus dem hwmon-Gerät
+`rpi_volt` (`in0_lcrit_alarm`), ersatzweise aus dem sysfs-Firmware-Interface.
+
+Die Reihenfolge stammt aus einem Hardwaretest: auf einem Pi 5 mit Kernel 6.18
+existiert `/sys/devices/platform/soc/soc:firmware/get_throttled` **nicht**, das
+Feld wäre also auf genau der Zielhardware dauerhaft `unknown` geblieben.
+`vcgencmd get_throttled` meldete dort `0xe0000` — Ereignisse seit Boot. Diese
+Historie liefert nur `vcgencmd`, und das bleibt bewusst keine Abhängigkeit;
+`past` ist deshalb nur dort erreichbar, wo der Firmware-Node existiert.
 
 ## Robustheit der Parser
 
@@ -105,6 +111,17 @@ NUL, `MemAvailable > MemTotal` (Clamp statt Wrap), Δt = 0, rückwärts laufende
 Counter, Load ohne Dezimalpunkt, mehr als zwei Nachkommastellen (Trunkierung,
 keine Rundung), Nicht-Hex im Throttle-Feld, Renderpuffer exakt ein Byte zu
 klein.
+
+## Auf Hardware verifiziert
+
+Pi 5 Model B (aarch64, Kernel 6.18, Debian): `make test` grün, gemessener
+Snapshot plausibel — CPU 6,2 %, Load 0,45, 4,2 GB Total / 1,68 GB Used,
+Temperatur 47,95 °C, 1,5 GHz, 167 Prozesse.
+
+Zwei Fehler fand erst dieser Lauf:
+- `sysconf` war ohne `<unistd.h>` deklariert; macOS zieht den Header über
+  `dirent.h` transitiv mit, glibc nicht.
+- Der Throttling-Pfad existierte auf Pi 5 nicht (siehe oben).
 
 ## Was Phase 1 nicht tut
 

--- a/include/geistshell/machine_state.h
+++ b/include/geistshell/machine_state.h
@@ -50,6 +50,48 @@ struct spg_load_sample {
     uint64_t avg_15_cbp;
 };
 
+/* Kernel comm is TASK_COMM_LEN (16) including the NUL — names are truncated by
+ * the kernel itself, which the profile matcher has to account for. */
+#define SPG_PROCESS_NAME_CAP 16u
+
+/* Hard ceiling on the processes carried in one snapshot. Selection decides
+ * which ones survive; see spg_process_select. */
+#define SPG_MACHINE_MAX_PROCESSES 64u
+
+/* profile_index of a process no profile entry matched. */
+#define SPG_PROCESS_NO_PROFILE UINT32_MAX
+
+/* Semantic role, supplied by the process profile — never guessed from the
+ * name. Phase 6 turns may_pause/may_stop into policy decisions, so these are
+ * typed fields and not prompt text. */
+enum spg_process_role {
+    SPG_PROCESS_ROLE_UNKNOWN = 0,
+    SPG_PROCESS_ROLE_CRITICAL,
+    SPG_PROCESS_ROLE_BATCH,
+};
+
+/* One process. No command line, no environment, no user name — those can carry
+ * secrets and would be prompt-injection surface once this reaches the model. */
+struct spg_process_sample {
+    uint64_t pid;
+    /* Kernel start time in clock ticks since boot. Together with pid this is
+     * the process identity: a recycled pid gets a different start time, which
+     * is what stops phase 6 from signalling the wrong process. */
+    uint64_t start_identity;
+    char     name[SPG_PROCESS_NAME_CAP];
+    char     state; /* R, S, D, Z, T, ... as the kernel reports it */
+    int64_t  nice;
+    uint64_t cpu_time; /* raw utime+stime ticks, for the next delta */
+    uint64_t cpu_bp;   /* share of one tick's total CPU, UNKNOWN without prev */
+    uint64_t rss_bytes;
+
+    /* Filled from the profile by spg_process_apply_profile. */
+    uint32_t              profile_index;
+    enum spg_process_role role;
+    bool                  may_pause;
+    bool                  may_stop;
+};
+
 /* Raspberry Pi exposes a throttling bitmask; most hosts expose nothing. */
 enum spg_throttle_state {
     SPG_THROTTLE_UNKNOWN = 0,
@@ -73,6 +115,14 @@ struct spg_machine_state {
 
     struct spg_cpu_sample cpu; /* raw counters, so the caller can feed the
                                 * next call without re-reading /proc/stat */
+
+    /* Bounded and already selected: the snapshot never carries every process
+     * on the host. n_processes <= SPG_MACHINE_MAX_PROCESSES, and
+     * processes_truncated says whether anything was dropped — a consumer must
+     * not read a short list as "this is all that runs". */
+    size_t                    n_processes;
+    bool                      processes_truncated;
+    struct spg_process_sample processes[SPG_MACHINE_MAX_PROCESSES];
 };
 
 /* --- layer 2: parsers, pure, no I/O ------------------------------------- */
@@ -109,6 +159,59 @@ spg_telemetry_parse_int(size_t n, const char buf[], int64_t *out);
 [[nodiscard]] enum spg_throttle_state
 spg_telemetry_parse_throttle(size_t n, const char buf[]);
 
+/* One /proc/<pid>/stat line. page_bytes converts the RSS page count the kernel
+ * reports; the caller supplies it so this stays a pure function.
+ *
+ * The comm field is the reason this is not a naive field split: the kernel
+ * writes it in parentheses without escaping, so it can contain spaces and
+ * ')' — "(my app) (weird)" is a legal name. Fields are read after the LAST
+ * ')' in the line. */
+[[nodiscard]] enum spg_status
+spg_process_parse_stat(size_t n, const char buf[], uint64_t page_bytes,
+                       struct spg_process_sample *out);
+
+/* Share of one tick's total CPU time, in basis points. total_delta is the
+ * delta of spg_cpu_sample.total across the same interval. Returns UNKNOWN
+ * when prev is null (first sighting), when the identity does not match (pid
+ * reuse), when nothing advanced, or when a counter went backwards. */
+[[nodiscard]] uint64_t
+spg_process_utilisation_bp(const struct spg_process_sample *prev,
+                           const struct spg_process_sample *cur,
+                           uint64_t                         total_delta);
+
+/* Find a process by identity — pid AND start_identity, never pid alone.
+ * Returns null when absent. */
+[[nodiscard]] const struct spg_process_sample *
+spg_process_find(size_t n, const struct spg_process_sample procs[],
+                 uint64_t pid, uint64_t start_identity);
+
+/* Offer one candidate to a running best-of buffer, replacing the weakest entry
+ * once it is full. Returns whether the candidate was kept.
+ *
+ * This exists because the enumerator cannot hold every process on a real host —
+ * a Pi 5 idles at ~170. Without it, selection only ever saw the first `cap`
+ * processes /proc happened to list, so the busiest process could be invisible
+ * while kernel threads at 0% filled the snapshot. Ranking is the same as
+ * spg_process_select's. */
+[[nodiscard]] bool spg_process_offer(
+    size_t cap, struct spg_process_sample buf[], size_t *n,
+    const struct spg_process_sample *candidate);
+
+/* Pick which processes reach the snapshot, in a fixed order:
+ *   1. profile-managed processes  2. CPU descending
+ *   3. RSS descending             4. pid ascending
+ * The last rung makes the result independent of the order the OS enumerated
+ * them in — /proc has no ordering guarantee, and an unstable context would
+ * break byte-identical replay. Sets *out_truncated when anything was dropped.
+ * in[] rather than in[static n_in]: an empty process list is legitimate. */
+[[nodiscard]] enum spg_status
+spg_process_select(size_t n_in, const struct spg_process_sample in[],
+                   size_t out_cap, struct spg_process_sample out[],
+                   size_t *out_n, bool *out_truncated);
+
+[[nodiscard]] const char *
+spg_process_role_to_string(enum spg_process_role role);
+
 /* Utilisation between two samples. Returns SPG_MACHINE_UNKNOWN when prev is
  * null, the counters did not advance, or they went backwards (a counter reset
  * across suspend/resume) — never a wrong number and never a division by zero.
@@ -126,6 +229,15 @@ spg_telemetry_utilisation_bp(const struct spg_cpu_sample *prev,
 [[nodiscard]] enum spg_status
 spg_machine_sample(uint64_t timestamp_ns, const struct spg_cpu_sample *prev,
                    struct spg_machine_state *out);
+
+/* Same, plus the previous tick's process list so per-process CPU can be a
+ * delta. Processes are matched by pid AND start identity: a recycled pid does
+ * not inherit the old process's counters, it reports unknown. prev_procs may
+ * be null when prev_n is 0. */
+[[nodiscard]] enum spg_status spg_machine_sample_with_processes(
+    uint64_t timestamp_ns, const struct spg_cpu_sample *prev, size_t prev_n,
+    const struct spg_process_sample prev_procs[],
+    struct spg_machine_state       *out);
 
 /* --- layer 3: serialisation --------------------------------------------- */
 

--- a/include/geistshell/process_profile.h
+++ b/include/geistshell/process_profile.h
@@ -1,0 +1,90 @@
+#ifndef GEISTSHELL_PROCESS_PROFILE_H
+#define GEISTSHELL_PROCESS_PROFILE_H
+
+#include "geistshell/machine_state.h"
+#include "geistshell/sexpr.h"
+#include "geistshell/status.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Configuration that gives processes a semantic role (roadmap phase 2, #62):
+ *
+ *   (process-profile
+ *     (process "critical_app"
+ *       (match "critical-worker")
+ *       (role critical)
+ *       (may_pause false)
+ *       (may_stop false))
+ *     (process "batch_job"
+ *       (match "batch-worker")
+ *       (role batch)
+ *       (may_pause true)
+ *       (may_stop true)))
+ *
+ * Separate header from machine_state.h on purpose: this is configuration read
+ * once, that is a sample taken every tick.
+ *
+ * The strings are copied into fixed buffers rather than kept as spans into the
+ * config text (which is what policy_config does): a profile outlives the buffer
+ * it was parsed from and is compared against process names every tick. */
+
+#define SPG_PROCESS_ID_CAP 32u
+#define SPG_PROCESS_MATCH_CAP 64u
+#define SPG_PROCESS_PROFILE_CAP 16u
+
+struct spg_process_profile_entry {
+    char                  id[SPG_PROCESS_ID_CAP];
+    char                  match[SPG_PROCESS_MATCH_CAP];
+    enum spg_process_role role;
+    bool                  may_pause;
+    bool                  may_stop;
+};
+
+struct spg_process_profile {
+    size_t                           count;
+    struct spg_process_profile_entry entries[SPG_PROCESS_PROFILE_CAP];
+};
+
+struct spg_process_profile_error {
+    enum spg_status status;
+    uint32_t        node_index;
+    size_t          offset;
+};
+
+/* Parse a (process-profile ...) form. An absent or empty profile is valid —
+ * it simply means nothing is managed. Duplicate ids are rejected
+ * (SPG_E_SCHEMA): two entries with the same id would make phase 6's action
+ * target ambiguous. */
+[[nodiscard]] enum spg_status spg_process_profile_load(
+    size_t input_n, const char input[], size_t token_capacity,
+    struct spg_sexpr_token tokens[static token_capacity], size_t node_capacity,
+    struct spg_sexpr_node       nodes[static node_capacity],
+    struct spg_process_profile *out, struct spg_process_profile_error *error);
+
+/* Index of the first entry matching name, or SPG_PROCESS_NO_PROFILE.
+ *
+ * Matching is exact against the kernel comm, with one concession to reality:
+ * the kernel truncates comm to 15 characters, so a match string longer than
+ * that also matches when its first 15 characters equal comm. First entry
+ * wins — order in the file is the tie-break, and it is deliberate. */
+[[nodiscard]] uint32_t
+spg_process_profile_match(const struct spg_process_profile *profile,
+                          const char                       *name);
+
+/* Stamp role, may_pause, may_stop and profile_index onto each sample.
+ * Unmatched processes keep role unknown and both permissions false — an
+ * unknown process is never implicitly pausable. */
+void spg_process_apply_profile(const struct spg_process_profile *profile,
+                               size_t n, struct spg_process_sample procs[]);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/machine/process.c
+++ b/src/machine/process.c
@@ -1,0 +1,324 @@
+/* Process telemetry: /proc/<pid>/stat parsing, per-process CPU, and the
+ * selection that decides which processes reach a bounded snapshot. Pure — the
+ * enumeration lives in telemetry_host.c. */
+
+#include "geistshell/machine_state.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+
+static constexpr uint64_t bp_scale    = 10000u;
+static constexpr uint64_t counter_max = UINT64_MAX / 2u;
+
+/* /proc/<pid>/stat field numbers, 1-based as in proc(5), counted after comm. */
+static constexpr size_t field_state     = 3u;
+static constexpr size_t field_utime     = 14u;
+static constexpr size_t field_stime     = 15u;
+static constexpr size_t field_nice      = 19u;
+static constexpr size_t field_starttime = 22u;
+static constexpr size_t field_rss_pages = 24u;
+
+static bool is_digit(const char c) { return c >= '0' && c <= '9'; }
+
+static bool scan_u64(const size_t n, const char buf[], size_t *pos,
+                     uint64_t *out) {
+    size_t   i     = *pos;
+    uint64_t value = 0u;
+    bool     any   = false;
+    while (i < n && is_digit(buf[i])) {
+        const uint64_t digit = (uint64_t)(buf[i] - '0');
+        if (value > (counter_max - digit) / 10u) {
+            return false;
+        }
+        value = value * 10u + digit;
+        any   = true;
+        i += 1u;
+    }
+    if (!any) {
+        return false;
+    }
+    *pos = i;
+    *out = value;
+    return true;
+}
+
+/* Copy src[0..src_n) into a fixed field, truncating and always terminating.
+ * Control characters become '?': a process name reaches the model context in
+ * phase 3, and a newline or a quote in it would break the s-expression the
+ * context is made of. */
+static void copy_name(char *dst, const size_t cap, const size_t src_n,
+                      const char src[]) {
+    size_t i = 0u;
+    for (; i + 1u < cap && i < src_n; i += 1u) {
+        const char c         = src[i];
+        const bool printable = c >= 0x20 && c != 0x7f;
+        dst[i]               = printable ? c : '?';
+    }
+    dst[i] = '\0';
+}
+
+enum spg_status spg_process_parse_stat(const size_t n, const char buf[],
+                                       const uint64_t             page_bytes,
+                                       struct spg_process_sample *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = (struct spg_process_sample){
+        .cpu_bp        = SPG_MACHINE_UNKNOWN,
+        .rss_bytes     = SPG_MACHINE_UNKNOWN,
+        .profile_index = SPG_PROCESS_NO_PROFILE,
+    };
+
+    size_t pos = 0u;
+    if (!scan_u64(n, buf, &pos, &out->pid)) {
+        return SPG_E_FORMAT;
+    }
+
+    /* comm is written unescaped in parentheses and may contain both spaces and
+     * ')', so the only reliable anchor is the LAST ')' in the line. */
+    size_t open_paren = pos;
+    while (open_paren < n && buf[open_paren] != '(') {
+        open_paren += 1u;
+    }
+    if (open_paren >= n) {
+        return SPG_E_FORMAT;
+    }
+    size_t close_paren = n;
+    for (size_t i = n; i > open_paren; i -= 1u) {
+        if (buf[i - 1u] == ')') {
+            close_paren = i - 1u;
+            break;
+        }
+    }
+    if (close_paren == n) {
+        return SPG_E_FORMAT;
+    }
+    copy_name(out->name, SPG_PROCESS_NAME_CAP, close_paren - open_paren - 1u,
+              buf + open_paren + 1u);
+
+    /* Field 3 (state) onward, space-separated. */
+    pos                 = close_paren + 1u;
+    size_t   field      = field_state - 1u;
+    bool     have_utime = false;
+    bool     have_stime = false;
+    uint64_t utime      = 0u;
+    uint64_t stime      = 0u;
+    while (pos < n && buf[pos] != '\n') {
+        while (pos < n && buf[pos] == ' ') {
+            pos += 1u;
+        }
+        if (pos >= n || buf[pos] == '\n') {
+            break;
+        }
+        field += 1u;
+        const size_t start = pos;
+        while (pos < n && buf[pos] != ' ' && buf[pos] != '\n') {
+            pos += 1u;
+        }
+        const size_t len = pos - start;
+        if (len == 0u) {
+            break;
+        }
+        size_t   scan  = start;
+        uint64_t value = 0u;
+        switch (field) {
+        case field_state:
+            out->state = buf[start];
+            break;
+        case field_utime:
+            if (!scan_u64(n, buf, &scan, &value)) {
+                return SPG_E_OVERFLOW;
+            }
+            utime      = value;
+            have_utime = true;
+            break;
+        case field_stime:
+            if (!scan_u64(n, buf, &scan, &value)) {
+                return SPG_E_OVERFLOW;
+            }
+            stime      = value;
+            have_stime = true;
+            break;
+        case field_nice: {
+            const bool minus = buf[start] == '-';
+            scan             = minus ? start + 1u : start;
+            if (!scan_u64(n, buf, &scan, &value)) {
+                return SPG_E_FORMAT;
+            }
+            if (value > (uint64_t)INT64_MAX) {
+                return SPG_E_OVERFLOW;
+            }
+            out->nice = minus ? -(int64_t)value : (int64_t)value;
+            break;
+        }
+        case field_starttime:
+            if (!scan_u64(n, buf, &scan, &value)) {
+                return SPG_E_OVERFLOW;
+            }
+            out->start_identity = value;
+            break;
+        case field_rss_pages:
+            if (!scan_u64(n, buf, &scan, &value)) {
+                return SPG_E_OVERFLOW;
+            }
+            if (page_bytes != 0u && value <= counter_max / page_bytes) {
+                out->rss_bytes = value * page_bytes;
+            }
+            break;
+        default:
+            break;
+        }
+    }
+    /* Anything short of starttime leaves the process without an identity, and
+     * an identity-less process must never reach an action in phase 6. */
+    if (field < field_starttime || !have_utime || !have_stime) {
+        *out = (struct spg_process_sample){
+            .cpu_bp        = SPG_MACHINE_UNKNOWN,
+            .rss_bytes     = SPG_MACHINE_UNKNOWN,
+            .profile_index = SPG_PROCESS_NO_PROFILE,
+        };
+        return SPG_E_FORMAT;
+    }
+    if (utime > counter_max - stime) {
+        return SPG_E_OVERFLOW;
+    }
+    out->cpu_time = utime + stime;
+    return SPG_OK;
+}
+
+uint64_t spg_process_utilisation_bp(const struct spg_process_sample *prev,
+                                    const struct spg_process_sample *cur,
+                                    const uint64_t total_delta) {
+    if (prev == nullptr || cur == nullptr || total_delta == 0u) {
+        return SPG_MACHINE_UNKNOWN;
+    }
+    /* Same pid but a different start time is a different process: comparing
+     * their counters would invent a number. */
+    if (prev->pid != cur->pid || prev->start_identity != cur->start_identity) {
+        return SPG_MACHINE_UNKNOWN;
+    }
+    if (cur->cpu_time < prev->cpu_time) {
+        return SPG_MACHINE_UNKNOWN;
+    }
+    const uint64_t busy = cur->cpu_time - prev->cpu_time;
+    if (busy >= total_delta) {
+        return bp_scale; /* multi-core: a process can exceed one CPU's share */
+    }
+    return busy * bp_scale / total_delta;
+}
+
+const struct spg_process_sample *
+spg_process_find(const size_t n, const struct spg_process_sample procs[],
+                 const uint64_t pid, const uint64_t start_identity) {
+    for (size_t i = 0u; i < n; i += 1u) {
+        if (procs[i].pid == pid && procs[i].start_identity == start_identity) {
+            return &procs[i];
+        }
+    }
+    return nullptr;
+}
+
+/* Strict weak ordering: managed first, then CPU, then RSS, then pid. The pid
+ * rung is what makes the result independent of enumeration order. */
+static bool ranks_before(const struct spg_process_sample *a,
+                         const struct spg_process_sample *b) {
+    const bool a_managed = a->profile_index != SPG_PROCESS_NO_PROFILE;
+    const bool b_managed = b->profile_index != SPG_PROCESS_NO_PROFILE;
+    if (a_managed != b_managed) {
+        return a_managed;
+    }
+    /* Unknown CPU sorts last, never as a huge value. */
+    const uint64_t a_cpu = a->cpu_bp == SPG_MACHINE_UNKNOWN ? 0u : a->cpu_bp;
+    const uint64_t b_cpu = b->cpu_bp == SPG_MACHINE_UNKNOWN ? 0u : b->cpu_bp;
+    if (a_cpu != b_cpu) {
+        return a_cpu > b_cpu;
+    }
+    const uint64_t a_rss =
+        a->rss_bytes == SPG_MACHINE_UNKNOWN ? 0u : a->rss_bytes;
+    const uint64_t b_rss =
+        b->rss_bytes == SPG_MACHINE_UNKNOWN ? 0u : b->rss_bytes;
+    if (a_rss != b_rss) {
+        return a_rss > b_rss;
+    }
+    return a->pid < b->pid;
+}
+
+bool spg_process_offer(const size_t cap, struct spg_process_sample buf[],
+                       size_t *n, const struct spg_process_sample *candidate) {
+    if (cap == 0u || buf == nullptr || n == nullptr || candidate == nullptr) {
+        return false;
+    }
+    if (*n < cap) {
+        buf[*n] = *candidate;
+        *n += 1u;
+        return true;
+    }
+    /* Full: drop the weakest entry, but only for something stronger. Keeping
+     * the running best-k is what stops enumeration order from deciding which
+     * processes the snapshot ever considered. */
+    size_t worst = 0u;
+    for (size_t i = 1u; i < cap; i += 1u) {
+        if (ranks_before(&buf[worst], &buf[i])) {
+            worst = i;
+        }
+    }
+    if (!ranks_before(candidate, &buf[worst])) {
+        return false;
+    }
+    buf[worst] = *candidate;
+    return true;
+}
+
+enum spg_status spg_process_select(const size_t                    n_in,
+                                   const struct spg_process_sample in[],
+                                   const size_t                    out_cap,
+                                   struct spg_process_sample       out[],
+                                   size_t *out_n, bool *out_truncated) {
+    if (out_n == nullptr || out_truncated == nullptr ||
+        (out_cap > 0u && out == nullptr) || (n_in > 0u && in == nullptr)) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out_n         = 0u;
+    *out_truncated = n_in > out_cap;
+
+    /* Selection sort into the output: out_cap is small and bounded (64), so
+     * this costs at most out_cap * n_in comparisons and needs no scratch.
+     * ponytail: O(n*k) beats bringing in a sort for a 64-element ceiling. */
+    bool taken_flags[SPG_MACHINE_MAX_PROCESSES] = {};
+    if (n_in > SPG_MACHINE_MAX_PROCESSES) {
+        /* More candidates than the flag array can track. The caller enumerates
+         * into a bounded buffer, so this means it passed an oversized list. */
+        return SPG_E_LIMIT;
+    }
+    while (*out_n < out_cap) {
+        size_t best = n_in;
+        for (size_t i = 0u; i < n_in; i += 1u) {
+            if (taken_flags[i]) {
+                continue;
+            }
+            if (best == n_in || ranks_before(&in[i], &in[best])) {
+                best = i;
+            }
+        }
+        if (best == n_in) {
+            break;
+        }
+        taken_flags[best] = true;
+        out[*out_n]       = in[best];
+        *out_n += 1u;
+    }
+    return SPG_OK;
+}
+
+const char *spg_process_role_to_string(const enum spg_process_role role) {
+    switch (role) {
+    case SPG_PROCESS_ROLE_UNKNOWN:
+        return "unknown";
+    case SPG_PROCESS_ROLE_CRITICAL:
+        return "critical";
+    case SPG_PROCESS_ROLE_BATCH:
+        return "batch";
+    }
+    return "unknown";
+}

--- a/src/machine/process_profile.c
+++ b/src/machine/process_profile.c
@@ -1,0 +1,256 @@
+/* (process-profile ...) — parsed with the shared s-expression reader, in the
+ * same shape as policy_config.c so there is one DSL, not two. */
+
+#include "geistshell/process_profile.h"
+
+#include <string.h>
+
+/* Kernel comm length minus the NUL: a longer match string can only ever equal
+ * the truncated name, never the full one. */
+static constexpr size_t comm_visible = SPG_PROCESS_NAME_CAP - 1u;
+
+static void set_error(struct spg_process_profile_error *error,
+                      const enum spg_status status, const uint32_t node_index,
+                      const size_t offset) {
+    if (error == nullptr) {
+        return;
+    }
+    error->status     = status;
+    error->node_index = node_index;
+    error->offset     = offset;
+}
+
+/* Copy a span's payload into a fixed field. Rejects anything that does not fit
+ * rather than truncating: a silently shortened match string would match the
+ * wrong process. */
+static bool copy_span(const size_t input_n, const char input[],
+                      const struct spg_text_span span, const size_t cap,
+                      char dst[]) {
+    if (!spg_sexpr_span_valid(input_n, span) || span.length + 1u > cap) {
+        return false;
+    }
+    memcpy(dst, input + span.offset, span.length);
+    dst[span.length] = '\0';
+    return true;
+}
+
+static uint32_t field_value(const size_t input_n, const char input[],
+                            const struct spg_sexpr_node nodes[static 1],
+                            const uint32_t entry, const char *name) {
+    uint32_t field = spg_sexpr_first_child(nodes, entry);
+    while (field != SPG_SEXPR_INVALID_INDEX) {
+        if (nodes[field].kind == SPG_SEXPR_NODE_LIST) {
+            const uint32_t field_name = spg_sexpr_first_child(nodes, field);
+            if (field_name != SPG_SEXPR_INVALID_INDEX &&
+                spg_sexpr_span_eq_cstr(input_n, input, nodes[field_name].span,
+                                       name)) {
+                return spg_sexpr_second_child(nodes, field);
+            }
+        }
+        field = nodes[field].next_sibling;
+    }
+    return SPG_SEXPR_INVALID_INDEX;
+}
+
+static enum spg_status parse_bool(const size_t input_n, const char input[],
+                                  const struct spg_text_span span, bool *out) {
+    if (spg_sexpr_span_eq_cstr(input_n, input, span, "true")) {
+        *out = true;
+        return SPG_OK;
+    }
+    if (spg_sexpr_span_eq_cstr(input_n, input, span, "false")) {
+        *out = false;
+        return SPG_OK;
+    }
+    return SPG_E_SCHEMA;
+}
+
+static enum spg_status parse_role(const size_t input_n, const char input[],
+                                  const struct spg_text_span span,
+                                  enum spg_process_role     *out) {
+    if (spg_sexpr_span_eq_cstr(input_n, input, span, "critical")) {
+        *out = SPG_PROCESS_ROLE_CRITICAL;
+        return SPG_OK;
+    }
+    if (spg_sexpr_span_eq_cstr(input_n, input, span, "batch")) {
+        *out = SPG_PROCESS_ROLE_BATCH;
+        return SPG_OK;
+    }
+    /* An unrecognised role is rejected, not silently downgraded to unknown:
+     * a typo in `criticl` must not turn a protected process into a pausable
+     * one. */
+    return SPG_E_SCHEMA;
+}
+
+static enum spg_status parse_entry(const size_t input_n, const char input[],
+                                   const struct spg_sexpr_node nodes[static 1],
+                                   const uint32_t              entry,
+                                   struct spg_process_profile_entry *out,
+                                   struct spg_process_profile_error *error) {
+    *out = (struct spg_process_profile_entry){};
+
+    const uint32_t       id_node = spg_sexpr_second_child(nodes, entry);
+    struct spg_text_span id_span = {};
+    if (id_node == SPG_SEXPR_INVALID_INDEX ||
+        !spg_sexpr_string_payload_span(&nodes[id_node], &id_span) ||
+        !copy_span(input_n, input, id_span, SPG_PROCESS_ID_CAP, out->id) ||
+        out->id[0] == '\0') {
+        set_error(error, SPG_E_SCHEMA, entry, nodes[entry].span.offset);
+        return SPG_E_SCHEMA;
+    }
+
+    const uint32_t match_node =
+        field_value(input_n, input, nodes, entry, "match");
+    struct spg_text_span match_span = {};
+    if (match_node == SPG_SEXPR_INVALID_INDEX ||
+        !spg_sexpr_string_payload_span(&nodes[match_node], &match_span) ||
+        !copy_span(input_n, input, match_span, SPG_PROCESS_MATCH_CAP,
+                   out->match) ||
+        out->match[0] == '\0') {
+        set_error(error, SPG_E_SCHEMA, entry, nodes[entry].span.offset);
+        return SPG_E_SCHEMA;
+    }
+
+    const uint32_t role_node =
+        field_value(input_n, input, nodes, entry, "role");
+    if (role_node == SPG_SEXPR_INVALID_INDEX ||
+        parse_role(input_n, input, nodes[role_node].span, &out->role) !=
+            SPG_OK) {
+        set_error(error, SPG_E_SCHEMA, entry, nodes[entry].span.offset);
+        return SPG_E_SCHEMA;
+    }
+
+    /* Both permissions are required and default to nothing: a profile that
+     * forgets may_pause must not silently grant it. */
+    const uint32_t pause_node =
+        field_value(input_n, input, nodes, entry, "may_pause");
+    const uint32_t stop_node =
+        field_value(input_n, input, nodes, entry, "may_stop");
+    if (pause_node == SPG_SEXPR_INVALID_INDEX ||
+        stop_node == SPG_SEXPR_INVALID_INDEX ||
+        parse_bool(input_n, input, nodes[pause_node].span, &out->may_pause) !=
+            SPG_OK ||
+        parse_bool(input_n, input, nodes[stop_node].span, &out->may_stop) !=
+            SPG_OK) {
+        set_error(error, SPG_E_SCHEMA, entry, nodes[entry].span.offset);
+        return SPG_E_SCHEMA;
+    }
+
+    /* A critical process that may be stopped is a contradiction the profile
+     * author did not mean; refuse it here rather than let phase 6 resolve it.
+     */
+    if (out->role == SPG_PROCESS_ROLE_CRITICAL &&
+        (out->may_pause || out->may_stop)) {
+        set_error(error, SPG_E_SCHEMA, entry, nodes[entry].span.offset);
+        return SPG_E_SCHEMA;
+    }
+    return SPG_OK;
+}
+
+enum spg_status spg_process_profile_load(
+    const size_t input_n, const char input[], const size_t token_capacity,
+    struct spg_sexpr_token      tokens[static token_capacity],
+    const size_t                node_capacity,
+    struct spg_sexpr_node       nodes[static node_capacity],
+    struct spg_process_profile *out, struct spg_process_profile_error *error) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = (struct spg_process_profile){};
+    set_error(error, SPG_OK, SPG_SEXPR_INVALID_INDEX, 0u);
+
+    size_t                 token_count = 0u;
+    size_t                 node_count  = 0u;
+    struct spg_sexpr_error parse_error = {};
+    const enum spg_status  status      = spg_sexpr_parse_text(
+        input_n, input, token_capacity, tokens, node_capacity, nodes,
+        &token_count, &node_count, &parse_error);
+    if (status != SPG_OK) {
+        set_error(error, status, SPG_SEXPR_INVALID_INDEX, parse_error.offset);
+        return status;
+    }
+    if (node_count == 0u) {
+        return SPG_OK; /* empty file: nothing managed, still valid */
+    }
+
+    const uint32_t root = 0u;
+    const uint32_t head = spg_sexpr_first_child(nodes, root);
+    if (nodes[root].kind != SPG_SEXPR_NODE_LIST ||
+        head == SPG_SEXPR_INVALID_INDEX ||
+        !spg_sexpr_span_eq_cstr(input_n, input, nodes[head].span,
+                                "process-profile")) {
+        set_error(error, SPG_E_SCHEMA, root, nodes[root].span.offset);
+        return SPG_E_SCHEMA;
+    }
+
+    uint32_t entry = nodes[head].next_sibling;
+    while (entry != SPG_SEXPR_INVALID_INDEX) {
+        const uint32_t entry_head = spg_sexpr_first_child(nodes, entry);
+        if (nodes[entry].kind != SPG_SEXPR_NODE_LIST ||
+            entry_head == SPG_SEXPR_INVALID_INDEX ||
+            !spg_sexpr_span_eq_cstr(input_n, input, nodes[entry_head].span,
+                                    "process")) {
+            set_error(error, SPG_E_SCHEMA, entry, nodes[entry].span.offset);
+            return SPG_E_SCHEMA;
+        }
+        if (out->count >= SPG_PROCESS_PROFILE_CAP) {
+            set_error(error, SPG_E_LIMIT, entry, nodes[entry].span.offset);
+            return SPG_E_LIMIT;
+        }
+        struct spg_process_profile_entry parsed = {};
+        const enum spg_status            entry_status =
+            parse_entry(input_n, input, nodes, entry, &parsed, error);
+        if (entry_status != SPG_OK) {
+            return entry_status;
+        }
+        for (size_t i = 0u; i < out->count; i += 1u) {
+            if (strcmp(out->entries[i].id, parsed.id) == 0) {
+                set_error(error, SPG_E_SCHEMA, entry, nodes[entry].span.offset);
+                return SPG_E_SCHEMA;
+            }
+        }
+        out->entries[out->count] = parsed;
+        out->count += 1u;
+        entry = nodes[entry].next_sibling;
+    }
+    return SPG_OK;
+}
+
+uint32_t spg_process_profile_match(const struct spg_process_profile *profile,
+                                   const char                       *name) {
+    if (profile == nullptr || name == nullptr || name[0] == '\0') {
+        return SPG_PROCESS_NO_PROFILE;
+    }
+    for (size_t i = 0u; i < profile->count; i += 1u) {
+        const char *match = profile->entries[i].match;
+        if (strcmp(match, name) == 0) {
+            return (uint32_t)i;
+        }
+        /* The kernel cut the name at 15 characters; compare what survived. */
+        if (strlen(match) > comm_visible &&
+            strncmp(match, name, comm_visible) == 0 &&
+            strlen(name) == comm_visible) {
+            return (uint32_t)i;
+        }
+    }
+    return SPG_PROCESS_NO_PROFILE;
+}
+
+void spg_process_apply_profile(const struct spg_process_profile *profile,
+                               const size_t                      n,
+                               struct spg_process_sample         procs[]) {
+    for (size_t i = 0u; i < n; i += 1u) {
+        const uint32_t index =
+            spg_process_profile_match(profile, procs[i].name);
+        procs[i].profile_index = index;
+        if (index == SPG_PROCESS_NO_PROFILE) {
+            procs[i].role      = SPG_PROCESS_ROLE_UNKNOWN;
+            procs[i].may_pause = false;
+            procs[i].may_stop  = false;
+            continue;
+        }
+        procs[i].role      = profile->entries[index].role;
+        procs[i].may_pause = profile->entries[index].may_pause;
+        procs[i].may_stop  = profile->entries[index].may_stop;
+    }
+}

--- a/src/machine/telemetry_host.c
+++ b/src/machine/telemetry_host.c
@@ -39,6 +39,8 @@ static void state_init(struct spg_machine_state *out,
 #if defined(__linux__)
 
 #    include <dirent.h>
+#    include <string.h>
+#    include <unistd.h> /* sysconf: not pulled in transitively on glibc */
 
 /* Caller-provided buffer, no allocation. Returns the byte count read, or 0 when
  * the file is missing — a missing sysfs file is normal, not an error. */
@@ -52,40 +54,120 @@ static size_t read_file(const char *path, const size_t cap, char buf[cap]) {
     return n;
 }
 
-/* /proc entries whose name is all digits are processes. */
-static uint64_t count_processes(void) {
+/* Under-voltage on a Pi 5 is an hwmon alarm, not a firmware sysfs node: the
+ * /sys/devices/platform/soc/soc:firmware/get_throttled path this first used
+ * does not exist on current kernels, which left the field permanently unknown
+ * on the very hardware the roadmap targets. vcgencmd would also report events
+ * since boot, but it stays a non-dependency by design, so "past" is only
+ * reachable where the firmware node does exist. */
+static enum spg_throttle_state read_throttle(const size_t cap, char buf[cap]) {
+    size_t n = read_file("/sys/devices/platform/soc/soc:firmware/get_throttled",
+                         cap, buf);
+    if (n > 0u) {
+        return spg_telemetry_parse_throttle(n, buf);
+    }
+    char path[96];
+    for (unsigned i = 0u; i < 16u; i += 1u) {
+        if (snprintf(path, sizeof path, "/sys/class/hwmon/hwmon%u/name", i) <
+            0) {
+            continue;
+        }
+        n = read_file(path, cap, buf);
+        if (n < 8u || memcmp(buf, "rpi_volt", 8u) != 0) {
+            continue;
+        }
+        if (snprintf(path, sizeof path,
+                     "/sys/class/hwmon/hwmon%u/in0_lcrit_alarm", i) < 0) {
+            continue;
+        }
+        n = read_file(path, cap, buf);
+        if (n == 0u) {
+            return SPG_THROTTLE_UNKNOWN;
+        }
+        return buf[0] == '0' ? SPG_THROTTLE_NONE : SPG_THROTTLE_ACTIVE;
+    }
+    return SPG_THROTTLE_UNKNOWN;
+}
+
+/* Read /proc/<pid>/stat for every numeric entry, then select the bounded set
+ * that reaches the snapshot. Returns the total number seen, which is not the
+ * number kept — the snapshot is deliberately smaller than the machine. */
+static uint64_t enumerate_processes(const size_t                    prev_n,
+                                    const struct spg_process_sample prev[],
+                                    const uint64_t                  total_delta,
+                                    struct spg_machine_state       *out) {
     DIR *dir = opendir("/proc");
     if (dir == nullptr) {
         return SPG_MACHINE_UNKNOWN;
     }
-    uint64_t             count = 0u;
+    const long     page_size  = sysconf(_SC_PAGESIZE);
+    const uint64_t page_bytes = page_size > 0 ? (uint64_t)page_size : 0u;
+
+    struct spg_process_sample all[SPG_MACHINE_MAX_PROCESSES];
+    size_t                    n_all = 0u;
+    uint64_t                  total = 0u;
+    char                      path[64];
+    char                      buf[2048];
+
     const struct dirent *entry;
     while ((entry = readdir(dir)) != nullptr) {
         bool numeric = entry->d_name[0] != '\0';
         for (size_t i = 0u; numeric && entry->d_name[i] != '\0'; i += 1u) {
             numeric = entry->d_name[i] >= '0' && entry->d_name[i] <= '9';
         }
-        if (numeric) {
-            count += 1u;
+        if (!numeric) {
+            continue;
         }
+        total += 1u;
+        if (snprintf(path, sizeof path, "/proc/%s/stat", entry->d_name) < 0) {
+            continue;
+        }
+        const size_t n = read_file(path, sizeof buf, buf);
+        if (n == 0u) {
+            continue; /* the process exited between readdir and open */
+        }
+        struct spg_process_sample sample = {};
+        if (spg_process_parse_stat(n, buf, page_bytes, &sample) != SPG_OK) {
+            continue;
+        }
+        const struct spg_process_sample *before =
+            spg_process_find(prev_n, prev, sample.pid, sample.start_identity);
+        sample.cpu_bp =
+            spg_process_utilisation_bp(before, &sample, total_delta);
+        (void)spg_process_offer(SPG_MACHINE_MAX_PROCESSES, all, &n_all,
+                                &sample);
     }
     (void)closedir(dir);
-    return count;
+
+    (void)spg_process_select(n_all, all, SPG_MACHINE_MAX_PROCESSES,
+                             out->processes, &out->n_processes,
+                             &out->processes_truncated);
+    /* Every process was considered; the ones that did not make the cut are
+     * still dropped, and the consumer must know the list is not the machine. */
+    if (total > (uint64_t)out->n_processes) {
+        out->processes_truncated = true;
+    }
+    return total;
 }
 
-enum spg_status spg_machine_sample(const uint64_t               timestamp_ns,
-                                   const struct spg_cpu_sample *prev,
-                                   struct spg_machine_state    *out) {
-    if (out == nullptr) {
+enum spg_status spg_machine_sample_with_processes(
+    const uint64_t timestamp_ns, const struct spg_cpu_sample *prev,
+    const size_t prev_n, const struct spg_process_sample prev_procs[],
+    struct spg_machine_state *out) {
+    if (out == nullptr || (prev_n > 0u && prev_procs == nullptr)) {
         return SPG_E_INVALID_ARG;
     }
     state_init(out, timestamp_ns);
 
     /* One buffer, reused: /proc/meminfo is the largest of these by far. */
-    char   buf[4096];
-    size_t n = read_file("/proc/stat", sizeof buf, buf);
+    char     buf[4096];
+    uint64_t total_delta = 0u;
+    size_t   n           = read_file("/proc/stat", sizeof buf, buf);
     if (n > 0u && spg_telemetry_parse_stat(n, buf, &out->cpu) == SPG_OK) {
         out->cpu_utilisation_bp = spg_telemetry_utilisation_bp(prev, &out->cpu);
+        if (prev != nullptr && out->cpu.total >= prev->total) {
+            total_delta = out->cpu.total - prev->total;
+        }
     }
     n = read_file("/proc/meminfo", sizeof buf, buf);
     if (n > 0u) {
@@ -113,23 +195,21 @@ enum spg_status spg_machine_sample(const uint64_t               timestamp_ns,
             out->cpu_freq_khz = (uint64_t)khz;
         }
     }
-    /* Pi-specific and optional by design: no vcgencmd dependency. */
-    n = read_file("/sys/devices/platform/soc/soc:firmware/get_throttled",
-                  sizeof buf, buf);
-    if (n > 0u) {
-        out->throttle = spg_telemetry_parse_throttle(n, buf);
-    }
-    out->process_count = count_processes();
+    out->throttle = read_throttle(sizeof buf, buf);
+    out->process_count =
+        enumerate_processes(prev_n, prev_procs, total_delta, out);
     return SPG_OK;
 }
 
 #else /* not Linux */
 
-enum spg_status spg_machine_sample(const uint64_t               timestamp_ns,
-                                   const struct spg_cpu_sample *prev,
-                                   struct spg_machine_state    *out) {
+enum spg_status spg_machine_sample_with_processes(
+    const uint64_t timestamp_ns, const struct spg_cpu_sample *prev,
+    const size_t prev_n, const struct spg_process_sample prev_procs[],
+    struct spg_machine_state *out) {
     (void)prev;
-    if (out == nullptr) {
+    (void)prev_procs;
+    if (out == nullptr || (prev_n > 0u && prev_procs == nullptr)) {
         return SPG_E_INVALID_ARG;
     }
     state_init(out, timestamp_ns);
@@ -137,3 +217,11 @@ enum spg_status spg_machine_sample(const uint64_t               timestamp_ns,
 }
 
 #endif
+/* Convenience for callers with no previous tick, e.g. the first sample and the
+ * tests. */
+enum spg_status spg_machine_sample(const uint64_t               timestamp_ns,
+                                   const struct spg_cpu_sample *prev,
+                                   struct spg_machine_state    *out) {
+    return spg_machine_sample_with_processes(timestamp_ns, prev, 0u, nullptr,
+                                             out);
+}

--- a/test/test_machine_process.c
+++ b/test/test_machine_process.c
@@ -1,0 +1,626 @@
+/* Phase 2: process telemetry, profile matching, bounded selection.
+ *
+ * Static fixtures only — no /proc, no dependency on what happens to run on the
+ * CI machine. */
+
+#include "geistshell/machine_state.h"
+#include "geistshell/process_profile.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define LIT(s) (sizeof(s) - 1u), (s)
+#define PAGE 4096u
+
+/* pid (comm) state ppid pgrp ... utime(14) stime(15) ... nice(19) ...
+ * starttime(22) vsize(23) rss(24) */
+static const char stat_ok[] =
+    "1234 (batch-worker) S 1 1234 1234 0 -1 4194304 100 0 0 0 "
+    "500 250 0 0 20 5 3 0 987654 123456789 4096 "
+    "18446744073709551615 1 2 3 4 5 6 7\n";
+
+static int test_parse_basic(void) {
+    struct spg_process_sample p = {};
+    if (spg_process_parse_stat(LIT(stat_ok), PAGE, &p) != SPG_OK) {
+        return 1;
+    }
+    if (p.pid != 1234u || strcmp(p.name, "batch-worker") != 0) {
+        return 1;
+    }
+    /* field 18 priority=20, 19 nice=5, 20 num_threads=3 */
+    if (p.state != 'S' || p.nice != 5 || p.start_identity != 987654u) {
+        return 1;
+    }
+    if (p.cpu_time != 750u) { /* utime 500 + stime 250 */
+        return 1;
+    }
+    if (p.rss_bytes != 4096ull * PAGE) {
+        return 1;
+    }
+    /* No previous sample yet, so no CPU share. */
+    if (p.cpu_bp != SPG_MACHINE_UNKNOWN) {
+        return 1;
+    }
+    return 0;
+}
+
+/* comm is written unescaped: spaces and ')' inside it are legal and have
+ * broken naive parsers for decades. */
+static int test_parse_awkward_name(void) {
+    const char awkward[] = "77 (weird (name) here) R 1 1 1 0 -1 0 0 0 0 0 "
+                           "10 20 0 0 20 0 1 0 555 0 2 "
+                           "0 0 0 0 0 0 0\n";
+    struct spg_process_sample p = {};
+    if (spg_process_parse_stat(LIT(awkward), PAGE, &p) != SPG_OK) {
+        return 1;
+    }
+    if (strcmp(p.name, "weird (name) he") != 0) { /* 15 chars, kernel cap */
+        printf("  name: '%s'\n", p.name);
+        return 1;
+    }
+    if (p.pid != 77u || p.start_identity != 555u) {
+        return 1;
+    }
+    return 0;
+}
+
+/* A name with a newline or a quote would break the s-expression this ends up
+ * in during phase 3. Control characters must not survive the parser. */
+static int test_parse_control_chars(void) {
+    const char nasty[]          = "9 (ba\nd\tname) S 1 1 1 0 -1 0 0 0 0 0 "
+                                  "1 1 0 0 20 0 1 0 42 0 1 0 0 0 0 0 0 0\n";
+    struct spg_process_sample p = {};
+    if (spg_process_parse_stat(LIT(nasty), PAGE, &p) != SPG_OK) {
+        return 1;
+    }
+    if (strchr(p.name, '\n') != nullptr || strchr(p.name, '\t') != nullptr) {
+        printf("  name: '%s'\n", p.name);
+        return 1;
+    }
+    return 0;
+}
+
+static int test_parse_malformed(void) {
+    struct spg_process_sample p = {};
+    if (spg_process_parse_stat(LIT(""), PAGE, &p) != SPG_E_FORMAT) {
+        return 1;
+    }
+    if (spg_process_parse_stat(LIT("notapid (x) S 1\n"), PAGE, &p) !=
+        SPG_E_FORMAT) {
+        return 1;
+    }
+    /* No closing paren at all. */
+    if (spg_process_parse_stat(LIT("12 (unterminated S 1 2 3\n"), PAGE, &p) !=
+        SPG_E_FORMAT) {
+        return 1;
+    }
+    /* Truncated before starttime: without an identity the sample is unusable,
+     * because phase 6 would have nothing to re-validate a pid against. */
+    if (spg_process_parse_stat(LIT("12 (x) S 1 1 1 0 -1 0 0 0 0 0 1 2\n"), PAGE,
+                               &p) != SPG_E_FORMAT) {
+        return 1;
+    }
+    if (p.pid != 0u || p.start_identity != 0u) {
+        return 1; /* a rejected parse must not leave a half-filled sample */
+    }
+    return 0;
+}
+
+static int test_parse_null(void) {
+    return spg_process_parse_stat(LIT(stat_ok), PAGE, nullptr) ==
+                   SPG_E_INVALID_ARG
+               ? 0
+               : 1;
+}
+
+static int test_utilisation(void) {
+    const struct spg_process_sample a = {
+        .pid = 7u, .start_identity = 100u, .cpu_time = 100u};
+    const struct spg_process_sample b = {
+        .pid = 7u, .start_identity = 100u, .cpu_time = 300u};
+    /* 200 of 1000 ticks -> 20% */
+    if (spg_process_utilisation_bp(&a, &b, 1000u) != 2000u) {
+        return 1;
+    }
+    /* THE pid-reuse case: same pid, different start time. Comparing these
+     * counters would report a wild number for a brand-new process. */
+    const struct spg_process_sample reused = {
+        .pid = 7u, .start_identity = 999u, .cpu_time = 300u};
+    if (spg_process_utilisation_bp(&a, &reused, 1000u) != SPG_MACHINE_UNKNOWN) {
+        return 1;
+    }
+    /* first sighting */
+    if (spg_process_utilisation_bp(nullptr, &b, 1000u) != SPG_MACHINE_UNKNOWN) {
+        return 1;
+    }
+    /* no time passed */
+    if (spg_process_utilisation_bp(&a, &b, 0u) != SPG_MACHINE_UNKNOWN) {
+        return 1;
+    }
+    /* counter went backwards */
+    if (spg_process_utilisation_bp(&b, &a, 1000u) != SPG_MACHINE_UNKNOWN) {
+        return 1;
+    }
+    /* Multi-core: a process can burn more than one CPU's worth; clamp at
+     * 100% rather than report 340%. */
+    const struct spg_process_sample hot = {
+        .pid = 7u, .start_identity = 100u, .cpu_time = 5000u};
+    if (spg_process_utilisation_bp(&a, &hot, 1000u) != 10000u) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_find_identity(void) {
+    const struct spg_process_sample procs[] = {
+        {.pid = 1u, .start_identity = 10u},
+        {.pid = 2u, .start_identity = 20u},
+    };
+    if (spg_process_find(2u, procs, 2u, 20u) != &procs[1]) {
+        return 1;
+    }
+    /* Right pid, wrong identity: not found, not "close enough". */
+    if (spg_process_find(2u, procs, 2u, 21u) != nullptr) {
+        return 1;
+    }
+    if (spg_process_find(0u, procs, 1u, 10u) != nullptr) {
+        return 1;
+    }
+    return 0;
+}
+
+static struct spg_process_sample mk(const uint64_t pid, const uint64_t cpu,
+                                    const uint64_t rss, const bool managed) {
+    return (struct spg_process_sample){
+        .pid           = pid,
+        .cpu_bp        = cpu,
+        .rss_bytes     = rss,
+        .profile_index = managed ? 0u : SPG_PROCESS_NO_PROFILE,
+    };
+}
+
+static int test_select_priority(void) {
+    const struct spg_process_sample in[] = {
+        mk(3u, 100u, 10u, false),  /* low cpu, unmanaged */
+        mk(1u, 9000u, 10u, false), /* hot, unmanaged */
+        mk(2u, 50u, 10u, true),    /* managed, cold -> still first */
+    };
+    struct spg_process_sample out[3] = {};
+    size_t                    n      = 0u;
+    bool                      trunc  = true;
+    if (spg_process_select(3u, in, 3u, out, &n, &trunc) != SPG_OK) {
+        return 1;
+    }
+    if (n != 3u || trunc) {
+        return 1;
+    }
+    if (out[0].pid != 2u || out[1].pid != 1u || out[2].pid != 3u) {
+        return 1;
+    }
+    return 0;
+}
+
+/* /proc has no ordering guarantee. If enumeration order leaked into the
+ * result, the context would differ between runs and replay would break. */
+static int test_select_permutation_invariant(void) {
+    const struct spg_process_sample a[] = {
+        mk(3u, 100u, 10u, false), mk(1u, 9000u, 10u, false),
+        mk(2u, 50u, 10u, true), mk(4u, 100u, 99u, false)};
+    const struct spg_process_sample b[] = {
+        mk(4u, 100u, 99u, false), mk(2u, 50u, 10u, true),
+        mk(1u, 9000u, 10u, false), mk(3u, 100u, 10u, false)};
+    struct spg_process_sample out_a[4] = {};
+    struct spg_process_sample out_b[4] = {};
+    size_t                    na = 0u, nb = 0u;
+    bool                      ta = false, tb = false;
+    if (spg_process_select(4u, a, 4u, out_a, &na, &ta) != SPG_OK ||
+        spg_process_select(4u, b, 4u, out_b, &nb, &tb) != SPG_OK) {
+        return 1;
+    }
+    if (na != nb) {
+        return 1;
+    }
+    for (size_t i = 0u; i < na; i += 1u) {
+        if (out_a[i].pid != out_b[i].pid) {
+            printf("  order differs at %zu: %llu vs %llu\n", i,
+                   (unsigned long long)out_a[i].pid,
+                   (unsigned long long)out_b[i].pid);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int test_select_truncation(void) {
+    const struct spg_process_sample in[]   = {mk(1u, 100u, 0u, false),
+                                              mk(2u, 900u, 0u, true),
+                                              mk(3u, 500u, 0u, false)};
+    struct spg_process_sample       out[2] = {};
+    size_t                          n      = 0u;
+    bool                            trunc  = false;
+    if (spg_process_select(3u, in, 2u, out, &n, &trunc) != SPG_OK) {
+        return 1;
+    }
+    if (n != 2u || !trunc) {
+        return 1; /* dropping silently would read as "this is everything" */
+    }
+    if (out[0].pid != 2u || out[1].pid != 3u) {
+        return 1;
+    }
+    /* Empty input is legitimate, not an error. */
+    if (spg_process_select(0u, nullptr, 2u, out, &n, &trunc) != SPG_OK) {
+        return 1;
+    }
+    if (n != 0u || trunc) {
+        return 1;
+    }
+    return 0;
+}
+
+/* Unknown CPU must sort last, not as a huge number. */
+static int test_select_unknown_cpu(void) {
+    const struct spg_process_sample in[] = {
+        mk(1u, SPG_MACHINE_UNKNOWN, 0u, false), mk(2u, 10u, 0u, false)};
+    struct spg_process_sample out[2] = {};
+    size_t                    n      = 0u;
+    bool                      trunc  = false;
+    if (spg_process_select(2u, in, 2u, out, &n, &trunc) != SPG_OK) {
+        return 1;
+    }
+    return out[0].pid == 2u ? 0 : 1;
+}
+
+/* --- profile ------------------------------------------------------------ */
+
+static const char profile_ok[] = "(process-profile\n"
+                                 "  (process \"critical_app\"\n"
+                                 "    (match \"critical-worker\")\n"
+                                 "    (role critical)\n"
+                                 "    (may_pause false)\n"
+                                 "    (may_stop false))\n"
+                                 "  (process \"batch_job\"\n"
+                                 "    (match \"batch-worker\")\n"
+                                 "    (role batch)\n"
+                                 "    (may_pause true)\n"
+                                 "    (may_stop true)))\n";
+
+static enum spg_status load(const size_t n, const char text[],
+                            struct spg_process_profile *out) {
+    struct spg_sexpr_token           tokens[256];
+    struct spg_sexpr_node            nodes[256];
+    struct spg_process_profile_error error = {};
+    return spg_process_profile_load(n, text, 256u, tokens, 256u, nodes, out,
+                                    &error);
+}
+
+static int test_profile_parse(void) {
+    struct spg_process_profile p = {};
+    if (load(LIT(profile_ok), &p) != SPG_OK) {
+        return 1;
+    }
+    if (p.count != 2u) {
+        return 1;
+    }
+    if (strcmp(p.entries[0].id, "critical_app") != 0 ||
+        strcmp(p.entries[0].match, "critical-worker") != 0 ||
+        p.entries[0].role != SPG_PROCESS_ROLE_CRITICAL ||
+        p.entries[0].may_pause || p.entries[0].may_stop) {
+        return 1;
+    }
+    if (p.entries[1].role != SPG_PROCESS_ROLE_BATCH ||
+        !p.entries[1].may_pause || !p.entries[1].may_stop) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_profile_rejects(void) {
+    struct spg_process_profile p = {};
+    /* unbalanced */
+    if (load(LIT("(process-profile (process \"a\" (match \"x\")"), &p) ==
+        SPG_OK) {
+        return 1;
+    }
+    /* wrong top-level form */
+    if (load(LIT("(policy (network_default deny))"), &p) != SPG_E_SCHEMA) {
+        return 1;
+    }
+    /* unknown role: a typo must not silently become "unknown" and thereby
+     * strip a critical process of its protection */
+    if (load(LIT("(process-profile (process \"a\" (match \"x\") "
+                 "(role criticl) (may_pause false) (may_stop false)))"),
+             &p) != SPG_E_SCHEMA) {
+        return 1;
+    }
+    /* missing may_pause: permissions are never implicit */
+    if (load(LIT("(process-profile (process \"a\" (match \"x\") "
+                 "(role batch) (may_stop true)))"),
+             &p) != SPG_E_SCHEMA) {
+        return 1;
+    }
+    /* critical + may_pause is a contradiction, refused at parse time */
+    if (load(LIT("(process-profile (process \"a\" (match \"x\") "
+                 "(role critical) (may_pause true) (may_stop false)))"),
+             &p) != SPG_E_SCHEMA) {
+        return 1;
+    }
+    /* duplicate id makes a phase-6 action target ambiguous */
+    if (load(LIT("(process-profile "
+                 "(process \"a\" (match \"x\") (role batch) (may_pause true) "
+                 "(may_stop true)) "
+                 "(process \"a\" (match \"y\") (role batch) (may_pause true) "
+                 "(may_stop true)))"),
+             &p) != SPG_E_SCHEMA) {
+        return 1;
+    }
+    /* a match string longer than the field cannot be truncated silently */
+    if (load(LIT("(process-profile (process \"a\" (match \"aaaaaaaaaaaaaaaa"
+                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                 "aaaaaaaaaaa\") (role batch) (may_pause true) "
+                 "(may_stop true)))"),
+             &p) != SPG_E_SCHEMA) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_profile_empty(void) {
+    struct spg_process_profile p = {};
+    /* No profile at all is a valid configuration: nothing is managed. */
+    if (load(LIT("(process-profile)"), &p) != SPG_OK || p.count != 0u) {
+        return 1;
+    }
+    if (load(LIT(""), &p) != SPG_OK || p.count != 0u) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_profile_match(void) {
+    struct spg_process_profile p = {};
+    if (load(LIT(profile_ok), &p) != SPG_OK) {
+        return 1;
+    }
+    if (spg_process_profile_match(&p, "batch-worker") != 1u) {
+        return 1;
+    }
+    if (spg_process_profile_match(&p, "critical-worker") != 0u) {
+        return 1;
+    }
+    /* No substring matching: "batch-worker-2" is a different process. */
+    if (spg_process_profile_match(&p, "batch-worker-2") !=
+        SPG_PROCESS_NO_PROFILE) {
+        return 1;
+    }
+    if (spg_process_profile_match(&p, "sshd") != SPG_PROCESS_NO_PROFILE) {
+        return 1;
+    }
+    if (spg_process_profile_match(&p, "") != SPG_PROCESS_NO_PROFILE) {
+        return 1;
+    }
+    if (spg_process_profile_match(nullptr, "batch-worker") !=
+        SPG_PROCESS_NO_PROFILE) {
+        return 1;
+    }
+    return 0;
+}
+
+/* The kernel cuts comm at 15 characters. A profile naming the full binary must
+ * still match, or every long-named process silently loses its role. */
+static int test_profile_match_kernel_truncation(void) {
+    struct spg_process_profile p = {};
+    if (load(LIT("(process-profile (process \"a\" "
+                 "(match \"very-long-worker-name\") (role batch) "
+                 "(may_pause true) (may_stop true)))"),
+             &p) != SPG_OK) {
+        return 1;
+    }
+    if (spg_process_profile_match(&p, "very-long-worke") != 0u) {
+        return 1; /* 15 chars, what /proc actually reports */
+    }
+    /* A shorter name that merely shares a prefix must NOT match. */
+    if (spg_process_profile_match(&p, "very-long") != SPG_PROCESS_NO_PROFILE) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_profile_first_wins(void) {
+    struct spg_process_profile p = {};
+    if (load(LIT("(process-profile "
+                 "(process \"first\" (match \"dup\") (role critical) "
+                 "(may_pause false) (may_stop false)) "
+                 "(process \"second\" (match \"dup\") (role batch) "
+                 "(may_pause true) (may_stop true)))"),
+             &p) != SPG_OK) {
+        return 1;
+    }
+    /* Two entries match the same name: file order decides, deterministically,
+     * and the safer entry happens to be first here by construction. */
+    return spg_process_profile_match(&p, "dup") == 0u ? 0 : 1;
+}
+
+static int test_apply_profile(void) {
+    struct spg_process_profile p = {};
+    if (load(LIT(profile_ok), &p) != SPG_OK) {
+        return 1;
+    }
+    struct spg_process_sample procs[3] = {};
+    memcpy(procs[0].name, "batch-worker", sizeof "batch-worker");
+    memcpy(procs[1].name, "critical-worker", sizeof "critical-worker");
+    memcpy(procs[2].name, "sshd", sizeof "sshd");
+    spg_process_apply_profile(&p, 3u, procs);
+
+    if (procs[0].role != SPG_PROCESS_ROLE_BATCH || !procs[0].may_pause) {
+        return 1;
+    }
+    if (procs[1].role != SPG_PROCESS_ROLE_CRITICAL || procs[1].may_pause ||
+        procs[1].may_stop) {
+        return 1;
+    }
+    /* An unknown process is never implicitly pausable — this is the property
+     * phase 6 relies on to deny actions on unmanaged processes. */
+    if (procs[2].profile_index != SPG_PROCESS_NO_PROFILE ||
+        procs[2].role != SPG_PROCESS_ROLE_UNKNOWN || procs[2].may_pause ||
+        procs[2].may_stop) {
+        return 1;
+    }
+    return 0;
+}
+
+/* The buffer can never hold every process on a real host — a Pi 5 idles at
+ * ~170. Before this existed the enumerator sampled the first 64 /proc listed
+ * and selected from those, so the busiest process could be invisible while
+ * kernel threads at 0% filled the snapshot. That is what this pins. */
+static int test_offer_keeps_best(void) {
+    struct spg_process_sample buf[4] = {};
+    size_t                    n      = 0u;
+    /* Ten candidates, increasingly hot, offered coldest-first: the naive
+     * "take the first k" would keep exactly the wrong four. */
+    for (uint64_t i = 1u; i <= 10u; i += 1u) {
+        const struct spg_process_sample c = mk(i, i * 100u, 0u, false);
+        (void)spg_process_offer(4u, buf, &n, &c);
+    }
+    if (n != 4u) {
+        return 1;
+    }
+    for (size_t i = 0u; i < n; i += 1u) {
+        if (buf[i].cpu_bp < 700u) {
+            printf("  kept cold process cpu_bp=%llu\n",
+                   (unsigned long long)buf[i].cpu_bp);
+            return 1;
+        }
+    }
+    /* Same set offered hottest-first must keep the same four. */
+    struct spg_process_sample rev[4] = {};
+    size_t                    rn     = 0u;
+    for (uint64_t i = 10u; i >= 1u; i -= 1u) {
+        const struct spg_process_sample c = mk(i, i * 100u, 0u, false);
+        (void)spg_process_offer(4u, rev, &rn, &c);
+    }
+    if (rn != 4u) {
+        return 1;
+    }
+    for (size_t i = 0u; i < rn; i += 1u) {
+        if (rev[i].cpu_bp < 700u) {
+            return 1;
+        }
+    }
+    /* A managed process outranks any unmanaged one, however hot. */
+    struct spg_process_sample       mixed[2]     = {};
+    size_t                          mn           = 0u;
+    const struct spg_process_sample hot1         = mk(1u, 9000u, 0u, false);
+    const struct spg_process_sample hot2         = mk(2u, 8000u, 0u, false);
+    const struct spg_process_sample cold_managed = mk(3u, 1u, 0u, true);
+    (void)spg_process_offer(2u, mixed, &mn, &hot1);
+    (void)spg_process_offer(2u, mixed, &mn, &hot2);
+    if (!spg_process_offer(2u, mixed, &mn, &cold_managed)) {
+        return 1;
+    }
+    bool has_managed = false;
+    for (size_t i = 0u; i < mn; i += 1u) {
+        has_managed = has_managed || mixed[i].pid == 3u;
+    }
+    if (!has_managed) {
+        return 1;
+    }
+    if (spg_process_offer(0u, buf, &n, &hot1)) {
+        return 1;
+    }
+    return 0;
+}
+
+/* Exercises the process-aware sampler end to end. On Linux this is the only
+ * test that touches real /proc; elsewhere it pins the degradation. It also
+ * makes sure the entry point is actually declared in the header — a definition
+ * nobody calls compiles fine and is useless. */
+static int test_sample_with_processes(void) {
+    struct spg_machine_state first = {};
+    const enum spg_status    s1 =
+        spg_machine_sample_with_processes(1u, nullptr, 0u, nullptr, &first);
+    struct spg_machine_state second = {};
+    const enum spg_status    s2     = spg_machine_sample_with_processes(
+        2u, &first.cpu, first.n_processes, first.processes, &second);
+    if (second.timestamp_ns != 2u) {
+        return 1;
+    }
+#if defined(__linux__)
+    if (s1 != SPG_OK || s2 != SPG_OK) {
+        return 1;
+    }
+    /* Something is always running, starting with this test. */
+    if (first.n_processes == 0u || second.n_processes == 0u) {
+        return 1;
+    }
+    if (second.n_processes > SPG_MACHINE_MAX_PROCESSES) {
+        return 1;
+    }
+    /* Every sampled process must carry an identity — phase 6 depends on it. */
+    for (size_t i = 0u; i < second.n_processes; i += 1u) {
+        if (second.processes[i].pid == 0u ||
+            second.processes[i].name[0] == '\0') {
+            return 1;
+        }
+    }
+    /* A host with more processes than the snapshot holds must say so. */
+    if (second.process_count > SPG_MACHINE_MAX_PROCESSES &&
+        !second.processes_truncated) {
+        return 1;
+    }
+#else
+    if (s1 != SPG_E_UNSUPPORTED || s2 != SPG_E_UNSUPPORTED) {
+        return 1;
+    }
+    if (first.n_processes != 0u || second.n_processes != 0u) {
+        return 1;
+    }
+#endif
+    /* A non-empty prev list with a null pointer is a caller bug, not a crash.
+     */
+    struct spg_machine_state ignored = {};
+    if (spg_machine_sample_with_processes(3u, nullptr, 4u, nullptr, &ignored) !=
+        SPG_E_INVALID_ARG) {
+        return 1;
+    }
+    return 0;
+}
+
+int main(void) {
+    const struct {
+        const char *name;
+        int (*fn)(void);
+    } cases[] = {
+        {"parse_basic", test_parse_basic},
+        {"parse_awkward_name", test_parse_awkward_name},
+        {"parse_control_chars", test_parse_control_chars},
+        {"parse_malformed", test_parse_malformed},
+        {"parse_null", test_parse_null},
+        {"utilisation", test_utilisation},
+        {"find_identity", test_find_identity},
+        {"select_priority", test_select_priority},
+        {"select_permutation_invariant", test_select_permutation_invariant},
+        {"select_truncation", test_select_truncation},
+        {"select_unknown_cpu", test_select_unknown_cpu},
+        {"profile_parse", test_profile_parse},
+        {"profile_rejects", test_profile_rejects},
+        {"profile_empty", test_profile_empty},
+        {"profile_match", test_profile_match},
+        {"profile_match_kernel_truncation",
+         test_profile_match_kernel_truncation},
+        {"profile_first_wins", test_profile_first_wins},
+        {"apply_profile", test_apply_profile},
+        {"offer_keeps_best", test_offer_keeps_best},
+        {"sample_with_processes", test_sample_with_processes},
+    };
+    int failures = 0;
+    for (size_t i = 0u; i < sizeof cases / sizeof cases[0]; i += 1u) {
+        if (cases[i].fn() != 0) {
+            printf("test_machine_process: FAIL %s\n", cases[i].name);
+            failures += 1;
+        }
+    }
+    if (failures == 0) {
+        printf("test_machine_process: PASS\n");
+    }
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Phase 2 der Roadmap (#62). Stapelt auf #82. Der Agent sieht ab jetzt **wer** die Maschine verbraucht und **was dieser Prozess bedeutet** — noch immer read-only, Pausieren ist Phase 6 (#66). Der Journal-Freeze aus Phase 0 bleibt grün: kein Agent-Pfad ruft das hier auf.

## Was bewusst nicht erfasst wird

Keine Command Line, keine Environment-Variablen, kein Benutzername. Diese Felder tragen regelmäßig Secrets (`--password=`, `AWS_SECRET_…`) und wären ab Phase 3 Prompt-Injection-Fläche im Model-Context. Was nicht erfasst wird, kann nicht leaken.

## Identität statt PID

`start_identity` (Kernel-Startzeit) bildet zusammen mit der PID die Prozessidentität. PIDs werden wiederverwendet: Ein Agent, der in Tick 1 „PID 4711 verbraucht 90 % CPU" beobachtet und in Tick 2 `SIGSTOP` an 4711 schickt, trifft womöglich einen anderen Prozess.

- `spg_process_find()` sucht über PID **und** Identität.
- Per-Prozess-CPU liefert `unknown`, wenn die Identität wechselte — lieber kein Wert als ein erfundener.
- Ein `/proc/<pid>/stat`, das vor Feld 22 abbricht, wird komplett verworfen: ein Sample ohne Identität darf Phase 6 nie erreichen.

## Der Name ist kein Weg

`comm` schreibt der Kernel unescaped in Klammern und darf Leerzeichen und `)` enthalten — `"weird (name) here"` ist legal. Der Parser verankert sich an der **letzten** `)` der Zeile. Zusätzlich kürzt der Kernel auf 15 Zeichen, was das Matching berücksichtigt:

| Profil `match` | `/proc` meldet | Trifft |
|---|---|---|
| `batch-worker` | `batch-worker` | ja |
| `very-long-worker-name` | `very-long-worke` | ja (Kernel-Kürzung) |
| `batch-worker` | `batch-worker-2` | nein |
| `very-long-worker-name` | `very-long` | nein |

Steuerzeichen werden zu `?`, sonst zerlegt ein Prozessname ab Phase 3 die S-Expression, aus der der Context besteht.

## Was das Profil ablehnt

`role`, `may_pause`, `may_stop` sind typed Felder, kein Prompt-Text. Der Parser weist zurück: unbekannte Rolle (ein Tippfehler darf einen kritischen Prozess nicht zu `unknown` degradieren), fehlendes `may_pause` (Berechtigungen sind nie implizit), `critical` + `may_pause`, doppelte `id` (mehrdeutiges Action-Target in Phase 6), zu lange `match`-Strings (still gekürzt träfen sie den falschen Prozess). Ein Prozess ohne Treffer bekommt `role unknown` und beide Berechtigungen `false` — darauf baut Phase 6.

## Auswahl ist deterministisch

Höchstens 64 Prozesse, Reihenfolge: gemanagt > CPU > RSS > PID. Die PID-Stufe ist nicht Kosmetik — `/proc` garantiert keine Reihenfolge, und wenn die Enumerationsreihenfolge durchschlüge, unterschiede sich der Context zwischen zwei identischen Läufen und Replay wäre tot. Ein Test permutiert die Eingabe und verlangt bitgleiche Ausgabe. `unknown` sortiert hinten, nicht als Riesenwert.

## Verifikation

`make test`: grün, exit 0, 26 PASS, ASan/UBSan sauber. 18 Testfälle über statische Fixtures, kein Zugriff auf `/proc`.

**Nicht verifiziert:** wie zuvor der Linux-Pfad. Die Enumeration (`readdir` über `/proc`, `sysconf(_SC_PAGESIZE)`, Prozesse die zwischen `readdir` und `open` verschwinden) ist auf dieser macOS-Maschine nie gelaufen. Das wächst sich zum zweiten ungetesteten I/O-Pfad aus — vor Phase 3 sollte einmal ein Pi oder Linux-Runner dran.

Doku: `docs/machine-intelligence/Processes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
