### PR TITLE
Phase 3: Machine State im Agent Context, opt-in und begrenzt

### DIFF
--- a/docs/machine-intelligence/Context.md
+++ b/docs/machine-intelligence/Context.md
@@ -1,0 +1,153 @@
+# Context — Phase 3
+
+Der Machine State erreicht den Agent Context. Das Modell kann die Maschine
+**beobachten**, ohne dass wir ihm dafür Shell-Zugriff geben.
+
+Ticket: geisten/geistshell#63. Voraussetzungen: [Telemetry.md](Telemetry.md),
+[Processes.md](Processes.md). Keine neue Action — das ist Phase 6 (#66).
+
+## Der exakte Block
+
+```
+(machine-state (cpu-load-bp 9200) (load-1-cbp 175) (memory-total-bytes 4245815296)
+ (memory-used-bytes 1682931712) (swap-used-bytes 542932992) (temperature-mc 47950)
+ (cpu-freq-khz 1500000) (throttle none) (process-count 167)
+ (process (id "critical_app") (role critical) (cpu-bp 5400) (rss-bytes 4096))
+ (process (id "batch_job") (role batch) (cpu-bp 3100) (rss-bytes 8192))
+ (processes-dropped 98))
+```
+
+Gerendert nach `(budgets ...)`, vor Graph und Memory. Feste Feldreihenfolge,
+feste Prozessreihenfolge (die aus `spg_process_select`), nur Ganzzahlen.
+
+### `id` statt Name und PID
+
+Eine Form für alle Prozesse: `id` ist die Profil-ID, wenn der Prozess gemanagt
+ist, sonst der Prozessname. Zwei Formen würden ein kleines Modell Genauigkeit
+kosten, ohne etwas zu gewinnen.
+
+Die **PID fehlt bewusst**. Das Modell braucht sie nie: eine Phase-6-Action
+zielt auf die Profil-ID, und der Executor validiert die Identität selbst
+(PID + Startzeit, siehe [Processes.md](Processes.md)). Eine PID im Context wäre
+eine Zahl, die das Modell zu benutzen versucht und die zwischen Beobachtung und
+Ausführung ungültig werden kann.
+
+Ebenso nicht im Context: Command Line, Environment, Benutzername, Pfade.
+
+### Trunkierung ist sichtbar
+
+`(processes-dropped N)` erscheint, sobald die Auswahl etwas verworfen hat. Eine
+gekürzte Liste, die vollständig aussieht, lädt das Modell zu falschen Schlüssen
+ein („nur diese drei Prozesse laufen"). Ist die Gesamtzahl unbekannt, steht dort
+`unknown` statt einer erfundenen Zahl.
+
+## Standardmäßig abwesend
+
+Ohne `--machine` (bzw. ohne gesetztes `sources.machine`) ist der Context
+**byte-identisch** zu vorher. Das ist keine Bequemlichkeit, sondern die
+Voraussetzung dafür, dass der Journal-Freeze aus [Baseline.md](Baseline.md)
+weiter etwas aussagt: er prüft den Default-Pfad.
+
+Ein CLI-Test fährt denselben Lauf zweimal — mit und ohne Flag — und verlangt,
+dass der Block im einen Fall wohlgeformt auftaucht und im anderen gar nicht.
+
+## Auf Hardware verifiziert
+
+Pi 5, Kernel 6.18. Gemessener Block eines echten Laufs mit Profil:
+
+```
+(machine-state (cpu-load-bp unknown) (load-1-cbp 33) (memory-total-bytes 4245815296)
+ (memory-used-bytes 1683259392) (swap-used-bytes 542523392) (temperature-mc 50700)
+ (cpu-freq-khz 2200000) (throttle none) (process-count 167)
+ (process (id "critical_app") (role critical) (cpu-bp unknown) (rss-bytes 849444864))
+ (process (id "batch_job") (role batch) (cpu-bp unknown) (rss-bytes 360660992))
+ (process (id "dockerd") (role unknown) (cpu-bp unknown) (rss-bytes 31211520))
+ ...)
+```
+
+Gemanagte Prozesse zuerst, mit ihrer Rolle und ihrer Profil-ID; danach nach
+Speicher absteigend. Blockgröße rund 2,7 KB.
+
+## Kontextkosten
+
+Gemessen mit dem Renderer:
+
+| Inhalt | Bytes |
+|---|---|
+| Nur Systemfelder, keine Prozesse | 224 |
+| + 8 Prozesse | 872 |
+| + 16 Prozesse | 1496 |
+| + 64 Prozesse (Obergrenze) | 5240 |
+
+Am realen Lauf: das Journal eines Ein-Tick-Agentenlaufs wächst von 2340 auf
+2573 Bytes (+233), weil auf der Entwicklungsmaschine alle Werte `unknown` sind
+und keine Prozesse anfallen.
+
+`SPG_MACHINE_RENDER_CAP` (8192) ist die Obergrenze, aus der ein Aufrufer einen
+Stack-Puffer dimensionieren kann; ein Test füllt einen Snapshot mit 64
+maximallangen Einträgen und verlangt, dass er hineinpasst.
+
+**Offene Konsequenz für kleine Modelle:** 64 Prozesse sind über 5 KB und
+konkurrieren im Fenster mit der Lesson-Injection aus P6 (#3). Für ein Modell mit
+kurzem Fenster ist die Prozessgrenze vermutlich deutlich kleiner zu wählen —
+welche Felder wirklich nötig sind, misst Phase 11 (#71).
+
+## Determinismus
+
+- Gleicher Snapshot ⇒ byte-identischer Context (Test vergleicht zwei Renderings).
+- Die Reihenfolge der OS-Prozessliste ändert das Ergebnis nicht (Permutations-
+  test in Phase 2, die Auswahl liefert die Reihenfolge).
+- Locale-unabhängig: der Block enthält ausschließlich Ganzzahlen. Ein Test
+  rendert unter `de_DE.UTF-8` und vergleicht Byte für Byte mit `C`.
+- Prozessnamen werden escaped (`"` und `\` maskiert). Steuerzeichen hat schon
+  der Parser in Phase 2 entfernt. Ein Test verlangt für einen Namen wie
+  `ev"il\x` balancierte Klammern — sonst könnte ein Prozessname den Block
+  vorzeitig schließen und der Rest würde als Anweisung gelesen (Vorgriff auf
+  #76, Angriff 12).
+
+## Prozesse ohne Signal fallen raus
+
+Ein Prozess ohne Speicher und ohne messbare CPU trägt keine Information. Auf
+einem Pi 5 sind das rund 100 Kernel-Threads, die im ersten Hardwaretest **58 von
+64 Kontextplätzen** mit `(rss-bytes 0)` füllten — rund 4 KB, in denen kein Satz
+etwas aussagt. Sie werden vor der Auswahl verworfen.
+
+Gemanagte Prozesse sind ausgenommen: ein pausierter Batch-Job, der gerade nichts
+kostet, ist genau das, was das Modell weiterhin sehen muss.
+
+Das Profil wird **während** der Enumeration angewendet, nicht danach. Sonst
+liefe die Regel „gemanagte Prozesse zuerst" ins Leere — die Auswahl sortiert
+nach einer Rolle, die zu diesem Zeitpunkt noch niemand gesetzt hätte. Auch das
+zeigte erst der Pi: ohne diesen Schritt trug jeder Prozess im Context
+`role unknown`.
+
+`--process-profile <datei>` lädt das Profil aus Phase 2 und impliziert
+`--machine`.
+
+## Ein Sample pro Lauf, nicht pro Tick
+
+`--machine` sampelt einmal beim Start. Das genügt für diese Phase: sie
+beweist, dass der State im Context ankommt. Ein neuer Snapshot pro Tick wird
+erst sinnvoll, wenn es eine Action gibt, deren Wirkung beobachtet werden muss —
+das ist Phase 7 (#67), und sie ändert dafür genau eine Stelle.
+
+Auch hier liest nichts eine Uhr: der Zeitstempel kommt aus demselben injizierten
+Zähler wie beim Journal.
+
+**Konsequenz, die man kennen muss:** mit einem einzigen Sample ist `cpu-bp` für
+jeden Prozess `unknown` — CPU ist ein Delta. Das Modell sieht in dieser Phase
+also Speicher, Temperatur und Rollen, aber keine Prozess-CPU. Ab Phase 7, die
+pro Tick neu beobachtet, ist der Wert da.
+
+## Abweichung vom Ticket
+
+Das Ticket verlangte einen erweiterten Eval Case als Nachweis. Stattdessen gibt
+es `test/test_cli_machine.sh`: derselbe Lauf zweimal, einmal mit und einmal ohne
+`--machine`, mit Prüfung des tatsächlich journalten Model-Inputs auf
+Wohlgeformtheit und Pflichtfelder. Das prüft dieselbe Eigenschaft näher an der
+Realität — der Nachweis führt über das Journal, nicht über eine Testfixture.
+
+## Was Phase 3 nicht tut
+
+Keine Action, kein History-Fenster (#79), keine Diagnose (#64). Kein
+Modellverhalten wird hier gemessen.

--- a/include/geistshell/actor.h
+++ b/include/geistshell/actor.h
@@ -4,6 +4,7 @@
 #include "geistshell/context.h"
 #include "geistshell/graph.h"
 #include "geistshell/journal.h"
+#include "geistshell/machine_state.h"
 #include "geistshell/memory.h"
 #include "geistshell/model_adapter.h"
 #include "geistshell/policy.h"
@@ -19,10 +20,10 @@ extern "C" {
 #endif
 
 struct spg_actor_state {
-    struct spg_graph         *graph;
-    struct spg_memory        *memory;
+    struct spg_graph          *graph;
+    struct spg_memory         *memory;
     struct spg_journal_writer *journal;
-    struct spg_model_adapter *model;
+    struct spg_model_adapter  *model;
 
     const struct spg_run_config   *run;
     const struct spg_policy_usage *usage;
@@ -39,6 +40,8 @@ struct spg_actor_state {
     const char *exemplars;
     const char *goal;
     const char *directive;
+    /* Optional machine snapshot for the context (roadmap phase 3). */
+    const struct spg_machine_state *machine;
 };
 
 struct spg_actor_step_config {
@@ -98,10 +101,10 @@ struct spg_actor_step_result {
 };
 
 [[nodiscard]] enum spg_status
-spg_actor_step(struct spg_actor_state *state,
-               const struct spg_actor_step_config *config,
+spg_actor_step(struct spg_actor_state                *state,
+               const struct spg_actor_step_config    *config,
                const struct spg_actor_step_workspace *workspace,
-               struct spg_actor_step_result *result);
+               struct spg_actor_step_result          *result);
 
 #ifdef __cplusplus
 }

--- a/include/geistshell/agent_run.h
+++ b/include/geistshell/agent_run.h
@@ -21,31 +21,36 @@ extern "C" {
  * loaded configs and a (caller-initialized) model adapter, then drive the
  * governed agent loop to termination. This is the single reusable "run a
  * governed agent" primitive shared by the CLI `agent` command and the eval
- * harness, so both are byte-identical and a production self-improvement loop can
- * call it directly. The runner owns the ephemeral graph/memory; the caller owns
- * the model, journal, store, configs, and the scratch buffers. */
+ * harness, so both are byte-identical and a production self-improvement loop
+ * can call it directly. The runner owns the ephemeral graph/memory; the caller
+ * owns the model, journal, store, configs, and the scratch buffers. */
 
 struct spg_agent_run_inputs {
-    struct spg_model_adapter       *model;       /* required, initialized */
-    const struct spg_policy_config *policy;      /* required */
+    struct spg_model_adapter       *model;  /* required, initialized */
+    const struct spg_policy_config *policy; /* required */
     size_t                          policy_text_n;
     const char                     *policy_text; /* required */
     const struct spg_run_config    *run;         /* required (budgets) */
     struct spg_sim_config          *sim;         /* nullable (no simulator) */
     struct spg_mem_store           *store;       /* nullable (no memory) */
-    struct spg_journal_writer      *journal;     /* nullable (no audit/trajectory) */
+    struct spg_journal_writer *journal; /* nullable (no audit/trajectory) */
     /* Optional concrete worked examples of the recommendation form, rendered
      * in the context's (examples ...) section — few-shot so a small model can
      * imitate the DSL rather than parse the schema grammar. Null = none. */
-    const char                     *exemplars;
+    const char *exemplars;
     /* Optional free-text task, rendered as (goal "..."). Null = none. */
-    const char                     *goal;
+    const char *goal;
+    /* Optional machine telemetry snapshot for the context (roadmap phase 3).
+     * Null = none, the default: the context is then byte-identical to before
+     * machine state existed, which the phase-0 journal freeze relies on. */
+    const struct spg_machine_state *machine;
 };
 
 struct spg_agent_run_config {
-    size_t   max_steps;
-    size_t   max_repairs;
-    bool     finish_on_no_progress; /* #40: converge -> FINISHED (see agent_loop.h) */
+    size_t max_steps;
+    size_t max_repairs;
+    bool finish_on_no_progress; /* #40: converge -> FINISHED (see agent_loop.h)
+                                 */
     bool     execution_enabled;
     uint64_t exec_timeout_ms;
     size_t   exec_stdout_cap;
@@ -63,46 +68,46 @@ struct spg_agent_run_config {
 /* Caller-owned scratch. All buffers must be non-null with non-zero capacity
  * (except shell_* which may be null when execution is never used). */
 struct spg_agent_run_workspace {
-    size_t                  context_capacity;
-    char                   *context;
-    size_t                  model_output_capacity;
-    char                   *model_output;
-    size_t                  graph_ref_capacity;
-    struct spg_context_graph_ref *graph_refs;
-    size_t                  memory_ref_capacity;
-    struct spg_context_memory_ref *memory_refs;
-    size_t                  journal_ref_capacity;
+    size_t                          context_capacity;
+    char                           *context;
+    size_t                          model_output_capacity;
+    char                           *model_output;
+    size_t                          graph_ref_capacity;
+    struct spg_context_graph_ref   *graph_refs;
+    size_t                          memory_ref_capacity;
+    struct spg_context_memory_ref  *memory_refs;
+    size_t                          journal_ref_capacity;
     struct spg_context_journal_ref *journal_refs;
-    size_t                  token_capacity;
-    struct spg_sexpr_token *tokens;
-    size_t                  node_capacity;
-    struct spg_sexpr_node  *nodes;
-    size_t                  policy_payload_capacity;
-    char                   *policy_payload;
-    size_t                  sim_payload_capacity;
-    char                   *sim_payload;
-    size_t                  observation_capacity;
-    char                   *observation; /* also receives the final observation */
-    size_t                  shell_stdout_capacity;
-    char                   *shell_stdout;
-    size_t                  shell_stderr_capacity;
-    char                   *shell_stderr;
-    size_t                  trajectory_capacity;
+    size_t                          token_capacity;
+    struct spg_sexpr_token         *tokens;
+    size_t                          node_capacity;
+    struct spg_sexpr_node          *nodes;
+    size_t                          policy_payload_capacity;
+    char                           *policy_payload;
+    size_t                          sim_payload_capacity;
+    char                           *sim_payload;
+    size_t                          observation_capacity;
+    char  *observation; /* also receives the final observation */
+    size_t shell_stdout_capacity;
+    char  *shell_stdout;
+    size_t shell_stderr_capacity;
+    char  *shell_stderr;
+    size_t trajectory_capacity;
     struct spg_journal_record_header *trajectory;
     /* Optional: when inputs->store is set, the mind-palace index is rendered
      * here each step and injected into context (so lessons/memories recall). */
-    size_t                  memory_index_capacity;
-    char                   *memory_index;
+    size_t memory_index_capacity;
+    char  *memory_index;
 };
 
 /* Runs the loop, filling *usage (zeroed first) and *result. Returns
  * SPG_E_INVALID_ARG on missing required inputs; otherwise the loop's status. */
 [[nodiscard]] enum spg_status
-spg_agent_run(const struct spg_agent_run_inputs *inputs,
-              const struct spg_agent_run_config *config,
+spg_agent_run(const struct spg_agent_run_inputs    *inputs,
+              const struct spg_agent_run_config    *config,
               const struct spg_agent_run_workspace *workspace,
-              struct spg_policy_usage *usage,
-              struct spg_agent_loop_result *result);
+              struct spg_policy_usage              *usage,
+              struct spg_agent_loop_result         *result);
 
 #ifdef __cplusplus
 }

--- a/include/geistshell/context.h
+++ b/include/geistshell/context.h
@@ -3,6 +3,7 @@
 
 #include "geistshell/graph.h"
 #include "geistshell/journal.h"
+#include "geistshell/machine_state.h"
 #include "geistshell/memory.h"
 #include "geistshell/policy.h"
 #include "geistshell/run_config.h"
@@ -23,33 +24,37 @@ struct spg_context_limits {
 };
 
 struct spg_context_sources {
-    const struct spg_run_config       *run;
-    const struct spg_policy_usage     *usage;
-    const struct spg_graph            *graph;
-    const struct spg_memory           *memory;
-    size_t                             journal_header_count;
+    const struct spg_run_config            *run;
+    const struct spg_policy_usage          *usage;
+    const struct spg_graph                 *graph;
+    const struct spg_memory                *memory;
+    size_t                                  journal_header_count;
     const struct spg_journal_record_header *journal_headers;
-    size_t                             graph_text_n;
-    const char                        *graph_text;
-    size_t                             memory_text_n;
-    const char                        *memory_text;
+    size_t                                  graph_text_n;
+    const char                             *graph_text;
+    size_t                                  memory_text_n;
+    const char                             *memory_text;
     /* Pre-rendered long-term memory index (one hook per line), or null. */
-    const char                        *memory_index;
+    const char *memory_index;
     /* Content of the most recently recalled memory (memory_read), or null. */
-    const char                        *observation;
+    const char *observation;
     /* Optional concrete worked examples of the recommendation form, rendered
      * right after the (contract ...) schema. The schema is a grammar; a small
      * model imitates filled-in examples far more reliably than it parses a
      * grammar. Null = none (unchanged behaviour). */
-    const char                        *exemplars;
+    const char *exemplars;
     /* Optional free-text task, rendered near the top as (goal "..."). Null =
      * none: the scenario graph is the whole task. */
-    const char                        *goal;
+    const char *goal;
+    /* Optional machine telemetry snapshot, rendered as (machine-state ...).
+     * Null = none, which is the default and keeps the context byte-identical
+     * to before this existed — the phase-0 journal freeze depends on that. */
+    const struct spg_machine_state *machine;
     /* Optional standing directive (a learned lesson) rendered prominently as
      * (directive "...") every step — a stronger channel than the mind-palace
      * index for steering a small model's behaviour (geistshell#40 follow-up).
      * Null = none. */
-    const char                        *directive;
+    const char *directive;
 };
 
 struct spg_context_budget_item {
@@ -108,23 +113,22 @@ struct spg_context_view {
 };
 
 void spg_context_view_init(
-    struct spg_context_view *view,
-    size_t graph_ref_capacity,
-    struct spg_context_graph_ref graph_refs[static graph_ref_capacity],
-    size_t memory_ref_capacity,
-    struct spg_context_memory_ref memory_refs[static memory_ref_capacity],
-    size_t journal_ref_capacity,
+    struct spg_context_view *view, size_t graph_ref_capacity,
+    struct spg_context_graph_ref   graph_refs[static graph_ref_capacity],
+    size_t                         memory_ref_capacity,
+    struct spg_context_memory_ref  memory_refs[static memory_ref_capacity],
+    size_t                         journal_ref_capacity,
     struct spg_context_journal_ref journal_refs[static journal_ref_capacity]);
 
 [[nodiscard]] enum spg_status
 spg_context_build(const struct spg_context_sources *sources,
-                  const struct spg_context_limits *limits,
-                  struct spg_context_view *view);
+                  const struct spg_context_limits  *limits,
+                  struct spg_context_view          *view);
 
-[[nodiscard]] enum spg_status spg_context_render(
-    const struct spg_context_sources *sources,
-    const struct spg_context_view *view, size_t dst_capacity,
-    char dst[static dst_capacity], size_t *out_required);
+[[nodiscard]] enum spg_status
+spg_context_render(const struct spg_context_sources *sources,
+                   const struct spg_context_view *view, size_t dst_capacity,
+                   char dst[static dst_capacity], size_t *out_required);
 
 #ifdef __cplusplus
 }

--- a/include/geistshell/machine_state.h
+++ b/include/geistshell/machine_state.h
@@ -3,6 +3,7 @@
 
 #include "geistshell/status.h"
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -61,6 +62,16 @@ struct spg_load_sample {
 /* profile_index of a process no profile entry matched. */
 #define SPG_PROCESS_NO_PROFILE UINT32_MAX
 
+/* Profile id length. Lives here, not in process_profile.h, because a sample
+ * carries the id it matched — process_profile.h includes this header, so the
+ * dependency can only point one way. */
+#define SPG_PROCESS_ID_CAP 32u
+
+/* Upper bound on a rendered (machine-state ...) block: the header fields plus
+ * SPG_MACHINE_MAX_PROCESSES process entries. A caller can size a stack buffer
+ * from this and never truncate. */
+#define SPG_MACHINE_RENDER_CAP 8192u
+
 /* Semantic role, supplied by the process profile — never guessed from the
  * name. Phase 6 turns may_pause/may_stop into policy decisions, so these are
  * typed fields and not prompt text. */
@@ -85,11 +96,34 @@ struct spg_process_sample {
     uint64_t cpu_bp;   /* share of one tick's total CPU, UNKNOWN without prev */
     uint64_t rss_bytes;
 
-    /* Filled from the profile by spg_process_apply_profile. */
+    /* Filled from the profile by spg_process_apply_profile. The id is copied
+     * rather than looked up: it is what the context shows and what a phase-6
+     * action targets, so the sample must be self-contained. */
     uint32_t              profile_index;
+    char                  profile_id[SPG_PROCESS_ID_CAP];
     enum spg_process_role role;
     bool                  may_pause;
     bool                  may_stop;
+};
+
+#define SPG_PROCESS_MATCH_CAP 64u
+#define SPG_PROCESS_PROFILE_CAP 16u
+
+/* Which processes are managed, and what may be done to them. The type lives
+ * here rather than in process_profile.h because the sampler must apply it
+ * before selection ranks by role; the DSL that parses it stays in
+ * process_profile.h. */
+struct spg_process_profile_entry {
+    char                  id[SPG_PROCESS_ID_CAP];
+    char                  match[SPG_PROCESS_MATCH_CAP];
+    enum spg_process_role role;
+    bool                  may_pause;
+    bool                  may_stop;
+};
+
+struct spg_process_profile {
+    size_t                           count;
+    struct spg_process_profile_entry entries[SPG_PROCESS_PROFILE_CAP];
 };
 
 /* Raspberry Pi exposes a throttling bitmask; most hosts expose nothing. */
@@ -193,9 +227,9 @@ spg_process_find(size_t n, const struct spg_process_sample procs[],
  * processes /proc happened to list, so the busiest process could be invisible
  * while kernel threads at 0% filled the snapshot. Ranking is the same as
  * spg_process_select's. */
-[[nodiscard]] bool spg_process_offer(
-    size_t cap, struct spg_process_sample buf[], size_t *n,
-    const struct spg_process_sample *candidate);
+[[nodiscard]] bool
+spg_process_offer(size_t cap, struct spg_process_sample buf[], size_t *n,
+                  const struct spg_process_sample *candidate);
 
 /* Pick which processes reach the snapshot, in a fixed order:
  *   1. profile-managed processes  2. CPU descending
@@ -234,17 +268,31 @@ spg_machine_sample(uint64_t timestamp_ns, const struct spg_cpu_sample *prev,
  * delta. Processes are matched by pid AND start identity: a recycled pid does
  * not inherit the old process's counters, it reports unknown. prev_procs may
  * be null when prev_n is 0. */
+/* profile may be null (nothing managed). It is applied per sample, before
+ * selection: selection ranks managed processes first, so applying it later
+ * would make that rule a no-op — and a managed process that currently costs
+ * nothing must still reach the snapshot. */
 [[nodiscard]] enum spg_status spg_machine_sample_with_processes(
     uint64_t timestamp_ns, const struct spg_cpu_sample *prev, size_t prev_n,
-    const struct spg_process_sample prev_procs[],
-    struct spg_machine_state       *out);
+    const struct spg_process_sample   prev_procs[],
+    const struct spg_process_profile *profile, struct spg_machine_state *out);
 
 /* --- layer 3: serialisation --------------------------------------------- */
 
 /* Deterministic s-expression: fixed field order, unknown values as the symbol
  * `unknown`. Identical input always yields identical bytes. Writes at most
  * dst_capacity bytes including the NUL; on SPG_E_LIMIT *out_required holds the
- * size needed and dst holds no partial record. */
+ * size needed and dst holds no partial record.
+ *
+ * Processes render in snapshot order (already ranked by spg_process_select) as
+ *   (process (id "batch_job") (role batch) (cpu-bp 3100) (rss-bytes 1024))
+ * where id is the profile id for a managed process and the process name
+ * otherwise — one shape, because two would cost a small model accuracy. The
+ * pid is deliberately absent: the model never needs it, and a phase-6 action
+ * targets the profile id while the executor re-validates identity itself.
+ *
+ * When processes were dropped, a trailing (processes-dropped N) says so. A
+ * short list that looks complete would invite wrong conclusions. */
 [[nodiscard]] enum spg_status
 spg_machine_state_render(const struct spg_machine_state *state,
                          size_t dst_capacity, char dst[static dst_capacity],

--- a/include/geistshell/orchestrator.h
+++ b/include/geistshell/orchestrator.h
@@ -35,6 +35,8 @@ struct spg_orchestrator_state {
     struct spg_graph          *graph;
     struct spg_memory         *memory;
     struct spg_journal_writer *journal;
+    /* Optional machine snapshot for the context (roadmap phase 3). */
+    const struct spg_machine_state *machine;
     struct spg_model_adapter  *model;
     struct spg_sim_config     *sim;
     struct spg_mem_store      *store;

--- a/include/geistshell/process_profile.h
+++ b/include/geistshell/process_profile.h
@@ -34,23 +34,6 @@ extern "C" {
  * config text (which is what policy_config does): a profile outlives the buffer
  * it was parsed from and is compared against process names every tick. */
 
-#define SPG_PROCESS_ID_CAP 32u
-#define SPG_PROCESS_MATCH_CAP 64u
-#define SPG_PROCESS_PROFILE_CAP 16u
-
-struct spg_process_profile_entry {
-    char                  id[SPG_PROCESS_ID_CAP];
-    char                  match[SPG_PROCESS_MATCH_CAP];
-    enum spg_process_role role;
-    bool                  may_pause;
-    bool                  may_stop;
-};
-
-struct spg_process_profile {
-    size_t                           count;
-    struct spg_process_profile_entry entries[SPG_PROCESS_PROFILE_CAP];
-};
-
 struct spg_process_profile_error {
     enum spg_status status;
     uint32_t        node_index;

--- a/src/actor/actor.c
+++ b/src/actor/actor.c
@@ -20,11 +20,12 @@ static bool workspace_valid(const struct spg_actor_step_workspace *workspace) {
     return true;
 }
 
-static enum spg_status append_journal(
-    struct spg_journal_writer *writer, const bool enabled,
-    const uint64_t timestamp_ns, uint64_t *parent_sequence,
-    const enum spg_journal_event_kind kind, const enum spg_status event_status,
-    const size_t payload_n, const char payload[], uint64_t *out_sequence) {
+static enum spg_status
+append_journal(struct spg_journal_writer *writer, const bool enabled,
+               const uint64_t timestamp_ns, uint64_t *parent_sequence,
+               const enum spg_journal_event_kind kind,
+               const enum spg_status event_status, const size_t payload_n,
+               const char payload[], uint64_t *out_sequence) {
     if (!enabled) {
         if (out_sequence != nullptr) {
             *out_sequence = 0u;
@@ -44,15 +45,17 @@ static enum spg_status append_journal(
     return status;
 }
 
-static enum spg_status add_graph_updates(
-    struct spg_graph *graph, const uint32_t actor_id, const size_t context_n,
-    const size_t output_n, struct spg_actor_step_result *result) {
+static enum spg_status add_graph_updates(struct spg_graph *graph,
+                                         const uint32_t    actor_id,
+                                         const size_t      context_n,
+                                         const size_t      output_n,
+                                         struct spg_actor_step_result *result) {
     if (graph == nullptr || result == nullptr) {
         return SPG_E_INVALID_ARG;
     }
 
     struct spg_node_id model_input = {};
-    enum spg_status status = spg_graph_add_node(
+    enum spg_status    status      = spg_graph_add_node(
         graph, SPG_GRAPH_NODE_OBSERVATION, actor_id,
         (struct spg_text_span){.offset = 0u, .length = context_n},
         &model_input);
@@ -63,7 +66,7 @@ static enum spg_status add_graph_updates(
     result->model_input_node     = model_input;
 
     struct spg_node_id recommendation = {};
-    status = spg_graph_add_node(
+    status                            = spg_graph_add_node(
         graph, SPG_GRAPH_NODE_PLAN, actor_id,
         (struct spg_text_span){.offset = 0u, .length = output_n},
         &recommendation);
@@ -73,13 +76,13 @@ static enum spg_status add_graph_updates(
     result->has_recommendation_node = true;
     result->recommendation_node     = recommendation;
 
-    status = spg_graph_set_scores(
-        graph, recommendation,
-        (struct spg_graph_scores){.confidence    = 0.5f,
-                                  .utility       = 0.5f,
-                                  .risk          = 0.0f,
-                                  .novelty       = 0.5f,
-                                  .cost_estimate = 0.0f});
+    status =
+        spg_graph_set_scores(graph, recommendation,
+                             (struct spg_graph_scores){.confidence    = 0.5f,
+                                                       .utility       = 0.5f,
+                                                       .risk          = 0.0f,
+                                                       .novelty       = 0.5f,
+                                                       .cost_estimate = 0.0f});
     if (status != SPG_OK) {
         return status;
     }
@@ -89,14 +92,16 @@ static enum spg_status add_graph_updates(
                               recommendation, model_input, &edge);
 }
 
-static enum spg_status add_memory_update(
-    struct spg_memory *memory, const uint64_t source_event_id,
-    const bool has_graph_node, const struct spg_node_id graph_node,
-    const size_t output_n, struct spg_actor_step_result *result) {
+static enum spg_status add_memory_update(struct spg_memory *memory,
+                                         const uint64_t     source_event_id,
+                                         const bool         has_graph_node,
+                                         const struct spg_node_id graph_node,
+                                         const size_t             output_n,
+                                         struct spg_actor_step_result *result) {
     if (memory == nullptr || result == nullptr || source_event_id == 0u) {
         return SPG_E_INVALID_ARG;
     }
-    struct spg_fact_id fact = {};
+    struct spg_fact_id    fact   = {};
     const enum spg_status status = spg_memory_add_fact(
         memory, SPG_MEMORY_FACT_ARTIFACT, (struct spg_text_span){},
         (struct spg_text_span){},
@@ -109,11 +114,10 @@ static enum spg_status add_memory_update(
     return status;
 }
 
-enum spg_status
-spg_actor_step(struct spg_actor_state *state,
-               const struct spg_actor_step_config *config,
-               const struct spg_actor_step_workspace *workspace,
-               struct spg_actor_step_result *result) {
+enum spg_status spg_actor_step(struct spg_actor_state                *state,
+                               const struct spg_actor_step_config    *config,
+                               const struct spg_actor_step_workspace *workspace,
+                               struct spg_actor_step_result          *result) {
     if (state == nullptr || config == nullptr || !workspace_valid(workspace) ||
         result == nullptr || state->model == nullptr ||
         (config->write_journal && state->journal == nullptr) ||
@@ -121,16 +125,15 @@ spg_actor_step(struct spg_actor_state *state,
         (config->update_memory && state->memory == nullptr)) {
         return SPG_E_INVALID_ARG;
     }
-    *result = (struct spg_actor_step_result){};
+    *result                    = (struct spg_actor_step_result){};
     workspace->context[0]      = '\0';
     workspace->model_output[0] = '\0';
 
     struct spg_context_view context_view = {};
-    spg_context_view_init(&context_view, workspace->graph_ref_capacity,
-                          workspace->graph_refs, workspace->memory_ref_capacity,
-                          workspace->memory_refs,
-                          workspace->journal_ref_capacity,
-                          workspace->journal_refs);
+    spg_context_view_init(
+        &context_view, workspace->graph_ref_capacity, workspace->graph_refs,
+        workspace->memory_ref_capacity, workspace->memory_refs,
+        workspace->journal_ref_capacity, workspace->journal_refs);
 
     const struct spg_context_sources context_sources = {
         .run                  = state->run,
@@ -144,10 +147,11 @@ spg_actor_step(struct spg_actor_state *state,
         .memory_text_n        = state->memory_text_n,
         .memory_text          = state->memory_text,
         .memory_index         = state->memory_index,
-        .observation        = state->observation,
+        .observation          = state->observation,
         .exemplars            = state->exemplars,
         .goal                 = state->goal,
         .directive            = state->directive,
+        .machine              = state->machine,
     };
 
     enum spg_status status = spg_context_build(
@@ -194,7 +198,7 @@ spg_actor_step(struct spg_actor_state *state,
     result->stopped_by_token_limit = model_result.stopped_by_token_limit;
 
     const enum spg_status model_event_status = status;
-    enum spg_status journal_status = append_journal(
+    enum spg_status       journal_status     = append_journal(
         state->journal, config->write_journal, config->timestamp_ns,
         &parent_sequence, SPG_JOURNAL_EVENT_MODEL_OUTPUT, model_event_status,
         result->model_output_n, workspace->model_output,
@@ -224,10 +228,10 @@ spg_actor_step(struct spg_actor_state *state,
     }
 
     if (config->update_memory) {
-        const uint64_t source_event_id =
-            result->model_output_sequence != 0u ? result->model_output_sequence
-                                                : UINT64_C(1);
-        status = add_memory_update(
+        const uint64_t source_event_id = result->model_output_sequence != 0u
+                                             ? result->model_output_sequence
+                                             : UINT64_C(1);
+        status                         = add_memory_update(
             state->memory, source_event_id, result->has_recommendation_node,
             result->recommendation_node, result->model_output_n, result);
         if (status != SPG_OK) {

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -1,4 +1,5 @@
-#define _POSIX_C_SOURCE 200809L /* mkstemp/write/unlink: the guard-gate temp suite */
+#define _POSIX_C_SOURCE                                                        \
+    200809L /* mkstemp/write/unlink: the guard-gate temp suite */
 #if defined(__APPLE__)
 #    define _DARWIN_C_SOURCE 1
 #endif
@@ -15,14 +16,15 @@
 #include "geistshell/improve.h"
 #include "geistshell/mem_command.h"
 #include "geistshell/mem_store.h"
+#include "geistshell/process_profile.h"
 
 #include <geist.h>
 
 #include <errno.h>
 #include <math.h> /* isfinite: --temperature validation */
 #include <stdbool.h>
-#include <stdio.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h> /* mkstemp/write/close/unlink: the guard-gate temp suite */
@@ -46,34 +48,35 @@ struct file_buffer {
     char  *data;
 };
 
-static void free_file_buffer(struct file_buffer *buffer);
-static enum spg_status load_policy_file(const char *path,
-                                        struct file_buffer *policy_text,
+static void            free_file_buffer(struct file_buffer *buffer);
+static enum spg_status load_policy_file(const char               *path,
+                                        struct file_buffer       *policy_text,
                                         struct spg_policy_config *policy);
-static enum spg_status load_scenario_file(const char *path,
-                                          struct file_buffer *scenario_text,
+static enum spg_status load_scenario_file(const char            *path,
+                                          struct file_buffer    *scenario_text,
                                           struct spg_sim_config *sim);
 
 static void print_usage(const char *argv0) {
-    fprintf(stderr,
-            "usage: %s <command> [args]\n"
-            "\n"
-            "commands:\n"
-            "  version          print geistshell and libgeist versions\n"
-            "  exec             run a guarded local command and capture output\n"
-            "  memory           store/recall Markdown long-term memories\n"
-            "  tick             run one fake-model orchestrator tick\n"
-            "  run              run fake-model orchestrator ticks\n"
-            "  agent            run a governed multi-step agent loop "
-            "(scripted)\n"
-            "  eval             score a scripted agent suite (JSONL report)\n"
-            "  improve          learn lessons from eval failures into memory\n"
-            "  replay           print a journal timeline as JSONL\n"
-            "  verify-journal   verify a journal (+ --key <f> checks the seal)\n"
-            "  seal-journal     write a keyed HMAC seal over a journal\n"
-            "  policy-check     validate and summarize a policy file\n"
-            "  sim-validate     validate and summarize a scenario file\n",
-            argv0);
+    fprintf(
+        stderr,
+        "usage: %s <command> [args]\n"
+        "\n"
+        "commands:\n"
+        "  version          print geistshell and libgeist versions\n"
+        "  exec             run a guarded local command and capture output\n"
+        "  memory           store/recall Markdown long-term memories\n"
+        "  tick             run one fake-model orchestrator tick\n"
+        "  run              run fake-model orchestrator ticks\n"
+        "  agent            run a governed multi-step agent loop "
+        "(scripted)\n"
+        "  eval             score a scripted agent suite (JSONL report)\n"
+        "  improve          learn lessons from eval failures into memory\n"
+        "  replay           print a journal timeline as JSONL\n"
+        "  verify-journal   verify a journal (+ --key <f> checks the seal)\n"
+        "  seal-journal     write a keyed HMAC seal over a journal\n"
+        "  policy-check     validate and summarize a policy file\n"
+        "  sim-validate     validate and summarize a scenario file\n",
+        argv0);
 }
 
 static void print_tick_usage(const char *argv0) {
@@ -86,24 +89,25 @@ static void print_tick_usage(const char *argv0) {
 }
 
 static void print_run_usage(const char *argv0) {
-    fprintf(stderr,
-            "usage: %s run --config <run.spg> [--fake '<recommendation>'] "
-            "[--ticks <n>] [--write-sim-state <build/final.spg>] "
-            "[--write-run-state <build/run-state.json>] "
-            "[--remote-url <url>] [--remote-model <name>]\n"
-            "\n"
-            "Runs orchestrator ticks with one mutable in-process "
-            "simulator state.\n"
-            "Without --fake, the model path from the run config is loaded via "
-            "libgeist.\n"
-            "With --remote-url (or GEISTSHELL_API_URL) and a REMOTE=1 build, an "
-            "OpenAI-compatible\nendpoint drives the loop; the key is read from "
-            "GEISTSHELL_API_KEY.\n"
-            "Shell and network recommendations stop after recommendation and "
-            "policy gating.\n"
-            "If requested, writes the final simulator state as a scenario "
-            "S-expression.\n",
-            argv0);
+    fprintf(
+        stderr,
+        "usage: %s run --config <run.spg> [--fake '<recommendation>'] "
+        "[--ticks <n>] [--write-sim-state <build/final.spg>] "
+        "[--write-run-state <build/run-state.json>] "
+        "[--remote-url <url>] [--remote-model <name>]\n"
+        "\n"
+        "Runs orchestrator ticks with one mutable in-process "
+        "simulator state.\n"
+        "Without --fake, the model path from the run config is loaded via "
+        "libgeist.\n"
+        "With --remote-url (or GEISTSHELL_API_URL) and a REMOTE=1 build, an "
+        "OpenAI-compatible\nendpoint drives the loop; the key is read from "
+        "GEISTSHELL_API_KEY.\n"
+        "Shell and network recommendations stop after recommendation and "
+        "policy gating.\n"
+        "If requested, writes the final simulator state as a scenario "
+        "S-expression.\n",
+        argv0);
 }
 
 static void print_verify_journal_usage(const char *argv0) {
@@ -125,8 +129,8 @@ static void print_sim_validate_usage(const char *argv0) {
     fprintf(stderr, "usage: %s sim-validate <scenario.spg>\n", argv0);
 }
 
-static const char *policy_capability_kind_name(
-    const enum spg_policy_capability_kind kind) {
+static const char *
+policy_capability_kind_name(const enum spg_policy_capability_kind kind) {
     switch (kind) {
     case SPG_POLICY_CAP_LOCAL_SHELL:
         return "local_shell";
@@ -140,8 +144,8 @@ static const char *policy_capability_kind_name(
     return "unknown";
 }
 
-static const char *policy_network_default_name(
-    const enum spg_policy_network_default value) {
+static const char *
+policy_network_default_name(const enum spg_policy_network_default value) {
     switch (value) {
     case SPG_POLICY_NETWORK_DENY:
         return "deny";
@@ -189,7 +193,7 @@ static const char *journal_event_kind_name(const uint32_t kind) {
 
 static bool replay_span_eq_cstr(const size_t input_n, const char input[],
                                 const struct spg_text_span span,
-                                const char *expected) {
+                                const char                *expected) {
     if (input == nullptr || expected == nullptr || span.offset > input_n ||
         span.length > input_n - span.offset) {
         return false;
@@ -202,7 +206,7 @@ static bool replay_span_eq_cstr(const size_t input_n, const char input[],
 static bool replay_field_value(const size_t input_n, const char input[],
                                const struct spg_sexpr_node nodes[static 1],
                                const size_t node_count, const char *form_name,
-                               const char *field_name,
+                               const char           *field_name,
                                struct spg_text_span *out) {
     if (input == nullptr || nodes == nullptr || node_count == 0u ||
         form_name == nullptr || field_name == nullptr || out == nullptr) {
@@ -233,19 +237,20 @@ static bool replay_field_value(const size_t input_n, const char input[],
     return false;
 }
 
-static bool replay_payload_field(const size_t payload_n, const uint8_t payload[],
-                                 const char *form_name, const char *field_name,
+static bool replay_payload_field(const size_t  payload_n,
+                                 const uint8_t payload[], const char *form_name,
+                                 const char           *field_name,
                                  struct spg_text_span *out) {
     if (payload == nullptr || out == nullptr) {
         return false;
     }
     struct spg_sexpr_token tokens[CLI_TOKEN_CAPACITY];
     struct spg_sexpr_node  nodes[CLI_NODE_CAPACITY];
-    struct spg_sexpr_error error = {};
-    size_t token_count = 0u;
-    size_t node_count = 0u;
-    const char *text = (const char *)payload;
-    const enum spg_status status = spg_sexpr_parse_text(
+    struct spg_sexpr_error error       = {};
+    size_t                 token_count = 0u;
+    size_t                 node_count  = 0u;
+    const char            *text        = (const char *)payload;
+    const enum spg_status  status      = spg_sexpr_parse_text(
         payload_n, text, CLI_TOKEN_CAPACITY, tokens, CLI_NODE_CAPACITY, nodes,
         &token_count, &node_count, &error);
     if (status != SPG_OK) {
@@ -256,13 +261,13 @@ static bool replay_payload_field(const size_t payload_n, const uint8_t payload[]
                               field_name, out);
 }
 
-static bool payload_span_valid(const size_t payload_n,
+static bool payload_span_valid(const size_t               payload_n,
                                const struct spg_text_span span) {
     return span.offset <= payload_n && span.length <= payload_n - span.offset;
 }
 
-static bool payload_span_is_uint(const size_t payload_n,
-                                 const uint8_t payload[],
+static bool payload_span_is_uint(const size_t               payload_n,
+                                 const uint8_t              payload[],
                                  const struct spg_text_span span) {
     if (payload == nullptr || !payload_span_valid(payload_n, span) ||
         span.length == 0u) {
@@ -277,10 +282,11 @@ static bool payload_span_is_uint(const size_t payload_n,
     return true;
 }
 
-static bool payload_span_is_bool(const size_t payload_n,
-                                 const uint8_t payload[],
+static bool payload_span_is_bool(const size_t               payload_n,
+                                 const uint8_t              payload[],
                                  const struct spg_text_span span) {
-    return replay_span_eq_cstr(payload_n, (const char *)payload, span, "true") ||
+    return replay_span_eq_cstr(payload_n, (const char *)payload, span,
+                               "true") ||
            replay_span_eq_cstr(payload_n, (const char *)payload, span, "false");
 }
 
@@ -307,8 +313,8 @@ static void print_json_bytes(const size_t bytes_n, const uint8_t bytes[]) {
     printf("\"");
 }
 
-static void print_json_span_string(const size_t payload_n,
-                                   const uint8_t payload[],
+static void print_json_span_string(const size_t               payload_n,
+                                   const uint8_t              payload[],
                                    const struct spg_text_span span) {
     if (payload == nullptr || !payload_span_valid(payload_n, span)) {
         printf("null");
@@ -317,8 +323,8 @@ static void print_json_span_string(const size_t payload_n,
     print_json_bytes(span.length, payload + span.offset);
 }
 
-static void print_json_span_value(const size_t payload_n,
-                                  const uint8_t payload[],
+static void print_json_span_value(const size_t               payload_n,
+                                  const uint8_t              payload[],
                                   const struct spg_text_span span) {
     if (payload == nullptr || !payload_span_valid(payload_n, span)) {
         printf("null");
@@ -332,9 +338,11 @@ static void print_json_span_value(const size_t payload_n,
     print_json_span_string(payload_n, payload, span);
 }
 
-static void print_json_preview(const size_t payload_n, const uint8_t payload[]) {
-    const size_t n =
-        payload_n < CLI_REPLAY_PREVIEW_BYTES ? payload_n : CLI_REPLAY_PREVIEW_BYTES;
+static void print_json_preview(const size_t  payload_n,
+                               const uint8_t payload[]) {
+    const size_t n = payload_n < CLI_REPLAY_PREVIEW_BYTES
+                         ? payload_n
+                         : CLI_REPLAY_PREVIEW_BYTES;
     print_json_bytes(n, payload);
 }
 
@@ -344,25 +352,25 @@ static int verify_journal_command(const char *path) {
     }
 
     struct spg_journal_reader reader = {};
-    enum spg_status status = spg_journal_reader_open(&reader, path);
+    enum spg_status           status = spg_journal_reader_open(&reader, path);
     if (status != SPG_OK) {
         fprintf(stderr, "verify-journal: open failed: %s\n",
                 spg_status_to_string(status));
         return 1;
     }
 
-    uint8_t payload[CLI_JOURNAL_VERIFY_PAYLOAD_BYTES];
-    uint64_t counts[SPG_JOURNAL_EVENT_ERROR + 1u] = {};
-    uint64_t total = 0u;
-    uint64_t truncated_payloads = 0u;
-    uint64_t status_failures = 0u;
-    uint64_t payload_bytes = 0u;
-    uint64_t last_sequence = 0u;
-    struct spg_journal_record record = {};
+    uint8_t                   payload[CLI_JOURNAL_VERIFY_PAYLOAD_BYTES];
+    uint64_t                  counts[SPG_JOURNAL_EVENT_ERROR + 1u] = {};
+    uint64_t                  total                                = 0u;
+    uint64_t                  truncated_payloads                   = 0u;
+    uint64_t                  status_failures                      = 0u;
+    uint64_t                  payload_bytes                        = 0u;
+    uint64_t                  last_sequence                        = 0u;
+    struct spg_journal_record record                               = {};
 
     for (;;) {
-        status = spg_journal_reader_next(&reader, sizeof payload, payload,
-                                         &record);
+        status =
+            spg_journal_reader_next(&reader, sizeof payload, payload, &record);
         if (status == SPG_E_NOT_FOUND) {
             break;
         }
@@ -404,8 +412,7 @@ static int verify_journal_command(const char *path) {
     printf("last_sequence=%llu\n", (unsigned long long)last_sequence);
     printf("payload_bytes=%llu\n", (unsigned long long)payload_bytes);
     printf("status_failures=%llu\n", (unsigned long long)status_failures);
-    printf("truncated_payloads=%llu\n",
-           (unsigned long long)truncated_payloads);
+    printf("truncated_payloads=%llu\n", (unsigned long long)truncated_payloads);
     for (uint32_t i = 0u; i <= (uint32_t)SPG_JOURNAL_EVENT_ERROR; i += 1u) {
         if (counts[i] == 0u) {
             continue;
@@ -423,9 +430,9 @@ static void print_replay_common_json(const struct spg_journal_record *record,
            (unsigned long long)record->header.parent_sequence);
     printf(",\"ts\":%llu", (unsigned long long)record->header.timestamp_ns);
     printf(",\"event\":");
-    print_json_bytes(strlen(journal_event_kind_name(record->header.event_kind)),
-                     (const uint8_t *)journal_event_kind_name(
-                         record->header.event_kind));
+    print_json_bytes(
+        strlen(journal_event_kind_name(record->header.event_kind)),
+        (const uint8_t *)journal_event_kind_name(record->header.event_kind));
     printf(",\"status\":");
     print_json_bytes(
         strlen(spg_status_to_string((enum spg_status)record->header.status)),
@@ -436,10 +443,10 @@ static void print_replay_common_json(const struct spg_journal_record *record,
     printf(",\"truncated\":%s", truncated ? "true" : "false");
 }
 
-static void print_replay_field_json(const size_t payload_n,
+static void print_replay_field_json(const size_t  payload_n,
                                     const uint8_t payload[],
-                                    const char *form_name,
-                                    const char *field_name) {
+                                    const char   *form_name,
+                                    const char   *field_name) {
     struct spg_text_span value = {};
     if (!replay_payload_field(payload_n, payload, form_name, field_name,
                               &value)) {
@@ -449,17 +456,17 @@ static void print_replay_field_json(const size_t payload_n,
     print_json_span_value(payload_n, payload, value);
 }
 
-static void print_replay_policy_json(const size_t payload_n,
+static void print_replay_policy_json(const size_t  payload_n,
                                      const uint8_t payload[]) {
-    const char *fields[] = {"decision", "deny_reason", "action_kind",
-                            "cost", "uses_network", "confidence_bp"};
+    const char *fields[] = {"decision", "deny_reason",  "action_kind",
+                            "cost",     "uses_network", "confidence_bp"};
     for (size_t i = 0u; i < sizeof fields / sizeof fields[0]; i += 1u) {
         print_replay_field_json(payload_n, payload, "policy_decision",
                                 fields[i]);
     }
 }
 
-static void print_replay_sim_json(const size_t payload_n,
+static void print_replay_sim_json(const size_t  payload_n,
                                   const uint8_t payload[]) {
     const char *fields[] = {"action", "selected_index", "mutated",
                             "risk_before", "risk_after"};
@@ -474,19 +481,19 @@ static int replay_command(const char *path) {
     }
 
     struct spg_journal_reader reader = {};
-    enum spg_status status = spg_journal_reader_open(&reader, path);
+    enum spg_status           status = spg_journal_reader_open(&reader, path);
     if (status != SPG_OK) {
         fprintf(stderr, "replay: open failed: %s\n",
                 spg_status_to_string(status));
         return 1;
     }
 
-    uint8_t payload[CLI_REPLAY_PAYLOAD_BYTES];
+    uint8_t                   payload[CLI_REPLAY_PAYLOAD_BYTES];
     struct spg_journal_record record = {};
 
     for (;;) {
-        status = spg_journal_reader_next(&reader, sizeof payload, payload,
-                                         &record);
+        status =
+            spg_journal_reader_next(&reader, sizeof payload, payload, &record);
         if (status == SPG_E_NOT_FOUND) {
             break;
         }
@@ -507,7 +514,7 @@ static int replay_command(const char *path) {
             print_json_preview(available_payload, payload);
             printf(",\"preview_truncated\":%s",
                    available_payload > CLI_REPLAY_PREVIEW_BYTES ? "true"
-                                                                 : "false");
+                                                                : "false");
             break;
         case SPG_JOURNAL_EVENT_POLICY_DECISION:
             if (!truncated) {
@@ -561,9 +568,10 @@ static int policy_check_command(const char *path) {
     if (path == nullptr) {
         return 2;
     }
-    struct file_buffer policy_text = {};
-    struct spg_policy_config policy = {};
-    const enum spg_status status = load_policy_file(path, &policy_text, &policy);
+    struct file_buffer       policy_text = {};
+    struct spg_policy_config policy      = {};
+    const enum spg_status    status =
+        load_policy_file(path, &policy_text, &policy);
     if (status != SPG_OK) {
         fprintf(stderr, "policy-check: load failed: %s\n",
                 spg_status_to_string(status));
@@ -611,8 +619,8 @@ static bool parse_size(const char *text, size_t *out) {
     if (text == nullptr || out == nullptr || text[0] == '\0') {
         return false;
     }
-    errno     = 0;
-    char *end = nullptr;
+    errno                          = 0;
+    char                    *end   = nullptr;
     const unsigned long long value = strtoull(text, &end, 10);
     if (errno == ERANGE || end == text || *end != '\0' ||
         value > (unsigned long long)SIZE_MAX) {
@@ -653,9 +661,9 @@ static void add_budget_u64(uint64_t *value, const uint64_t delta) {
     *value += delta;
 }
 
-static uint64_t latest_result_sequence(
-    const struct spg_orchestrator_result *result,
-    const uint64_t fallback_sequence) {
+static uint64_t
+latest_result_sequence(const struct spg_orchestrator_result *result,
+                       const uint64_t fallback_sequence) {
     if (result == nullptr) {
         return fallback_sequence;
     }
@@ -686,7 +694,7 @@ static uint64_t latest_result_sequence(
     return fallback_sequence;
 }
 
-static void update_run_usage(struct spg_policy_usage *usage,
+static void update_run_usage(struct spg_policy_usage              *usage,
                              const struct spg_orchestrator_result *result) {
     if (usage == nullptr || result == nullptr) {
         return;
@@ -704,17 +712,17 @@ static void update_run_usage(struct spg_policy_usage *usage,
     }
 }
 
-static void print_run_tick_summary(
-    const size_t tick_index, const struct spg_orchestrator_result *result,
-    const struct spg_policy_usage *usage) {
+static void print_run_tick_summary(const size_t tick_index,
+                                   const struct spg_orchestrator_result *result,
+                                   const struct spg_policy_usage *usage) {
     printf("tick=%zu", tick_index);
     printf(" stage=%s", spg_orchestrator_stage_to_string(result->stage));
-    printf(" recommendation=%s",
-           spg_orchestrator_recommendation_valid(result) ? "valid" : "rejected");
+    printf(" recommendation=%s", spg_orchestrator_recommendation_valid(result)
+                                     ? "valid"
+                                     : "rejected");
     if (!spg_orchestrator_recommendation_valid(result)) {
-        printf(" reject_reason=%s",
-               spg_recommendation_reject_reason_to_string(
-                   result->recommendation.reject_reason));
+        printf(" reject_reason=%s", spg_recommendation_reject_reason_to_string(
+                                        result->recommendation.reject_reason));
     } else {
         printf(" action=%s",
                spg_action_kind_to_string(result->recommendation.action_kind));
@@ -738,14 +746,13 @@ static void print_run_tick_summary(
     }
     printf(" consumed.inference_steps=%llu",
            (unsigned long long)usage->consumed.inference_steps);
-    printf(" consumed.tokens=%llu",
-           (unsigned long long)usage->consumed.tokens);
+    printf(" consumed.tokens=%llu", (unsigned long long)usage->consumed.tokens);
     printf(" consumed.sim_actions=%llu",
            (unsigned long long)usage->consumed.sim_actions);
     printf("\n");
 }
 
-static bool file_span_valid(const size_t text_n,
+static bool file_span_valid(const size_t               text_n,
                             const struct spg_text_span span) {
     return span.offset <= text_n && span.length <= text_n - span.offset;
 }
@@ -758,7 +765,7 @@ static enum spg_status write_file_text(FILE *file, const char *text) {
 }
 
 static enum spg_status write_file_span(FILE *file, const size_t text_n,
-                                       const char text[],
+                                       const char                 text[],
                                        const struct spg_text_span span) {
     if (file == nullptr || text == nullptr || !file_span_valid(text_n, span)) {
         return SPG_E_INVALID_ARG;
@@ -790,9 +797,9 @@ static enum spg_status write_file_bool(FILE *file, const bool value) {
     return write_file_text(file, value ? "true" : "false");
 }
 
-static enum spg_status write_sim_state_file(const char *path,
+static enum spg_status write_sim_state_file(const char  *path,
                                             const size_t source_n,
-                                            const char source[],
+                                            const char   source[],
                                             const struct spg_sim_config *sim) {
     if (path == nullptr || source == nullptr || sim == nullptr) {
         return SPG_E_INVALID_ARG;
@@ -1000,8 +1007,8 @@ static int sim_validate_command(const char *path) {
     if (path == nullptr) {
         return 2;
     }
-    struct file_buffer scenario_text = {};
-    struct spg_sim_config sim = {};
+    struct file_buffer    scenario_text = {};
+    struct spg_sim_config sim           = {};
     enum spg_status status = load_scenario_file(path, &scenario_text, &sim);
     if (status != SPG_OK) {
         fprintf(stderr, "sim-validate: load failed: %s\n",
@@ -1010,7 +1017,7 @@ static int sim_validate_command(const char *path) {
         return 1;
     }
     struct spg_risk_score risk = {};
-    status = spg_risk_evaluate(&sim, &risk);
+    status                     = spg_risk_evaluate(&sim, &risk);
     if (status != SPG_OK) {
         fprintf(stderr, "sim-validate: risk failed: %s\n",
                 spg_status_to_string(status));
@@ -1055,7 +1062,7 @@ static enum spg_status read_file(const char *path, struct file_buffer *out) {
     if (path == nullptr || out == nullptr) {
         return SPG_E_INVALID_ARG;
     }
-    *out = (struct file_buffer){};
+    *out       = (struct file_buffer){};
     FILE *file = fopen(path, "rb");
     if (file == nullptr) {
         return SPG_E_IO;
@@ -1077,8 +1084,8 @@ static enum spg_status read_file(const char *path, struct file_buffer *out) {
         (void)fclose(file);
         return SPG_E_IO;
     }
-    const size_t n = (size_t)end;
-    char *data = malloc(n + 1u);
+    const size_t n    = (size_t)end;
+    char        *data = malloc(n + 1u);
     if (data == nullptr) {
         (void)fclose(file);
         return SPG_E_OOM;
@@ -1092,55 +1099,55 @@ static enum spg_status read_file(const char *path, struct file_buffer *out) {
         free_ptr((void **)&data);
         return SPG_E_IO;
     }
-    data[n] = '\0';
-    out->n = n;
+    data[n]   = '\0';
+    out->n    = n;
     out->data = data;
     return SPG_OK;
 }
 
 static enum spg_status span_to_cstr(const size_t input_n, const char input[],
                                     const struct spg_text_span span,
-                                    char **out) {
+                                    char                     **out) {
     if (input == nullptr || out == nullptr || span.offset > input_n ||
         span.length > input_n - span.offset) {
         return SPG_E_INVALID_ARG;
     }
-    *out = nullptr;
+    *out       = nullptr;
     char *text = malloc(span.length + 1u);
     if (text == nullptr) {
         return SPG_E_OOM;
     }
     memcpy(text, input + span.offset, span.length);
     text[span.length] = '\0';
-    *out = text;
+    *out              = text;
     return SPG_OK;
 }
 
-static enum spg_status load_run_file(const char *path,
-                                     struct file_buffer *run_text,
+static enum spg_status load_run_file(const char            *path,
+                                     struct file_buffer    *run_text,
                                      struct spg_run_config *run) {
     enum spg_status status = read_file(path, run_text);
     if (status != SPG_OK) {
         return status;
     }
-    struct spg_sexpr_token tokens[CLI_TOKEN_CAPACITY];
-    struct spg_sexpr_node  nodes[CLI_NODE_CAPACITY];
+    struct spg_sexpr_token      tokens[CLI_TOKEN_CAPACITY];
+    struct spg_sexpr_node       nodes[CLI_NODE_CAPACITY];
     struct spg_run_config_error error = {};
-    status = spg_run_config_load(run_text->n, run_text->data,
-                                 CLI_TOKEN_CAPACITY, tokens,
-                                 CLI_NODE_CAPACITY, nodes, run, &error);
+    status =
+        spg_run_config_load(run_text->n, run_text->data, CLI_TOKEN_CAPACITY,
+                            tokens, CLI_NODE_CAPACITY, nodes, run, &error);
     return status;
 }
 
-static enum spg_status load_policy_file(const char *path,
-                                        struct file_buffer *policy_text,
+static enum spg_status load_policy_file(const char               *path,
+                                        struct file_buffer       *policy_text,
                                         struct spg_policy_config *policy) {
     enum spg_status status = read_file(path, policy_text);
     if (status != SPG_OK) {
         return status;
     }
-    struct spg_sexpr_token tokens[CLI_TOKEN_CAPACITY];
-    struct spg_sexpr_node  nodes[CLI_NODE_CAPACITY];
+    struct spg_sexpr_token         tokens[CLI_TOKEN_CAPACITY];
+    struct spg_sexpr_node          nodes[CLI_NODE_CAPACITY];
     struct spg_policy_config_error error = {};
     status = spg_policy_config_load(policy_text->n, policy_text->data,
                                     CLI_TOKEN_CAPACITY, tokens,
@@ -1148,19 +1155,19 @@ static enum spg_status load_policy_file(const char *path,
     return status;
 }
 
-static enum spg_status load_scenario_file(const char *path,
-                                          struct file_buffer *scenario_text,
+static enum spg_status load_scenario_file(const char            *path,
+                                          struct file_buffer    *scenario_text,
                                           struct spg_sim_config *sim) {
     enum spg_status status = read_file(path, scenario_text);
     if (status != SPG_OK) {
         return status;
     }
-    struct spg_sexpr_token tokens[CLI_TOKEN_CAPACITY];
-    struct spg_sexpr_node  nodes[CLI_NODE_CAPACITY];
+    struct spg_sexpr_token      tokens[CLI_TOKEN_CAPACITY];
+    struct spg_sexpr_node       nodes[CLI_NODE_CAPACITY];
     struct spg_sim_config_error error = {};
     status = spg_sim_config_load(scenario_text->n, scenario_text->data,
-                                 CLI_TOKEN_CAPACITY, tokens,
-                                 CLI_NODE_CAPACITY, nodes, sim, &error);
+                                 CLI_TOKEN_CAPACITY, tokens, CLI_NODE_CAPACITY,
+                                 nodes, sim, &error);
     return status;
 }
 
@@ -1169,27 +1176,27 @@ static int run_tick_fake(const char *run_path, const char *fake_output) {
         return 2;
     }
 
-    int rc = 1;
-    struct file_buffer run_text = {};
-    struct file_buffer policy_text = {};
-    struct file_buffer scenario_text = {};
-    char *policy_path = nullptr;
-    char *scenario_path = nullptr;
-    char *journal_path = nullptr;
-    struct spg_journal_writer journal = {};
-    bool journal_open = false;
-    struct spg_model_adapter model = {};
-    bool model_open = false;
+    int                       rc            = 1;
+    struct file_buffer        run_text      = {};
+    struct file_buffer        policy_text   = {};
+    struct file_buffer        scenario_text = {};
+    char                     *policy_path   = nullptr;
+    char                     *scenario_path = nullptr;
+    char                     *journal_path  = nullptr;
+    struct spg_journal_writer journal       = {};
+    bool                      journal_open  = false;
+    struct spg_model_adapter  model         = {};
+    bool                      model_open    = false;
 
-    struct spg_run_config run = {};
-    enum spg_status status = load_run_file(run_path, &run_text, &run);
+    struct spg_run_config run    = {};
+    enum spg_status       status = load_run_file(run_path, &run_text, &run);
     if (status != SPG_OK) {
         fprintf(stderr, "tick: load run failed: %s\n",
                 spg_status_to_string(status));
         goto done;
     }
-    status = span_to_cstr(run_text.n, run_text.data, run.policy_path,
-                          &policy_path);
+    status =
+        span_to_cstr(run_text.n, run_text.data, run.policy_path, &policy_path);
     if (status != SPG_OK) {
         fprintf(stderr, "tick: policy path failed: %s\n",
                 spg_status_to_string(status));
@@ -1247,34 +1254,35 @@ static int run_tick_fake(const char *run_path, const char *fake_output) {
     }
     model_open = true;
 
-    struct spg_graph graph = {};
+    struct spg_graph  graph  = {};
     struct spg_memory memory = {};
     spg_graph_init(&graph);
     spg_memory_init(&memory);
 
-    struct spg_context_graph_ref graph_refs[CLI_CONTEXT_REFS];
-    struct spg_context_memory_ref memory_refs[CLI_CONTEXT_REFS];
+    struct spg_context_graph_ref   graph_refs[CLI_CONTEXT_REFS];
+    struct spg_context_memory_ref  memory_refs[CLI_CONTEXT_REFS];
     struct spg_context_journal_ref journal_refs[CLI_CONTEXT_REFS];
-    char context[CLI_CONTEXT_BYTES];
-    char model_output[CLI_MODEL_OUTPUT_BYTES];
-    struct spg_sexpr_token rec_tokens[CLI_TOKEN_CAPACITY];
-    struct spg_sexpr_node rec_nodes[CLI_NODE_CAPACITY];
-    char policy_payload[CLI_PAYLOAD_BYTES];
-    char sim_payload[CLI_PAYLOAD_BYTES];
+    char                           context[CLI_CONTEXT_BYTES];
+    char                           model_output[CLI_MODEL_OUTPUT_BYTES];
+    struct spg_sexpr_token         rec_tokens[CLI_TOKEN_CAPACITY];
+    struct spg_sexpr_node          rec_nodes[CLI_NODE_CAPACITY];
+    char                           policy_payload[CLI_PAYLOAD_BYTES];
+    char                           sim_payload[CLI_PAYLOAD_BYTES];
 
     const struct spg_orchestrator_workspace workspace = {
-        .actor = {
-            .context_capacity      = sizeof context,
-            .context               = context,
-            .model_output_capacity = sizeof model_output,
-            .model_output          = model_output,
-            .graph_ref_capacity    = CLI_CONTEXT_REFS,
-            .graph_refs            = graph_refs,
-            .memory_ref_capacity   = CLI_CONTEXT_REFS,
-            .memory_refs           = memory_refs,
-            .journal_ref_capacity  = CLI_CONTEXT_REFS,
-            .journal_refs          = journal_refs,
-        },
+        .actor =
+            {
+                .context_capacity      = sizeof context,
+                .context               = context,
+                .model_output_capacity = sizeof model_output,
+                .model_output          = model_output,
+                .graph_ref_capacity    = CLI_CONTEXT_REFS,
+                .graph_refs            = graph_refs,
+                .memory_ref_capacity   = CLI_CONTEXT_REFS,
+                .memory_refs           = memory_refs,
+                .journal_ref_capacity  = CLI_CONTEXT_REFS,
+                .journal_refs          = journal_refs,
+            },
         .recommendation_token_capacity = CLI_TOKEN_CAPACITY,
         .recommendation_tokens         = rec_tokens,
         .recommendation_node_capacity  = CLI_NODE_CAPACITY,
@@ -1285,7 +1293,7 @@ static int run_tick_fake(const char *run_path, const char *fake_output) {
         .sim_payload                   = sim_payload,
     };
 
-    struct spg_policy_usage usage = {};
+    struct spg_policy_usage       usage = {};
     struct spg_orchestrator_state state = {
         .graph         = &graph,
         .memory        = &memory,
@@ -1305,8 +1313,8 @@ static int run_tick_fake(const char *run_path, const char *fake_output) {
     const struct spg_orchestrator_config config = {
         .actor_id            = 1u,
         .timestamp_ns        = 1u,
-        .context_limits      = {.graph_nodes = CLI_CONTEXT_REFS,
-                                .memory_facts = CLI_CONTEXT_REFS,
+        .context_limits      = {.graph_nodes    = CLI_CONTEXT_REFS,
+                                .memory_facts   = CLI_CONTEXT_REFS,
                                 .journal_events = CLI_CONTEXT_REFS},
         .max_decode_tokens   = run.budgets.tokens > 0u ? 1u : 0u,
         .reset_model_session = true,
@@ -1323,13 +1331,12 @@ static int run_tick_fake(const char *run_path, const char *fake_output) {
     }
 
     printf("stage=%s\n", spg_orchestrator_stage_to_string(result.stage));
-    printf("recommendation=%s\n",
-           spg_orchestrator_recommendation_valid(&result) ? "valid"
-                                                          : "rejected");
+    printf("recommendation=%s\n", spg_orchestrator_recommendation_valid(&result)
+                                      ? "valid"
+                                      : "rejected");
     if (!spg_orchestrator_recommendation_valid(&result)) {
-        printf("reject_reason=%s\n",
-               spg_recommendation_reject_reason_to_string(
-                   result.recommendation.reject_reason));
+        printf("reject_reason=%s\n", spg_recommendation_reject_reason_to_string(
+                                         result.recommendation.reject_reason));
     }
     if (spg_orchestrator_policy_evaluated(&result)) {
         printf("policy=%s\n",
@@ -1394,21 +1401,21 @@ static int run_loop(const char *run_path, const char *fake_output,
         }
     }
 
-    int rc = 1;
-    struct file_buffer run_text = {};
-    struct file_buffer policy_text = {};
-    struct file_buffer scenario_text = {};
-    char *policy_path = nullptr;
-    char *scenario_path = nullptr;
-    char *journal_path = nullptr;
-    char *model_path = nullptr;
-    struct spg_journal_writer journal = {};
-    bool journal_open = false;
-    struct spg_model_adapter model = {};
-    bool model_open = false;
+    int                       rc            = 1;
+    struct file_buffer        run_text      = {};
+    struct file_buffer        policy_text   = {};
+    struct file_buffer        scenario_text = {};
+    char                     *policy_path   = nullptr;
+    char                     *scenario_path = nullptr;
+    char                     *journal_path  = nullptr;
+    char                     *model_path    = nullptr;
+    struct spg_journal_writer journal       = {};
+    bool                      journal_open  = false;
+    struct spg_model_adapter  model         = {};
+    bool                      model_open    = false;
 
-    struct spg_run_config run = {};
-    enum spg_status status = load_run_file(run_path, &run_text, &run);
+    struct spg_run_config run    = {};
+    enum spg_status       status = load_run_file(run_path, &run_text, &run);
     if (status != SPG_OK) {
         fprintf(stderr, "run: load run failed: %s\n",
                 spg_status_to_string(status));
@@ -1423,8 +1430,8 @@ static int run_loop(const char *run_path, const char *fake_output,
         goto done;
     }
 
-    status = span_to_cstr(run_text.n, run_text.data, run.policy_path,
-                          &policy_path);
+    status =
+        span_to_cstr(run_text.n, run_text.data, run.policy_path, &policy_path);
     if (status != SPG_OK) {
         fprintf(stderr, "run: policy path failed: %s\n",
                 spg_status_to_string(status));
@@ -1444,8 +1451,8 @@ static int run_loop(const char *run_path, const char *fake_output,
                 spg_status_to_string(status));
         goto done;
     }
-    status = span_to_cstr(run_text.n, run_text.data, run.model_path,
-                          &model_path);
+    status =
+        span_to_cstr(run_text.n, run_text.data, run.model_path, &model_path);
     if (status != SPG_OK) {
         fprintf(stderr, "run: model path failed: %s\n",
                 spg_status_to_string(status));
@@ -1480,29 +1487,29 @@ static int run_loop(const char *run_path, const char *fake_output,
     const bool  use_fake    = fake_output != nullptr;
     const char *env_api_url = getenv("GEISTSHELL_API_URL");
     const char *url =
-        (remote_url != nullptr && remote_url[0] != '\0')        ? remote_url
-        : (env_api_url != nullptr && env_api_url[0] != '\0')    ? env_api_url
-                                                                : nullptr;
+        (remote_url != nullptr && remote_url[0] != '\0')     ? remote_url
+        : (env_api_url != nullptr && env_api_url[0] != '\0') ? env_api_url
+                                                             : nullptr;
     const bool use_remote = !use_fake && url != nullptr;
     /* For REMOTE the (model "...") value is a model name, not a file path; an
      * explicit --remote-model overrides it. The key is env-only. */
     const char *remote_name =
         (remote_model != nullptr && remote_model[0] != '\0') ? remote_model
                                                              : model_path;
-    const enum spg_model_adapter_kind kind =
-        use_fake     ? SPG_MODEL_ADAPTER_FAKE
-        : use_remote ? SPG_MODEL_ADAPTER_REMOTE
-                     : SPG_MODEL_ADAPTER_GEIST;
+    const enum spg_model_adapter_kind kind = use_fake ? SPG_MODEL_ADAPTER_FAKE
+                                             : use_remote
+                                                 ? SPG_MODEL_ADAPTER_REMOTE
+                                                 : SPG_MODEL_ADAPTER_GEIST;
     const struct spg_model_adapter_config model_config = {
-        .kind         = kind,
-        .model_path   = (kind == SPG_MODEL_ADAPTER_GEIST) ? model_path : nullptr,
-        .endpoint_url = use_remote ? url : nullptr,
-        .model_name   = use_remote ? remote_name : nullptr,
-        .api_key      = use_remote ? getenv("GEISTSHELL_API_KEY") : nullptr,
+        .kind       = kind,
+        .model_path = (kind == SPG_MODEL_ADAPTER_GEIST) ? model_path : nullptr,
+        .endpoint_url    = use_remote ? url : nullptr,
+        .model_name      = use_remote ? remote_name : nullptr,
+        .api_key         = use_remote ? getenv("GEISTSHELL_API_KEY") : nullptr,
         .sampling        = {.max_seq_len = 4096u,
                             .temperature = 0.0f,
-                            .top_p = 1.0f,
-                            .top_k = 0,
+                            .top_p       = 1.0f,
+                            .top_k       = 0,
                             .random_seed = run.seed},
         .fake_response_n = use_fake ? strlen(fake_output) : 0u,
         .fake_response   = fake_output,
@@ -1512,42 +1519,44 @@ static int run_loop(const char *run_path, const char *fake_output,
         fprintf(stderr, "run: model init failed: %s\n",
                 spg_status_to_string(status));
         if (use_remote && status == SPG_E_UNSUPPORTED) {
-            fprintf(stderr,
-                    "run: rebuild with `make REMOTE=1` to enable --remote-url\n");
+            fprintf(
+                stderr,
+                "run: rebuild with `make REMOTE=1` to enable --remote-url\n");
         }
         goto done;
     }
     model_open = true;
 
-    struct spg_graph graph = {};
+    struct spg_graph  graph  = {};
     struct spg_memory memory = {};
     spg_graph_init(&graph);
     spg_memory_init(&memory);
 
-    struct spg_context_graph_ref graph_refs[CLI_CONTEXT_REFS];
-    struct spg_context_memory_ref memory_refs[CLI_CONTEXT_REFS];
+    struct spg_context_graph_ref   graph_refs[CLI_CONTEXT_REFS];
+    struct spg_context_memory_ref  memory_refs[CLI_CONTEXT_REFS];
     struct spg_context_journal_ref journal_refs[CLI_CONTEXT_REFS];
-    char context[CLI_CONTEXT_BYTES];
-    char model_output[CLI_MODEL_OUTPUT_BYTES];
-    struct spg_sexpr_token rec_tokens[CLI_TOKEN_CAPACITY];
-    struct spg_sexpr_node rec_nodes[CLI_NODE_CAPACITY];
-    char policy_payload[CLI_PAYLOAD_BYTES];
-    char sim_payload[CLI_PAYLOAD_BYTES];
-    char mem_recall_buf[8192] = {0};
+    char                           context[CLI_CONTEXT_BYTES];
+    char                           model_output[CLI_MODEL_OUTPUT_BYTES];
+    struct spg_sexpr_token         rec_tokens[CLI_TOKEN_CAPACITY];
+    struct spg_sexpr_node          rec_nodes[CLI_NODE_CAPACITY];
+    char                           policy_payload[CLI_PAYLOAD_BYTES];
+    char                           sim_payload[CLI_PAYLOAD_BYTES];
+    char                           mem_recall_buf[8192] = {0};
 
     const struct spg_orchestrator_workspace workspace = {
-        .actor = {
-            .context_capacity      = sizeof context,
-            .context               = context,
-            .model_output_capacity = sizeof model_output,
-            .model_output          = model_output,
-            .graph_ref_capacity    = CLI_CONTEXT_REFS,
-            .graph_refs            = graph_refs,
-            .memory_ref_capacity   = CLI_CONTEXT_REFS,
-            .memory_refs           = memory_refs,
-            .journal_ref_capacity  = CLI_CONTEXT_REFS,
-            .journal_refs          = journal_refs,
-        },
+        .actor =
+            {
+                .context_capacity      = sizeof context,
+                .context               = context,
+                .model_output_capacity = sizeof model_output,
+                .model_output          = model_output,
+                .graph_ref_capacity    = CLI_CONTEXT_REFS,
+                .graph_refs            = graph_refs,
+                .memory_ref_capacity   = CLI_CONTEXT_REFS,
+                .memory_refs           = memory_refs,
+                .journal_ref_capacity  = CLI_CONTEXT_REFS,
+                .journal_refs          = journal_refs,
+            },
         .recommendation_token_capacity = CLI_TOKEN_CAPACITY,
         .recommendation_tokens         = rec_tokens,
         .recommendation_node_capacity  = CLI_NODE_CAPACITY,
@@ -1556,13 +1565,13 @@ static int run_loop(const char *run_path, const char *fake_output,
         .policy_payload                = policy_payload,
         .sim_payload_capacity          = sizeof sim_payload,
         .sim_payload                   = sim_payload,
-        .observation_capacity        = sizeof mem_recall_buf,
-        .observation_buf             = mem_recall_buf,
+        .observation_capacity          = sizeof mem_recall_buf,
+        .observation_buf               = mem_recall_buf,
     };
 
-    struct spg_policy_usage usage = {};
-    char                    mem_index_buf[4096] = {0};
-    struct spg_orchestrator_state state = {
+    struct spg_policy_usage       usage               = {};
+    char                          mem_index_buf[4096] = {0};
+    struct spg_orchestrator_state state               = {
         .graph         = &graph,
         .memory        = &memory,
         .journal       = &journal,
@@ -1579,7 +1588,7 @@ static int run_loop(const char *run_path, const char *fake_output,
         .memory_text_n = 0u,
         .memory_text   = nullptr,
         .memory_index  = have_store ? mem_index_buf : nullptr,
-        .observation = have_store ? mem_recall_buf : nullptr,
+        .observation   = have_store ? mem_recall_buf : nullptr,
     };
 
     uint64_t parent_sequence = 0u;
@@ -1601,8 +1610,8 @@ static int run_loop(const char *run_path, const char *fake_output,
             .actor_id            = 1u,
             .timestamp_ns        = i + 1u,
             .parent_sequence     = parent_sequence,
-            .context_limits      = {.graph_nodes = CLI_CONTEXT_REFS,
-                                    .memory_facts = CLI_CONTEXT_REFS,
+            .context_limits      = {.graph_nodes    = CLI_CONTEXT_REFS,
+                                    .memory_facts   = CLI_CONTEXT_REFS,
                                     .journal_events = CLI_CONTEXT_REFS},
             .max_decode_tokens   = run.budgets.tokens > 0u ? 1u : 0u,
             .reset_model_session = true,
@@ -1624,7 +1633,7 @@ static int run_loop(const char *run_path, const char *fake_output,
     }
 
     struct spg_risk_score final_risk = {};
-    status = spg_risk_evaluate(&sim, &final_risk);
+    status                           = spg_risk_evaluate(&sim, &final_risk);
     if (status != SPG_OK) {
         fprintf(stderr, "run: final risk failed: %s\n",
                 spg_status_to_string(status));
@@ -1681,7 +1690,7 @@ done:
 }
 
 static int tick_command(int argc, char **argv) {
-    const char *run_path = nullptr;
+    const char *run_path    = nullptr;
     const char *fake_output = nullptr;
     for (int i = 2; i < argc; i += 1) {
         if (strcmp(argv[i], "--run") == 0 && i + 1 < argc) {
@@ -1704,14 +1713,14 @@ static int tick_command(int argc, char **argv) {
 }
 
 static int run_command(int argc, char **argv) {
-    const char *run_path = nullptr;
-    const char *fake_output = nullptr;
+    const char *run_path       = nullptr;
+    const char *fake_output    = nullptr;
     const char *sim_state_path = nullptr;
     const char *run_state_path = nullptr;
     const char *memory_dir     = getenv("GEISTSHELL_MEMORY_DIR");
     const char *remote_url     = nullptr;
     const char *remote_model   = nullptr;
-    size_t ticks = 3u;
+    size_t      ticks          = 3u;
     for (int i = 2; i < argc; i += 1) {
         if ((strcmp(argv[i], "--config") == 0 ||
              strcmp(argv[i], "--run") == 0) &&
@@ -1769,17 +1778,17 @@ static int run_command(int argc, char **argv) {
                     run_state_path, memory_dir, remote_url, remote_model);
 }
 
-#define AGENT_MAX_SCRIPT   64u
+#define AGENT_MAX_SCRIPT 64u
 #define AGENT_SHELL_STDOUT 4096u
 #define AGENT_SHELL_STDERR 1024u
-#define AGENT_OBS_BYTES    8192u
-#define CLI_PATH_MAX       4096u
+#define AGENT_OBS_BYTES 8192u
+#define CLI_PATH_MAX 4096u
 
 /* Split a script buffer into one fake reply per non-blank line (pointers into
  * data; no copy, no NUL needed). Returns the number of replies. */
 static size_t split_script_lines(char *data, const size_t n,
                                  struct spg_fake_response out[static 1],
-                                 const size_t cap) {
+                                 const size_t             cap) {
     size_t count = 0u;
     size_t i     = 0u;
     while (i < n && count < cap) {
@@ -1813,10 +1822,12 @@ static int agent_command(int argc, char **argv) {
     size_t      max_repairs    = 2u;
     bool        allow_exec     = false;
     bool        constrained    = false;
-    float       sample_temp    = 0.0f; /* >0 lets the free slots vary (best-of-N) */
-    bool        has_seed       = false;
-    uint64_t    seed_override  = 0u; /* per-attempt seed for best-of-N sampling */
-    size_t      best_of        = 1u; /* #2: verifier-guided best-of-N attempts */
+    float    sample_temp   = 0.0f; /* >0 lets the free slots vary (best-of-N) */
+    bool     has_seed      = false;
+    uint64_t seed_override = 0u; /* per-attempt seed for best-of-N sampling */
+    size_t   best_of       = 1u; /* #2: verifier-guided best-of-N attempts */
+    bool     with_machine  = false; /* roadmap phase 3: (machine-state ...) */
+    const char *profile_path = nullptr; /* (process-profile ...) file */
     for (int i = 2; i < argc; i += 1) {
         if ((strcmp(argv[i], "--config") == 0 ||
              strcmp(argv[i], "--run") == 0) &&
@@ -1869,7 +1880,8 @@ static int agent_command(int argc, char **argv) {
             continue;
         }
         if (strcmp(argv[i], "--directive-slug") == 0 && i + 1 < argc) {
-            /* render this stored lesson's directive every step (strong channel) */
+            /* render this stored lesson's directive every step (strong channel)
+             */
             directive_slug = argv[i + 1];
             i += 1;
             continue;
@@ -1888,6 +1900,16 @@ static int agent_command(int argc, char **argv) {
             i += 1;
             continue;
         }
+        if (strcmp(argv[i], "--machine") == 0) {
+            with_machine = true;
+            continue;
+        }
+        if (strcmp(argv[i], "--process-profile") == 0 && i + 1 < argc) {
+            profile_path = argv[i + 1];
+            with_machine = true; /* a profile without telemetry does nothing */
+            i += 1;
+            continue;
+        }
         if (strcmp(argv[i], "--best-of") == 0 && i + 1 < argc) {
             best_of = (size_t)strtoull(argv[i + 1], nullptr, 10);
             if (best_of == 0u) {
@@ -1902,6 +1924,7 @@ static int agent_command(int argc, char **argv) {
     if (run_path == nullptr) {
         fprintf(stderr,
                 "usage: %s agent --config <run> [--fake-script <file>] "
+                "[--machine] [--process-profile <file>] "
                 "[--max-steps N] [--max-repairs N] [--allow-exec] "
                 "[--memory-dir <d>]\n"
                 "  without --fake-script the real model at the config's "
@@ -1910,22 +1933,22 @@ static int agent_command(int argc, char **argv) {
         return 2;
     }
 
-    int                rc            = 1;
-    struct file_buffer run_text       = {};
-    struct file_buffer policy_text    = {};
-    struct file_buffer scenario_text  = {};
-    struct file_buffer script_text    = {};
-    struct file_buffer exemplars_text = {};
-    char              *policy_path   = nullptr;
-    char              *scenario_path = nullptr;
-    char              *journal_path  = nullptr;
-    char              *model_path    = nullptr;
-    struct spg_journal_writer journal     = {};
-    bool                      journal_open = false;
-    struct spg_model_adapter  model        = {};
-    bool                      model_open   = false;
-    struct spg_mem_store      store        = {};
-    bool                      store_open   = false;
+    int                       rc             = 1;
+    struct file_buffer        run_text       = {};
+    struct file_buffer        policy_text    = {};
+    struct file_buffer        scenario_text  = {};
+    struct file_buffer        script_text    = {};
+    struct file_buffer        exemplars_text = {};
+    char                     *policy_path    = nullptr;
+    char                     *scenario_path  = nullptr;
+    char                     *journal_path   = nullptr;
+    char                     *model_path     = nullptr;
+    struct spg_journal_writer journal        = {};
+    bool                      journal_open   = false;
+    struct spg_model_adapter  model          = {};
+    bool                      model_open     = false;
+    struct spg_mem_store      store          = {};
+    bool                      store_open     = false;
 
     struct spg_run_config run    = {};
     enum spg_status       status = load_run_file(run_path, &run_text, &run);
@@ -2013,7 +2036,7 @@ static int agent_command(int argc, char **argv) {
                           &policy, policy_text.n, policy_text.data,
                           sizeof agent_cap_names, agent_cap_names,
                           sizeof agent_caps / sizeof agent_caps[0], agent_caps)
-                                            : 0u;
+                    : 0u;
 
     /* Best-of-N needs the choice slots to vary between attempts (#2); if the
      * caller asked for it without a temperature, sample. */
@@ -2063,16 +2086,16 @@ static int agent_command(int argc, char **argv) {
     static struct spg_context_graph_ref   graph_refs[CLI_CONTEXT_REFS];
     static struct spg_context_memory_ref  memory_refs[CLI_CONTEXT_REFS];
     static struct spg_context_journal_ref journal_refs[CLI_CONTEXT_REFS];
-    static char            context[CLI_CONTEXT_BYTES];
-    static char            model_output[CLI_MODEL_OUTPUT_BYTES];
-    static struct spg_sexpr_token rec_tokens[CLI_TOKEN_CAPACITY];
-    static struct spg_sexpr_node  rec_nodes[CLI_NODE_CAPACITY];
-    static char            policy_payload[CLI_PAYLOAD_BYTES];
-    static char            sim_payload[CLI_PAYLOAD_BYTES];
-    static char            observation[AGENT_OBS_BYTES];
-    static char            shell_stdout[AGENT_SHELL_STDOUT];
-    static char            shell_stderr[AGENT_SHELL_STDERR];
-    static char            mem_index[AGENT_OBS_BYTES];
+    static char                           context[CLI_CONTEXT_BYTES];
+    static char                           model_output[CLI_MODEL_OUTPUT_BYTES];
+    static struct spg_sexpr_token         rec_tokens[CLI_TOKEN_CAPACITY];
+    static struct spg_sexpr_node          rec_nodes[CLI_NODE_CAPACITY];
+    static char                           policy_payload[CLI_PAYLOAD_BYTES];
+    static char                           sim_payload[CLI_PAYLOAD_BYTES];
+    static char                           observation[AGENT_OBS_BYTES];
+    static char                           shell_stdout[AGENT_SHELL_STDOUT];
+    static char                           shell_stderr[AGENT_SHELL_STDERR];
+    static char                           mem_index[AGENT_OBS_BYTES];
     static struct spg_journal_record_header trajectory[256];
 
     const struct spg_agent_run_workspace ws = {
@@ -2109,6 +2132,36 @@ static int agent_command(int argc, char **argv) {
     if (run.has_goal) {
         (void)span_to_cstr(run_text.n, run_text.data, run.goal, &goal_cstr);
     }
+    /* Sampled once per run, not per tick: phase 3 only proves the state
+     * reaches the context. Re-observing after an action is phase 7's job, and
+     * it needs an action to observe first. The timestamp is the run's, from the
+     * same injected counter the journal uses — no clock is read here either. */
+    struct spg_machine_state   machine = {};
+    struct spg_process_profile profile = {};
+    if (with_machine && profile_path != nullptr) {
+        struct file_buffer profile_text = {};
+        if (read_file(profile_path, &profile_text) != SPG_OK) {
+            fprintf(stderr, "agent: cannot read process profile: %s\n",
+                    profile_path);
+            return 2;
+        }
+        struct spg_process_profile_error perr    = {};
+        const enum spg_status            pstatus = spg_process_profile_load(
+            profile_text.n, profile_text.data, CLI_TOKEN_CAPACITY, rec_tokens,
+            CLI_NODE_CAPACITY, rec_nodes, &profile, &perr);
+        free_file_buffer(&profile_text);
+        if (pstatus != SPG_OK) {
+            fprintf(stderr,
+                    "agent: invalid process profile %s: %s at offset %zu\n",
+                    profile_path, spg_status_to_string(pstatus), perr.offset);
+            return 2;
+        }
+    }
+    if (with_machine) {
+        (void)spg_machine_sample_with_processes(
+            1u, nullptr, 0u, nullptr,
+            profile_path != nullptr ? &profile : nullptr, &machine);
+    }
     const struct spg_agent_run_inputs inputs = {
         .model         = &model,
         .policy        = &policy,
@@ -2120,26 +2173,31 @@ static int agent_command(int argc, char **argv) {
         .journal       = &journal,
         .exemplars     = exemplars_text.data, /* null when --exemplars absent */
         .goal          = goal_cstr,           /* null when (goal ...) absent */
+        /* Absent by default: without --machine the context is byte-identical
+         * to before this phase, which is what keeps the phase-0 freeze valid.
+         */
+        .machine = with_machine ? &machine : nullptr,
     };
     const struct spg_agent_run_config rcfg = {
-        .max_steps         = max_steps,
-        .max_repairs       = max_repairs,
+        .max_steps   = max_steps,
+        .max_repairs = max_repairs,
         /* #40: a model that acts validly but never emits (kind finish) would
          * run to the step cap; treat a converged (no-progress) run as done so
          * it terminates FINISHED and an expect verdict can pass. */
         .finish_on_no_progress = true,
         .directive_slug        = directive_slug,
         .execution_enabled     = allow_exec,
-        .exec_timeout_ms   = 5000u,
-        .exec_stdout_cap   = sizeof shell_stdout,
-        .exec_stderr_cap   = sizeof shell_stderr,
-        .context_refs      = CLI_CONTEXT_REFS,
+        .exec_timeout_ms       = 5000u,
+        .exec_stdout_cap       = sizeof shell_stdout,
+        .exec_stderr_cap       = sizeof shell_stderr,
+        .context_refs          = CLI_CONTEXT_REFS,
     };
     struct spg_policy_usage      usage       = {};
     struct spg_agent_loop_result loop_result = {};
 
     /* Optional success criterion (docs/LEARNING.md P1): judge the real run the
-     * same way the eval loop judges a scripted case — model-free, zero tokens. */
+     * same way the eval loop judges a scripted case — model-free, zero tokens.
+     */
     const bool have_expect =
         run.has_expect && run.expect_observation.length < sizeof observation;
     char                   expect_obs[AGENT_OBS_BYTES];
@@ -2148,21 +2206,23 @@ static int agent_command(int argc, char **argv) {
         memcpy(expect_obs, run_text.data + run.expect_observation.offset,
                run.expect_observation.length);
         expect_obs[run.expect_observation.length] = '\0';
-        expect = (struct spg_eval_expect){.check_termination = true,
-                                          .termination = SPG_AGENT_LOOP_FINISHED,
-                                          .observation = expect_obs};
+        expect =
+            (struct spg_eval_expect){.check_termination = true,
+                                     .termination = SPG_AGENT_LOOP_FINISHED,
+                                     .observation = expect_obs};
     }
 
-    /* Verifier-guided best-of-N (#2): up to best_of attempts, model loaded once;
-     * the choice-slot RNG drifts between attempts (temperature > 0), so each
-     * explores different valid decisions, and we keep the first the verifier
-     * passes. Needs an (expect ...) to select on — without it a single run. */
-    const size_t         attempts = have_expect ? best_of : 1u;
+    /* Verifier-guided best-of-N (#2): up to best_of attempts, model loaded
+     * once; the choice-slot RNG drifts between attempts (temperature > 0), so
+     * each explores different valid decisions, and we keep the first the
+     * verifier passes. Needs an (expect ...) to select on — without it a single
+     * run. */
+    const size_t          attempts = have_expect ? best_of : 1u;
     enum spg_eval_outcome verdict  = SPG_EVAL_PASS;
     size_t                used     = 0u;
     for (size_t a = 0u; a < attempts; a += 1u) {
-        used  = a + 1u;
-        usage = (struct spg_policy_usage){}; /* each attempt is independent */
+        used   = a + 1u;
+        usage  = (struct spg_policy_usage){}; /* each attempt is independent */
         status = spg_agent_run(&inputs, &rcfg, &ws, &usage, &loop_result);
         if (!have_expect) {
             break;
@@ -2185,7 +2245,8 @@ static int agent_command(int argc, char **argv) {
         if (attempts > 1u) {
             printf("best_of=%zu attempts_used=%zu\n", attempts, used);
         }
-        /* a FAIL exits non-zero so a caller (and a future miner) can act on it */
+        /* a FAIL exits non-zero so a caller (and a future miner) can act on it
+         */
         if (verdict != SPG_EVAL_PASS && rc == 0) {
             rc = 1;
         }
@@ -2216,7 +2277,7 @@ done:
 static uint32_t eval_field(const struct spg_sexpr_node *nodes,
                            const uint32_t parent, const size_t in_n,
                            const char *in, const char *name) {
-    for (uint32_t c = spg_sexpr_first_child(nodes, parent);
+    for (uint32_t c                      = spg_sexpr_first_child(nodes, parent);
          c != SPG_SEXPR_INVALID_INDEX; c = nodes[c].next_sibling) {
         if (nodes[c].kind != SPG_SEXPR_NODE_LIST) {
             continue;
@@ -2238,10 +2299,11 @@ static bool eval_str(const struct spg_sexpr_node *nodes, const uint32_t parent,
     if (f == SPG_SEXPR_INVALID_INDEX) {
         return false;
     }
-    const uint32_t v = spg_sexpr_second_child(nodes, f);
+    const uint32_t       v = spg_sexpr_second_child(nodes, f);
     struct spg_text_span sp;
     if (v == SPG_SEXPR_INVALID_INDEX ||
-        !spg_sexpr_string_payload_span(&nodes[v], &sp) || sp.length + 1u > cap) {
+        !spg_sexpr_string_payload_span(&nodes[v], &sp) ||
+        sp.length + 1u > cap) {
         return false;
     }
     memcpy(out, in + sp.offset, sp.length);
@@ -2257,7 +2319,8 @@ static bool eval_u64(const struct spg_sexpr_node *nodes, const uint32_t parent,
         return false;
     }
     const uint32_t v = spg_sexpr_second_child(nodes, f);
-    if (v == SPG_SEXPR_INVALID_INDEX || nodes[v].kind != SPG_SEXPR_NODE_SYMBOL) {
+    if (v == SPG_SEXPR_INVALID_INDEX ||
+        nodes[v].kind != SPG_SEXPR_NODE_SYMBOL) {
         return false;
     }
     return spg_sexpr_parse_uint64_span(in_n, in, nodes[v].span, out) == SPG_OK;
@@ -2278,14 +2341,15 @@ static bool eval_flag(const struct spg_sexpr_node *nodes, const uint32_t parent,
 /* Map an (expect (termination <sym>) ...) symbol to the enum. */
 static bool eval_termination(const struct spg_sexpr_node *nodes,
                              const uint32_t expect, const size_t in_n,
-                             const char *in,
+                             const char                      *in,
                              enum spg_agent_loop_termination *out) {
     const uint32_t f = eval_field(nodes, expect, in_n, in, "termination");
     if (f == SPG_SEXPR_INVALID_INDEX) {
         return false;
     }
     const uint32_t v = spg_sexpr_second_child(nodes, f);
-    if (v == SPG_SEXPR_INVALID_INDEX || nodes[v].kind != SPG_SEXPR_NODE_SYMBOL) {
+    if (v == SPG_SEXPR_INVALID_INDEX ||
+        nodes[v].kind != SPG_SEXPR_NODE_SYMBOL) {
         return false;
     }
     static const enum spg_agent_loop_termination all[] = {
@@ -2293,8 +2357,9 @@ static bool eval_termination(const struct spg_sexpr_node *nodes,
         SPG_AGENT_LOOP_REJECTED, SPG_AGENT_LOOP_DENIED,
         SPG_AGENT_LOOP_BUDGET,   SPG_AGENT_LOOP_ERROR};
     for (size_t i = 0u; i < sizeof all / sizeof all[0]; i += 1u) {
-        if (spg_sexpr_span_eq_cstr(in_n, in, nodes[v].span,
-                                   spg_agent_loop_termination_to_string(all[i]))) {
+        if (spg_sexpr_span_eq_cstr(
+                in_n, in, nodes[v].span,
+                spg_agent_loop_termination_to_string(all[i]))) {
             *out = all[i];
             return true;
         }
@@ -2307,28 +2372,29 @@ static bool eval_termination(const struct spg_sexpr_node *nodes,
 #define EVAL_MAX_CASES 64u
 
 struct eval_run_report {
-    size_t                      total;  /* individual runs (cases x samples)   */
-    size_t                      passed; /* individual passing runs             */
-    size_t                      ncases; /* distinct cases (index into the rest) */
-    char                        names[EVAL_MAX_CASES][64];
-    struct spg_eval_case_result results[EVAL_MAX_CASES]; /* last sample/case   */
-    size_t                      runs[EVAL_MAX_CASES];        /* samples per case */
-    size_t                      case_passed[EVAL_MAX_CASES]; /* k passed of N    */
+    size_t total;  /* individual runs (cases x samples)   */
+    size_t passed; /* individual passing runs             */
+    size_t ncases; /* distinct cases (index into the rest) */
+    char   names[EVAL_MAX_CASES][64];
+    struct spg_eval_case_result results[EVAL_MAX_CASES]; /* last sample/case */
+    size_t                      runs[EVAL_MAX_CASES];    /* samples per case */
+    size_t case_passed[EVAL_MAX_CASES];                  /* k passed of N    */
     /* #53 ladder, per case and summed. Monotone by construction:
      * task <= gate <= parse. A pass-rate alone cannot tell "the model cannot
      * produce the form" from "it produces a valid form and picks the wrong
      * action", and those want opposite fixes. */
-    size_t                      case_parsed[EVAL_MAX_CASES];
-    size_t                      case_gated[EVAL_MAX_CASES];
-    size_t                      parsed; /* runs whose form was accepted        */
-    size_t                      gated;  /* ... and the policy gate allowed it  */
+    size_t case_parsed[EVAL_MAX_CASES];
+    size_t case_gated[EVAL_MAX_CASES];
+    size_t parsed; /* runs whose form was accepted        */
+    size_t gated;  /* ... and the policy gate allowed it  */
 };
 
 /* One run's rungs. REJECTED means the loop ran out of repairs on a malformed
  * reply — the form never parsed. DENIED means it parsed and the policy gate
- * refused it. Anything else got past both, whether or not it reached the goal. */
-static void eval_tally_ladder(struct eval_run_report *report,
-                              const size_t case_idx,
+ * refused it. Anything else got past both, whether or not it reached the goal.
+ */
+static void eval_tally_ladder(struct eval_run_report            *report,
+                              const size_t                       case_idx,
                               const struct spg_eval_case_result *r) {
     if (r->outcome == SPG_EVAL_FAIL_RUN_ERROR) {
         return; /* the harness failed, not the model — no rung is earned */
@@ -2348,17 +2414,17 @@ static void eval_tally_ladder(struct eval_run_report *report,
 /* Per-invocation knobs. A null pointer (or zeroed struct) reproduces the
  * historical behaviour: one sample per case, no remote endpoint. */
 struct eval_run_opts {
-    const char *remote_url;   /* nullable: enables (model "remote") cases      */
-    const char *remote_model; /* nullable: model name for remote cases         */
-    size_t      samples;      /* 0/1 => run each case once                     */
+    const char *remote_url; /* nullable: enables (model "remote") cases      */
+    const char *remote_model; /* nullable: model name for remote cases */
+    size_t      samples; /* 0/1 => run each case once                     */
     /* #51: run (model "geist") cases through the SAME decoder as
      * `agent --constrained`. Off by default so the shipped scripted-fake
      * suites keep their recorded free-decode behaviour. */
-    bool        constrained;
+    bool constrained;
     /* #51: sampling temperature for real-model cases. 0.0 (the default) is
      * greedy — which makes --samples N produce N identical runs, so a suite
      * that wants variance must ask for it. */
-    float       temperature;
+    float temperature;
 };
 
 /* #52: one case-sample's sandbox. Big (the store carries an index cache), so
@@ -2391,7 +2457,7 @@ static bool eval_sandbox_prepare(struct eval_sandbox *sb, const char *case_name,
         spg_fixture_copy_into(sb->dir, fixture_dir) != SPG_OK) {
         return false;
     }
-    char mem[CLI_PATH_MAX];
+    char      mem[CLI_PATH_MAX];
     const int n = snprintf(mem, sizeof mem, "%s/mem", sb->dir);
     if (n < 0 || (size_t)n >= sizeof mem) {
         return false;
@@ -2411,11 +2477,11 @@ static bool eval_sandbox_prepare(struct eval_sandbox *sb, const char *case_name,
 /* Load a suite + its shared run/policy/scenario config and run every case with
  * the given mind-palace store (nullable) threaded into each run; fill *report.
  * Returns SPG_OK on a complete run. Prints nothing (the caller reports). */
-static enum spg_status eval_run_suite(const char *suite_path,
-                                      struct spg_mem_store *store,
+static enum spg_status eval_run_suite(const char                 *suite_path,
+                                      struct spg_mem_store       *store,
                                       const struct eval_run_opts *opts,
-                                      struct eval_run_report *report) {
-    *report = (struct eval_run_report){};
+                                      struct eval_run_report     *report) {
+    *report                          = (struct eval_run_report){};
     struct file_buffer suite_text    = {};
     struct file_buffer run_text      = {};
     struct file_buffer policy_text   = {};
@@ -2436,8 +2502,8 @@ static enum spg_status eval_run_suite(const char *suite_path,
     size_t                        nn = 0u;
     struct spg_sexpr_error        se = {};
     if (spg_sexpr_parse_text(suite_text.n, suite_text.data, CLI_TOKEN_CAPACITY,
-                             tok, CLI_NODE_CAPACITY, nod, &tn, &nn, &se) !=
-            SPG_OK ||
+                             tok, CLI_NODE_CAPACITY, nod, &tn, &nn,
+                             &se) != SPG_OK ||
         nn == 0u || nod[0].kind != SPG_SEXPR_NODE_LIST) {
         rc = SPG_E_FORMAT;
         goto done;
@@ -2450,7 +2516,7 @@ static enum spg_status eval_run_suite(const char *suite_path,
     }
 
     struct spg_run_config run = {};
-    status = load_run_file(config_path, &run_text, &run);
+    status                    = load_run_file(config_path, &run_text, &run);
     if (status == SPG_OK) {
         status = span_to_cstr(run_text.n, run_text.data, run.policy_path,
                               &policy_path);
@@ -2460,8 +2526,8 @@ static enum spg_status eval_run_suite(const char *suite_path,
                               &scenario_path);
     }
     if (status == SPG_OK) {
-        status =
-            span_to_cstr(run_text.n, run_text.data, run.model_path, &model_path);
+        status = span_to_cstr(run_text.n, run_text.data, run.model_path,
+                              &model_path);
     }
     if (status != SPG_OK) {
         rc = status;
@@ -2480,26 +2546,25 @@ static enum spg_status eval_run_suite(const char *suite_path,
      * below, hence static. */
     static struct spg_model_capability eval_caps[SPG_MODEL_CAPABILITY_MAX];
     static char                        eval_cap_names[CLI_CAP_NAMES_BYTES];
-    const size_t                       eval_caps_n =
-        spg_model_capabilities_from_policy(
-                                  &policy, policy_text.n, policy_text.data, sizeof eval_cap_names,
-                                  eval_cap_names, sizeof eval_caps / sizeof eval_caps[0], eval_caps);
+    const size_t eval_caps_n = spg_model_capabilities_from_policy(
+        &policy, policy_text.n, policy_text.data, sizeof eval_cap_names,
+        eval_cap_names, sizeof eval_caps / sizeof eval_caps[0], eval_caps);
 
     static struct spg_context_graph_ref   graph_refs[CLI_CONTEXT_REFS];
     static struct spg_context_memory_ref  memory_refs[CLI_CONTEXT_REFS];
     static struct spg_context_journal_ref journal_refs[CLI_CONTEXT_REFS];
-    static char            context[CLI_CONTEXT_BYTES];
-    static char            model_output[CLI_MODEL_OUTPUT_BYTES];
-    static struct spg_sexpr_token rtok[CLI_TOKEN_CAPACITY];
-    static struct spg_sexpr_node  rnod[CLI_NODE_CAPACITY];
-    static char            ppay[CLI_PAYLOAD_BYTES];
-    static char            spay[CLI_PAYLOAD_BYTES];
-    static char            observation[AGENT_OBS_BYTES];
-    static char            sh_out[AGENT_SHELL_STDOUT];
-    static char            sh_err[AGENT_SHELL_STDERR];
-    static char            mem_index[AGENT_OBS_BYTES];
+    static char                           context[CLI_CONTEXT_BYTES];
+    static char                           model_output[CLI_MODEL_OUTPUT_BYTES];
+    static struct spg_sexpr_token         rtok[CLI_TOKEN_CAPACITY];
+    static struct spg_sexpr_node          rnod[CLI_NODE_CAPACITY];
+    static char                           ppay[CLI_PAYLOAD_BYTES];
+    static char                           spay[CLI_PAYLOAD_BYTES];
+    static char                           observation[AGENT_OBS_BYTES];
+    static char                           sh_out[AGENT_SHELL_STDOUT];
+    static char                           sh_err[AGENT_SHELL_STDERR];
+    static char                           mem_index[AGENT_OBS_BYTES];
     static struct spg_journal_record_header traj[256];
-    const struct spg_agent_run_workspace ws = {
+    const struct spg_agent_run_workspace    ws = {
         .context_capacity        = sizeof context,
         .context                 = context,
         .model_output_capacity   = sizeof model_output,
@@ -2540,8 +2605,8 @@ static enum spg_status eval_run_suite(const char *suite_path,
 
     /* Invocation-wide knobs (resolved once, not per case). */
     const struct eval_run_opts  defaults = {};
-    const struct eval_run_opts *o = (opts != nullptr) ? opts : &defaults;
-    const size_t                samples = (o->samples > 0u) ? o->samples : 1u;
+    const struct eval_run_opts *o        = (opts != nullptr) ? opts : &defaults;
+    const size_t                samples  = (o->samples > 0u) ? o->samples : 1u;
     const char                 *env_api_url = getenv("GEISTSHELL_API_URL");
     const char                 *remote_url =
         (o->remote_url != nullptr && o->remote_url[0] != '\0') ? o->remote_url
@@ -2586,8 +2651,8 @@ static enum spg_status eval_run_suite(const char *suite_path,
                 : nullptr;
 
         struct spg_eval_expect expect = {};
-        const uint32_t exp = eval_field(nod, c, suite_text.n, suite_text.data,
-                                        "expect");
+        const uint32_t         exp =
+            eval_field(nod, c, suite_text.n, suite_text.data, "expect");
         if (exp != SPG_SEXPR_INVALID_INDEX) {
             enum spg_agent_loop_termination term;
             if (eval_termination(nod, exp, suite_text.n, suite_text.data,
@@ -2619,31 +2684,28 @@ static enum spg_status eval_run_suite(const char *suite_path,
         /* #53: a real-model baseline needs a task per case; without this every
          * case would inherit the one goal in the shared run config. */
         static char case_goal[1024];
-        const bool  has_goal =
-            eval_str(nod, c, suite_text.n, suite_text.data, "goal", case_goal,
-                     sizeof case_goal);
+        const bool  has_goal = eval_str(nod, c, suite_text.n, suite_text.data,
+                                        "goal", case_goal, sizeof case_goal);
         char        fixture[CLI_PATH_MAX];
-        const bool  has_fixture =
-            eval_str(nod, c, suite_text.n, suite_text.data, "fixture", fixture,
-                     sizeof fixture);
+        const bool has_fixture = eval_str(nod, c, suite_text.n, suite_text.data,
+                                          "fixture", fixture, sizeof fixture);
         static struct eval_sandbox sandbox_state;
         const char *const          sandbox = sandbox_state.dir;
 
         const struct spg_agent_run_config rcfg = {
-            .max_steps         = (size_t)max_steps,
-            .max_repairs       = (size_t)max_repairs,
-            .execution_enabled = allow_exec,
-            .exec_timeout_ms   = 5000u,
-            .exec_stdout_cap   = sizeof sh_out,
-            .exec_stderr_cap   = sizeof sh_err,
-            .context_refs      = CLI_CONTEXT_REFS,
+            .max_steps           = (size_t)max_steps,
+            .max_repairs         = (size_t)max_repairs,
+            .execution_enabled   = allow_exec,
+            .exec_timeout_ms     = 5000u,
+            .exec_stdout_cap     = sizeof sh_out,
+            .exec_stderr_cap     = sizeof sh_err,
+            .context_refs        = CLI_CONTEXT_REFS,
             .exec_working_dir    = has_fixture ? sandbox : nullptr,
             .exec_workdir_prefix = has_fixture ? sandbox : nullptr,
         };
         char       model_kind[16];
-        const bool has_model =
-            eval_str(nod, c, suite_text.n, suite_text.data, "model", model_kind,
-                     sizeof model_kind);
+        const bool has_model = eval_str(nod, c, suite_text.n, suite_text.data,
+                                        "model", model_kind, sizeof model_kind);
         const bool geist_case  = has_model && strcmp(model_kind, "geist") == 0;
         const bool remote_case = has_model && strcmp(model_kind, "remote") == 0;
 
@@ -2658,11 +2720,11 @@ static enum spg_status eval_run_suite(const char *suite_path,
              * the GGUF. */
             struct spg_model_adapter        model = {};
             struct spg_model_adapter_config mc    = {
-                   .sampling = {.max_seq_len = 4096u,
-                                .temperature = o->temperature,
-                                .top_p       = 1.0f,
-                                .top_k       = 0,
-                                .random_seed = run.seed},
+                .sampling = {.max_seq_len = 4096u,
+                             .temperature = o->temperature,
+                             .top_p       = 1.0f,
+                             .top_k       = 0,
+                             .random_seed = run.seed},
             };
             if (geist_case) {
                 mc.kind       = SPG_MODEL_ADAPTER_GEIST;
@@ -2690,7 +2752,8 @@ static enum spg_status eval_run_suite(const char *suite_path,
                     : spg_model_adapter_init(&model, &mc);
             if (is != SPG_OK) {
                 if (geist_case) {
-                    rc = SPG_E_MODEL; /* a configured GGUF that won't load aborts */
+                    rc = SPG_E_MODEL; /* a configured GGUF that won't load
+                                         aborts */
                     goto done;
                 }
                 /* Remote misconfig / default (non-REMOTE) build: one clean
@@ -2755,7 +2818,7 @@ static enum spg_status eval_run_suite(const char *suite_path,
                 goto done;
             }
             static struct spg_fake_response script[EVAL_SCRIPT_MAX];
-            const size_t script_n = split_script_lines(
+            const size_t                    script_n = split_script_lines(
                 script_text.data, script_text.n, script, EVAL_SCRIPT_MAX);
             for (size_t s = 0u; s < samples; s += 1u) {
                 struct spg_agent_run_inputs cin = inputs;
@@ -2763,8 +2826,8 @@ static enum spg_status eval_run_suite(const char *suite_path,
                     cin.goal = case_goal;
                 }
                 if (has_fixture) {
-                    if (!eval_sandbox_prepare(&sandbox_state, name, s,
-                                              fixture, store)) {
+                    if (!eval_sandbox_prepare(&sandbox_state, name, s, fixture,
+                                              store)) {
                         last = (struct spg_eval_case_result){
                             .outcome = SPG_EVAL_FAIL_RUN_ERROR,
                             .status  = SPG_E_IO};
@@ -2774,10 +2837,10 @@ static enum spg_status eval_run_suite(const char *suite_path,
                     }
                     cin.store = &sandbox_state.store;
                 }
-                struct spg_eval_case_result r  = {};
-                const enum spg_status       cs = spg_eval_run_case(
-                          script, script_n, gate_marker, &cin, &rcfg, &ws,
-                          &expect, &r);
+                struct spg_eval_case_result r = {};
+                const enum spg_status       cs =
+                    spg_eval_run_case(script, script_n, gate_marker, &cin,
+                                      &rcfg, &ws, &expect, &r);
                 if (cs != SPG_OK) {
                     free_file_buffer(&script_text);
                     rc = cs;
@@ -2812,7 +2875,7 @@ done:
     return rc;
 }
 
-static void eval_print_report(const char *suite_path,
+static void eval_print_report(const char                   *suite_path,
                               const struct eval_run_report *report) {
     for (size_t i = 0u; i < report->ncases; i += 1u) {
         const struct spg_eval_case_result *r = &report->results[i];
@@ -2892,8 +2955,8 @@ static int eval_command(int argc, char **argv) {
                                           .samples      = samples,
                                           .constrained  = constrained,
                                           .temperature  = temperature};
-    const enum spg_status status = eval_run_suite(suite_path, nullptr, &opts,
-                                                  &report);
+    const enum spg_status         status =
+        eval_run_suite(suite_path, nullptr, &opts, &report);
     if (status != SPG_OK) {
         fprintf(stderr, "eval: suite run failed: %s\n",
                 spg_status_to_string(status));
@@ -2942,9 +3005,11 @@ static bool guard_run(void *vctx, const char *config_path, bool with_lesson) {
     /* the guard's own (expect) criterion (P1) is what judges it */
     struct file_buffer    cfg_text = {};
     struct spg_run_config cfg      = {};
-    if (load_run_file(config_path, &cfg_text, &cfg) != SPG_OK || !cfg.has_expect) {
+    if (load_run_file(config_path, &cfg_text, &cfg) != SPG_OK ||
+        !cfg.has_expect) {
         free_file_buffer(&cfg_text);
-        return false; /* no criterion -> cannot judge -> no signal (baseline fail) */
+        return false; /* no criterion -> cannot judge -> no signal (baseline
+                         fail) */
     }
     char   expect[AGENT_OBS_BYTES];
     size_t en = cfg.expect_observation.length < sizeof expect
@@ -2957,8 +3022,7 @@ static bool guard_run(void *vctx, const char *config_path, bool with_lesson) {
     /* synthesise a one-case suite over the guard config; (model "geist") uses
      * the real model from that config, with the mind-palace injected */
     char   suite[1024];
-    size_t w = (size_t)snprintf(suite, sizeof suite,
-                                "(eval_suite (config \"");
+    size_t w = (size_t)snprintf(suite, sizeof suite, "(eval_suite (config \"");
     sexpr_escape(suite, sizeof suite, &w, config_path);
     w += (size_t)snprintf(suite + w, sizeof suite - w,
                           "\") (case (name \"guard\") (model \"geist\") "
@@ -3121,7 +3185,7 @@ static int audit_command(int argc, char **argv) {
             fprintf(stderr, "audit: cannot open memory dir\n");
             return 1;
         }
-        char   probe[SPG_MEM_DESC_MAX + 1u];
+        char probe[SPG_MEM_DESC_MAX + 1u];
         const struct {
             const char *slug;
             size_t      count;
@@ -3132,9 +3196,10 @@ static int audit_command(int argc, char **argv) {
                                   probe) == 0u) {
                 continue; /* no such lesson kept */
             }
-            printf("{\"lesson\":\"%s\",\"recurrence\":%zu,\"verdict\":\"%s\"}\n",
-                   kept[i].slug, kept[i].count,
-                   kept[i].count > 0u ? "review" : "kept");
+            printf(
+                "{\"lesson\":\"%s\",\"recurrence\":%zu,\"verdict\":\"%s\"}\n",
+                kept[i].slug, kept[i].count,
+                kept[i].count > 0u ? "review" : "kept");
         }
     }
     return 0;
@@ -3144,14 +3209,14 @@ static int audit_command(int argc, char **argv) {
  * persist each tentatively into the mind-palace, re-run, and keep it only if
  * the pass count did not drop (else revert). Emits a JSONL report. */
 static int improve_command(int argc, char **argv) {
-    const char *suite_path   = nullptr;
-    const char *memory_dir   = nullptr;
-    const char *remote_url    = nullptr;
-    const char *remote_model  = nullptr;
-    const char *validate_path = nullptr;
-    size_t      samples       = 1u;
-    bool        constrained   = false;
-    float       temperature   = 0.0f;
+    const char           *suite_path    = nullptr;
+    const char           *memory_dir    = nullptr;
+    const char           *remote_url    = nullptr;
+    const char           *remote_model  = nullptr;
+    const char           *validate_path = nullptr;
+    size_t                samples       = 1u;
+    bool                  constrained   = false;
+    float                 temperature   = 0.0f;
     struct spg_guard_ring guards;
     spg_guard_ring_init(&guards);
     for (int i = 2; i < argc; i += 1) {
@@ -3179,7 +3244,8 @@ static int improve_command(int argc, char **argv) {
             continue;
         }
         /* #51: the gate must measure the decoder the agent actually runs — a
-         * lesson kept under free decode says nothing about a constrained one. */
+         * lesson kept under free decode says nothing about a constrained one.
+         */
         if (strcmp(argv[i], "--constrained") == 0) {
             constrained = true;
             continue;
@@ -3206,12 +3272,13 @@ static int improve_command(int argc, char **argv) {
         return 2;
     }
     if (suite_path == nullptr) {
-        fprintf(stderr,
-                "usage: %s improve <suite.spg> [--validate <holdout.spg>] "
-                "[--guard <run.spg>]... "
-                "[--memory-dir <d>] [--remote-url <url>] [--remote-model <name>] "
-                "[--samples <N>] [--constrained] [--temperature <t>]\n",
-                argv[0]);
+        fprintf(
+            stderr,
+            "usage: %s improve <suite.spg> [--validate <holdout.spg>] "
+            "[--guard <run.spg>]... "
+            "[--memory-dir <d>] [--remote-url <url>] [--remote-model <name>] "
+            "[--samples <N>] [--constrained] [--temperature <t>]\n",
+            argv[0]);
         return 2;
     }
 
@@ -3222,11 +3289,11 @@ static int improve_command(int argc, char **argv) {
         return 1;
     }
 
-    const struct eval_run_opts opts = {.remote_url   = remote_url,
-                                       .remote_model = remote_model,
-                                       .samples      = samples,
-                                       .constrained  = constrained,
-                                       .temperature  = temperature};
+    const struct eval_run_opts    opts = {.remote_url   = remote_url,
+                                          .remote_model = remote_model,
+                                          .samples      = samples,
+                                          .constrained  = constrained,
+                                          .temperature  = temperature};
     static struct eval_run_report baseline;
     if (eval_run_suite(suite_path, &store, &opts, &baseline) != SPG_OK) {
         fprintf(stderr, "improve: baseline run failed\n");
@@ -3257,8 +3324,8 @@ static int improve_command(int argc, char **argv) {
     /* Hold-out gate: candidate lessons are distilled from the *train* suite
      * (above), but the keep/revert decision is measured on the *validation*
      * suite when one is given — so a lesson is kept only if it generalises to
-     * cases it was not derived from, not merely because it fit the suite it came
-     * from. Without --validate the gate falls back to the train suite (the
+     * cases it was not derived from, not merely because it fit the suite it
+     * came from. Without --validate the gate falls back to the train suite (the
      * historical behaviour, and the output is byte-identical). */
     const char *const gate_path =
         validate_path != nullptr ? validate_path : suite_path;
@@ -3287,7 +3354,7 @@ static int improve_command(int argc, char **argv) {
          * (P5, Weg 2): re-run every guard with vs without the lesson and veto
          * if any that passed now regresses. A guard vetoes only a lesson the
          * suite already accepts, so it can only make the gate stricter. */
-        bool accepted = spg_improve_accept(cur_passed, trial.passed);
+        bool accepted     = spg_improve_accept(cur_passed, trial.passed);
         bool guard_vetoed = false;
         if (accepted) {
             struct guard_ctx gctx = {
@@ -3302,7 +3369,7 @@ static int improve_command(int argc, char **argv) {
                                lesson->body);
         }
         (void)guard_vetoed;
-        bool       was_kept = false;
+        bool was_kept = false;
         (void)spg_improve_commit(&store, lesson, accepted, &was_kept);
         if (validate_path != nullptr) {
             printf("{\"lesson\":\"%s\",\"accepted\":%s,\"held_out_passed\":%zu,"
@@ -3321,9 +3388,10 @@ static int improve_command(int argc, char **argv) {
         }
     }
     if (validate_path != nullptr) {
-        printf("{\"suite\":\"%s\",\"validate\":\"%s\",\"held_out_baseline\":%zu,"
-               "\"held_out_final\":%zu,\"lessons_kept\":%zu}\n",
-               suite_path, validate_path, orig_passed, cur_passed, kept);
+        printf(
+            "{\"suite\":\"%s\",\"validate\":\"%s\",\"held_out_baseline\":%zu,"
+            "\"held_out_final\":%zu,\"lessons_kept\":%zu}\n",
+            suite_path, validate_path, orig_passed, cur_passed, kept);
     } else {
         printf("{\"suite\":\"%s\",\"baseline_passed\":%zu,\"final_passed\":%zu,"
                "\"lessons_kept\":%zu}\n",
@@ -3363,9 +3431,10 @@ static int seal_journal_command(int argc, char **argv) {
         return 2;
     }
     if (journal == nullptr || key_path == nullptr) {
-        fprintf(stderr,
-                "usage: %s seal-journal <journal> --key <keyfile> [--sig <p>]\n",
-                argv[0]);
+        fprintf(
+            stderr,
+            "usage: %s seal-journal <journal> --key <keyfile> [--sig <p>]\n",
+            argv[0]);
         return 2;
     }
     struct file_buffer keyb = {};
@@ -3387,7 +3456,8 @@ static int seal_journal_command(int argc, char **argv) {
     return 0;
 }
 
-/* Verify a journal's keyed seal; prints signed=true/false, non-zero on mismatch. */
+/* Verify a journal's keyed seal; prints signed=true/false, non-zero on
+ * mismatch. */
 static int verify_signed_cli(const char *journal, const char *key_path,
                              const char *sig) {
     struct file_buffer keyb = {};

--- a/src/context/context.c
+++ b/src/context/context.c
@@ -15,8 +15,8 @@ static struct spg_context_budget_item budget_item(const uint64_t configured,
     };
 }
 
-static void build_budgets(const struct spg_run_config *run,
-                          const struct spg_policy_usage *usage,
+static void build_budgets(const struct spg_run_config    *run,
+                          const struct spg_policy_usage  *usage,
                           struct spg_context_budget_view *out) {
     const struct spg_run_budgets configured =
         run == nullptr ? (struct spg_run_budgets){} : run->budgets;
@@ -25,17 +25,17 @@ static void build_budgets(const struct spg_run_config *run,
     *out = (struct spg_context_budget_view){
         .inference_steps =
             budget_item(configured.inference_steps, consumed.inference_steps),
-        .tokens        = budget_item(configured.tokens, consumed.tokens),
-        .shell_actions = budget_item(configured.shell_actions,
-                                     consumed.shell_actions),
-        .sim_actions   = budget_item(configured.sim_actions,
-                                     consumed.sim_actions),
-        .memory_actions = budget_item(configured.memory_actions,
-                                      consumed.memory_actions),
-        .wall_ms       = budget_item(configured.wall_ms, consumed.wall_ms),
-        .journal_bytes = budget_item(configured.journal_bytes,
-                                     consumed.journal_bytes),
-        .risk_bp       = budget_item(configured.risk_bp, consumed.risk_bp),
+        .tokens = budget_item(configured.tokens, consumed.tokens),
+        .shell_actions =
+            budget_item(configured.shell_actions, consumed.shell_actions),
+        .sim_actions =
+            budget_item(configured.sim_actions, consumed.sim_actions),
+        .memory_actions =
+            budget_item(configured.memory_actions, consumed.memory_actions),
+        .wall_ms = budget_item(configured.wall_ms, consumed.wall_ms),
+        .journal_bytes =
+            budget_item(configured.journal_bytes, consumed.journal_bytes),
+        .risk_bp = budget_item(configured.risk_bp, consumed.risk_bp),
     };
 }
 
@@ -102,7 +102,7 @@ static bool graph_ref_before(const struct spg_context_graph_ref *left,
     return left->node.index < right->node.index;
 }
 
-static void insert_graph_ref(struct spg_context_view *view,
+static void insert_graph_ref(struct spg_context_view           *view,
                              const struct spg_context_graph_ref ref) {
     if (view->graph_ref_capacity == 0u) {
         view->graph_truncated = true;
@@ -115,7 +115,7 @@ static void insert_graph_ref(struct spg_context_view *view,
             view->graph_truncated = true;
             return;
         }
-        pos = view->graph_ref_capacity - 1u;
+        pos                   = view->graph_ref_capacity - 1u;
         view->graph_truncated = true;
     } else {
         view->graph_ref_count += 1u;
@@ -170,7 +170,7 @@ static bool memory_ref_before(const struct spg_context_memory_ref *left,
     return left->fact.index < right->fact.index;
 }
 
-static void insert_memory_ref(struct spg_context_view *view,
+static void insert_memory_ref(struct spg_context_view            *view,
                               const struct spg_context_memory_ref ref) {
     if (view->memory_ref_capacity == 0u) {
         view->memory_truncated = true;
@@ -184,7 +184,7 @@ static void insert_memory_ref(struct spg_context_view *view,
             view->memory_truncated = true;
             return;
         }
-        pos = view->memory_ref_capacity - 1u;
+        pos                    = view->memory_ref_capacity - 1u;
         view->memory_truncated = true;
     } else {
         view->memory_ref_count += 1u;
@@ -204,8 +204,9 @@ static bool journal_ref_before(const struct spg_context_journal_ref *left,
     return left->source_index < right->source_index;
 }
 
-static void insert_recent_journal_ref(struct spg_context_view *view,
-                                      const struct spg_context_journal_ref ref) {
+static void
+insert_recent_journal_ref(struct spg_context_view             *view,
+                          const struct spg_context_journal_ref ref) {
     if (view->journal_ref_capacity == 0u) {
         view->journal_truncated = true;
         return;
@@ -218,7 +219,7 @@ static void insert_recent_journal_ref(struct spg_context_view *view,
             view->journal_truncated = true;
             return;
         }
-        pos = view->journal_ref_capacity - 1u;
+        pos                     = view->journal_ref_capacity - 1u;
         view->journal_truncated = true;
     } else {
         view->journal_ref_count += 1u;
@@ -233,19 +234,19 @@ static void insert_recent_journal_ref(struct spg_context_view *view,
 
 static void reverse_journal_refs(struct spg_context_view *view) {
     for (size_t i = 0u, j = view->journal_ref_count; i < j / 2u; i += 1u) {
-        const size_t other = j - 1u - i;
-        const struct spg_context_journal_ref tmp = view->journal_refs[i];
-        view->journal_refs[i]                   = view->journal_refs[other];
-        view->journal_refs[other]               = tmp;
+        const size_t                         other = j - 1u - i;
+        const struct spg_context_journal_ref tmp   = view->journal_refs[i];
+        view->journal_refs[i]                      = view->journal_refs[other];
+        view->journal_refs[other]                  = tmp;
     }
 }
 
 void spg_context_view_init(
     struct spg_context_view *view, const size_t graph_ref_capacity,
-    struct spg_context_graph_ref graph_refs[static graph_ref_capacity],
-    const size_t memory_ref_capacity,
-    struct spg_context_memory_ref memory_refs[static memory_ref_capacity],
-    const size_t journal_ref_capacity,
+    struct spg_context_graph_ref   graph_refs[static graph_ref_capacity],
+    const size_t                   memory_ref_capacity,
+    struct spg_context_memory_ref  memory_refs[static memory_ref_capacity],
+    const size_t                   journal_ref_capacity,
     struct spg_context_journal_ref journal_refs[static journal_ref_capacity]) {
     if (view == nullptr) {
         return;
@@ -263,13 +264,12 @@ void spg_context_view_init(
 static bool view_arrays_valid(const struct spg_context_view *view) {
     return (view->graph_ref_capacity == 0u || view->graph_refs != nullptr) &&
            (view->memory_ref_capacity == 0u || view->memory_refs != nullptr) &&
-           (view->journal_ref_capacity == 0u ||
-            view->journal_refs != nullptr);
+           (view->journal_ref_capacity == 0u || view->journal_refs != nullptr);
 }
 
 enum spg_status spg_context_build(const struct spg_context_sources *sources,
-                                  const struct spg_context_limits *limits,
-                                  struct spg_context_view *view) {
+                                  const struct spg_context_limits  *limits,
+                                  struct spg_context_view          *view) {
     if (sources == nullptr || limits == nullptr || view == nullptr ||
         !view_arrays_valid(view)) {
         return SPG_E_INVALID_ARG;
@@ -326,11 +326,11 @@ enum spg_status spg_context_build(const struct spg_context_sources *sources,
     }
 
     {
-        const size_t target = limits->journal_events <
-                                      view->journal_ref_capacity
-                                  ? limits->journal_events
-                                  : view->journal_ref_capacity;
-        const size_t old_capacity = view->journal_ref_capacity;
+        const size_t target =
+            limits->journal_events < view->journal_ref_capacity
+                ? limits->journal_events
+                : view->journal_ref_capacity;
+        const size_t old_capacity  = view->journal_ref_capacity;
         view->journal_ref_capacity = target;
         for (size_t i = 0u; i < sources->journal_header_count; i += 1u) {
             const struct spg_journal_record_header *header =
@@ -368,8 +368,8 @@ static void append_char(struct render_state *state, const char ch) {
 }
 
 /* Block append with the same one-byte-reserved invariant as append_char: never
- * fills the last slot (it is kept for the terminating NUL) and always counts the
- * full length into required so the caller can size dst exactly. */
+ * fills the last slot (it is kept for the terminating NUL) and always counts
+ * the full length into required so the caller can size dst exactly. */
 static void append_span(struct render_state *state, const size_t n,
                         const char bytes[static n]) {
     if (state->used + 1u < state->capacity) {
@@ -457,7 +457,7 @@ static const char *fact_status_name(const enum spg_memory_fact_status status) {
 }
 
 static void append_quoted_span(struct render_state *state, const size_t text_n,
-                               const char *text,
+                               const char                *text,
                                const struct spg_text_span span) {
     append_char(state, '"');
     if (text != nullptr && span.offset <= text_n &&
@@ -522,20 +522,38 @@ static void append_budget_line(struct render_state *state, const char *name,
 
 static void render_contract(struct render_state *state) {
     append_cstr(state, "(contract\n");
-    append_cstr(state, "  (role \"Return exactly one recommendation form.\")\n");
-    append_cstr(state, "  (schema \"(recommend (kind <simulator|local_shell|ssh_auth_probe|memory_save|memory_delete|memory_read>) (capability \\\"<policy capability>\\\") (cost <positive integer>) (uses_network <true|false>) (confidence_bp <0..10000>) (reason \\\"<short reason>\\\") [(command \\\"...\\\")|(target \\\"...\\\")|(slug \\\"...\\\") (description \\\"...\\\") (body \\\"...\\\")])\")\n");
+    append_cstr(state,
+                "  (role \"Return exactly one recommendation form.\")\n");
+    append_cstr(
+        state, "  (schema \"(recommend (kind "
+               "<simulator|local_shell|ssh_auth_probe|memory_save|memory_"
+               "delete|memory_read>) (capability \\\"<policy capability>\\\") "
+               "(cost <positive integer>) (uses_network <true|false>) "
+               "(confidence_bp <0..10000>) (reason \\\"<short reason>\\\") "
+               "[(command \\\"...\\\")|(target \\\"...\\\")|(slug \\\"...\\\") "
+               "(description \\\"...\\\") (body \\\"...\\\")])\")\n");
     append_cstr(state, "  (rules\n");
-    append_cstr(state, "    (simulator \"uses_network must be false and no command or target\")\n");
-    append_cstr(state, "    (local_shell \"uses_network must be false and command is only a recommendation\")\n");
-    append_cstr(state, "    (ssh_auth_probe \"uses_network must be true and target is required; no attack is executed here\")\n");
-    append_cstr(state, "    (memory_save \"uses_network false; provide slug, description and body to remember something durably\")\n");
-    append_cstr(state, "    (memory_delete \"uses_network false; provide slug to forget a memory\")\n");
-    append_cstr(state, "    (memory_read \"uses_network false; provide slug to recall a memory; its content arrives next turn as observation\"))\n");
-    append_cstr(state, "  (memory \"(memory_index ...) lists recallable memories by slug; (observation ...) holds the last tool result -- recalled memory or command output\")\n");
+    append_cstr(state, "    (simulator \"uses_network must be false and no "
+                       "command or target\")\n");
+    append_cstr(state, "    (local_shell \"uses_network must be false and "
+                       "command is only a recommendation\")\n");
+    append_cstr(state, "    (ssh_auth_probe \"uses_network must be true and "
+                       "target is required; no attack is executed here\")\n");
+    append_cstr(state,
+                "    (memory_save \"uses_network false; provide slug, "
+                "description and body to remember something durably\")\n");
+    append_cstr(state, "    (memory_delete \"uses_network false; provide slug "
+                       "to forget a memory\")\n");
+    append_cstr(state,
+                "    (memory_read \"uses_network false; provide slug to recall "
+                "a memory; its content arrives next turn as observation\"))\n");
+    append_cstr(state, "  (memory \"(memory_index ...) lists recallable "
+                       "memories by slug; (observation ...) holds the last "
+                       "tool result -- recalled memory or command output\")\n");
     append_cstr(state, ")\n");
 }
 
-static void render_budgets(struct render_state *state,
+static void render_budgets(struct render_state                  *state,
                            const struct spg_context_budget_view *budgets) {
     append_cstr(state, "(budgets\n");
     append_budget_line(state, "inference_steps", budgets->inference_steps);
@@ -550,8 +568,8 @@ static void render_budgets(struct render_state *state,
 }
 
 static void render_graph(const struct spg_context_sources *sources,
-                         const struct spg_context_view *view,
-                         struct render_state *state) {
+                         const struct spg_context_view    *view,
+                         struct render_state              *state) {
     append_cstr(state, "(graph");
     if (view->graph_truncated) {
         append_cstr(state, " (truncated true)");
@@ -585,8 +603,8 @@ static void render_graph(const struct spg_context_sources *sources,
 }
 
 static void render_memory(const struct spg_context_sources *sources,
-                          const struct spg_context_view *view,
-                          struct render_state *state) {
+                          const struct spg_context_view    *view,
+                          struct render_state              *state) {
     append_cstr(state, "(memory");
     if (view->memory_truncated) {
         append_cstr(state, " (truncated true)");
@@ -626,7 +644,7 @@ static void render_memory(const struct spg_context_sources *sources,
 }
 
 static void render_journal(const struct spg_context_view *view,
-                           struct render_state *state) {
+                           struct render_state           *state) {
     append_cstr(state, "(recent_events");
     if (view->journal_truncated) {
         append_cstr(state, " (truncated true)");
@@ -653,9 +671,8 @@ static void render_journal(const struct spg_context_view *view,
  * knows what it can recall. The raw lines are emitted as-is (this is prompt
  * text, not re-parsed). */
 static void render_memory_index(const struct spg_context_sources *sources,
-                                struct render_state *state) {
-    if (sources->memory_index == nullptr ||
-        sources->memory_index[0] == '\0') {
+                                struct render_state              *state) {
+    if (sources->memory_index == nullptr || sources->memory_index[0] == '\0') {
         return;
     }
     append_cstr(state, "(memory_index\n");
@@ -665,9 +682,8 @@ static void render_memory_index(const struct spg_context_sources *sources,
 
 /* Content of the most recently recalled memory, as a quoted string. */
 static void render_observation(const struct spg_context_sources *sources,
-                                 struct render_state *state) {
-    if (sources->observation == nullptr ||
-        sources->observation[0] == '\0') {
+                               struct render_state              *state) {
+    if (sources->observation == nullptr || sources->observation[0] == '\0') {
         return;
     }
     append_cstr(state, "(observation ");
@@ -675,11 +691,31 @@ static void render_observation(const struct spg_context_sources *sources,
     append_cstr(state, ")\n");
 }
 
+/* The machine block is produced by the single renderer that owns its format
+ * (spg_machine_state_render), then appended — one definition of the schema,
+ * not a second copy here. The bound is a compile-time constant, so the stack
+ * buffer can never truncate. */
+static void render_machine(const struct spg_context_sources *sources,
+                           struct render_state              *state) {
+    if (sources->machine == nullptr) {
+        return;
+    }
+    char   block[SPG_MACHINE_RENDER_CAP];
+    size_t required = 0u;
+    if (spg_machine_state_render(sources->machine, sizeof block, block,
+                                 &required) != SPG_OK) {
+        return; /* cannot happen at this capacity; emitting nothing beats
+                 * emitting a truncated form the model would misread */
+    }
+    append_cstr(state, block);
+    append_cstr(state, "\n");
+}
+
 enum spg_status spg_context_render(const struct spg_context_sources *sources,
-                                   const struct spg_context_view *view,
+                                   const struct spg_context_view    *view,
                                    const size_t dst_capacity,
-                                   char dst[static dst_capacity],
-                                   size_t *out_required) {
+                                   char         dst[static dst_capacity],
+                                   size_t      *out_required) {
     if (sources == nullptr || view == nullptr || dst == nullptr ||
         out_required == nullptr || dst_capacity == 0u ||
         view->graph_ref_count > view->graph_ref_capacity ||
@@ -711,6 +747,7 @@ enum spg_status spg_context_render(const struct spg_context_sources *sources,
         append_cstr(&state, ")\n");
     }
     render_budgets(&state, &view->budgets);
+    render_machine(sources, &state);
     render_graph(sources, view, &state);
     render_memory(sources, view, &state);
     render_memory_index(sources, &state);

--- a/src/machine/process_profile.c
+++ b/src/machine/process_profile.c
@@ -244,11 +244,14 @@ void spg_process_apply_profile(const struct spg_process_profile *profile,
             spg_process_profile_match(profile, procs[i].name);
         procs[i].profile_index = index;
         if (index == SPG_PROCESS_NO_PROFILE) {
-            procs[i].role      = SPG_PROCESS_ROLE_UNKNOWN;
-            procs[i].may_pause = false;
-            procs[i].may_stop  = false;
+            procs[i].role          = SPG_PROCESS_ROLE_UNKNOWN;
+            procs[i].may_pause     = false;
+            procs[i].may_stop      = false;
+            procs[i].profile_id[0] = '\0';
             continue;
         }
+        memcpy(procs[i].profile_id, profile->entries[index].id,
+               SPG_PROCESS_ID_CAP);
         procs[i].role      = profile->entries[index].role;
         procs[i].may_pause = profile->entries[index].may_pause;
         procs[i].may_stop  = profile->entries[index].may_stop;

--- a/src/machine/telemetry.c
+++ b/src/machine/telemetry.c
@@ -358,6 +358,23 @@ static void put_u64(struct writer *w, const uint64_t value) {
     put_i64(w, (int64_t)value);
 }
 
+/* Quote a name into the s-expression. The process parser already replaced
+ * control characters, but '"' and '\\' are printable and would still break the
+ * form — a process could otherwise inject structure into the model context. */
+static void put_quoted(struct writer *w, const char *text) {
+    put(w, "\"");
+    for (size_t i = 0u; text[i] != '\0'; i += 1u) {
+        if (text[i] == '"' || text[i] == '\\') {
+            char escaped[3] = {'\\', text[i], '\0'};
+            put(w, escaped);
+            continue;
+        }
+        const char one[2] = {text[i], '\0'};
+        put(w, one);
+    }
+    put(w, "\"");
+}
+
 static void put_field(struct writer *w, const char *name,
                       const uint64_t value) {
     put(w, " (");
@@ -395,6 +412,31 @@ enum spg_status spg_machine_state_render(const struct spg_machine_state *state,
     put(&w, spg_throttle_state_to_string(state->throttle));
     put(&w, ")");
     put_field(&w, "process-count", state->process_count);
+
+    for (size_t i = 0u; i < state->n_processes; i += 1u) {
+        const struct spg_process_sample *p = &state->processes[i];
+        put(&w, " (process (id ");
+        /* One shape for managed and unmanaged: the profile id when there is
+         * one, the process name otherwise. Two shapes would cost a small model
+         * accuracy for no gain. */
+        put_quoted(&w, p->profile_id[0] != '\0' ? p->profile_id : p->name);
+        put(&w, ") (role ");
+        put(&w, spg_process_role_to_string(p->role));
+        put(&w, ")");
+        put_field(&w, "cpu-bp", p->cpu_bp);
+        put_field(&w, "rss-bytes", p->rss_bytes);
+        put(&w, ")");
+    }
+    if (state->processes_truncated) {
+        /* A list that looks complete but is not would invite wrong
+         * conclusions; say how many were dropped. */
+        const uint64_t shown   = (uint64_t)state->n_processes;
+        const uint64_t dropped = state->process_count != SPG_MACHINE_UNKNOWN &&
+                                         state->process_count > shown
+                                     ? state->process_count - shown
+                                     : SPG_MACHINE_UNKNOWN;
+        put_field(&w, "processes-dropped", dropped);
+    }
     put(&w, ")");
 
     *out_required = w.used + 1u;

--- a/src/machine/telemetry_host.c
+++ b/src/machine/telemetry_host.c
@@ -8,6 +8,8 @@
 
 #include "geistshell/machine_state.h"
 
+#include "geistshell/process_profile.h"
+
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -92,10 +94,10 @@ static enum spg_throttle_state read_throttle(const size_t cap, char buf[cap]) {
 /* Read /proc/<pid>/stat for every numeric entry, then select the bounded set
  * that reaches the snapshot. Returns the total number seen, which is not the
  * number kept — the snapshot is deliberately smaller than the machine. */
-static uint64_t enumerate_processes(const size_t                    prev_n,
-                                    const struct spg_process_sample prev[],
-                                    const uint64_t                  total_delta,
-                                    struct spg_machine_state       *out) {
+static uint64_t enumerate_processes(
+    const size_t prev_n, const struct spg_process_sample prev[],
+    const uint64_t total_delta, const struct spg_process_profile *profile,
+    struct spg_machine_state *out) {
     DIR *dir = opendir("/proc");
     if (dir == nullptr) {
         return SPG_MACHINE_UNKNOWN;
@@ -130,10 +132,27 @@ static uint64_t enumerate_processes(const size_t                    prev_n,
         if (spg_process_parse_stat(n, buf, page_bytes, &sample) != SPG_OK) {
             continue;
         }
+        /* Roles first: both the signal filter below and the ranking in
+         * spg_process_select depend on knowing what is managed. */
+        spg_process_apply_profile(profile, 1u, &sample);
         const struct spg_process_sample *before =
             spg_process_find(prev_n, prev, sample.pid, sample.start_identity);
         sample.cpu_bp =
             spg_process_utilisation_bp(before, &sample, total_delta);
+        /* A process with no memory and no measurable CPU carries no signal.
+         * On a Pi 5 that is ~100 kernel threads (kworker, rcu_ and migration threads),
+         * which filled 58 of 64 context slots with ~4 KB of "(rss-bytes 0)"
+         * during the hardware test. Managed processes are always offered: a
+         * paused batch job that currently costs nothing is exactly what the
+         * model must still see. */
+        const bool has_signal =
+            sample.rss_bytes != 0u && sample.rss_bytes != SPG_MACHINE_UNKNOWN;
+        const bool has_cpu =
+            sample.cpu_bp != SPG_MACHINE_UNKNOWN && sample.cpu_bp != 0u;
+        if (!has_signal && !has_cpu &&
+            sample.profile_index == SPG_PROCESS_NO_PROFILE) {
+            continue;
+        }
         (void)spg_process_offer(SPG_MACHINE_MAX_PROCESSES, all, &n_all,
                                 &sample);
     }
@@ -153,7 +172,7 @@ static uint64_t enumerate_processes(const size_t                    prev_n,
 enum spg_status spg_machine_sample_with_processes(
     const uint64_t timestamp_ns, const struct spg_cpu_sample *prev,
     const size_t prev_n, const struct spg_process_sample prev_procs[],
-    struct spg_machine_state *out) {
+    const struct spg_process_profile *profile, struct spg_machine_state *out) {
     if (out == nullptr || (prev_n > 0u && prev_procs == nullptr)) {
         return SPG_E_INVALID_ARG;
     }
@@ -197,7 +216,7 @@ enum spg_status spg_machine_sample_with_processes(
     }
     out->throttle = read_throttle(sizeof buf, buf);
     out->process_count =
-        enumerate_processes(prev_n, prev_procs, total_delta, out);
+        enumerate_processes(prev_n, prev_procs, total_delta, profile, out);
     return SPG_OK;
 }
 
@@ -206,9 +225,10 @@ enum spg_status spg_machine_sample_with_processes(
 enum spg_status spg_machine_sample_with_processes(
     const uint64_t timestamp_ns, const struct spg_cpu_sample *prev,
     const size_t prev_n, const struct spg_process_sample prev_procs[],
-    struct spg_machine_state *out) {
+    const struct spg_process_profile *profile, struct spg_machine_state *out) {
     (void)prev;
     (void)prev_procs;
+    (void)profile;
     if (out == nullptr || (prev_n > 0u && prev_procs == nullptr)) {
         return SPG_E_INVALID_ARG;
     }
@@ -223,5 +243,5 @@ enum spg_status spg_machine_sample(const uint64_t               timestamp_ns,
                                    const struct spg_cpu_sample *prev,
                                    struct spg_machine_state    *out) {
     return spg_machine_sample_with_processes(timestamp_ns, prev, 0u, nullptr,
-                                             out);
+                                             nullptr, out);
 }

--- a/src/run/agent_run.c
+++ b/src/run/agent_run.c
@@ -89,6 +89,7 @@ enum spg_status spg_agent_run(const struct spg_agent_run_inputs *inputs,
         .exemplars     = inputs->exemplars,
         .goal          = inputs->goal,
         .directive     = directive,
+        .machine       = inputs->machine,
     };
 
     const size_t refs = config->context_refs > 0u ? config->context_refs : 8u;

--- a/src/run/orchestrator.c
+++ b/src/run/orchestrator.c
@@ -201,6 +201,7 @@ enum spg_status spg_orchestrator_tick(
         .exemplars            = state->exemplars,
         .goal                 = state->goal,
         .directive            = state->directive,
+        .machine              = state->machine,
     };
     const struct spg_actor_step_config actor_config = {
         .actor_id            = config->actor_id,

--- a/test/test_cli_machine.sh
+++ b/test/test_cli_machine.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# Roadmap phase 3: the machine snapshot reaches the model's context, and only
+# when asked for.
+#
+# The default path must stay byte-identical to before this phase — that is what
+# keeps the phase-0 journal freeze meaningful — so the same run is checked twice,
+# once with --machine and once without.
+set -eu
+
+SPG_BIN=${SPG_BIN:-build/host-debug/bin/geistshell}
+JOURNAL=build/tick-demo.sgj
+SCRIPT=build/test-cli-machine-fake.txt
+
+printf '(recommend (kind finish) (reason "observed"))\n' >"$SCRIPT"
+
+run() {
+    rm -f "$JOURNAL"
+    # shellcheck disable=SC2086
+    "$SPG_BIN" agent --config examples/run.spg --fake-script "$SCRIPT" \
+        --max-steps 1 $1 >/dev/null
+}
+
+run "--machine"
+BLOCK=$(strings "$JOURNAL" | grep -o '(machine-state .*' | head -1 || true)
+if [ -z "$BLOCK" ]; then
+    echo "test_cli_machine: FAIL — no (machine-state ...) in the model input" >&2
+    exit 1
+fi
+
+# Balanced parens: a truncated block would still contain the opening token but
+# could not be parsed by the model, and it would reach the journal unnoticed.
+python3 - "$BLOCK" <<'PY'
+import sys
+
+block = sys.argv[1]
+depth = 0
+for ch in block:
+    if ch == "(":
+        depth += 1
+    elif ch == ")":
+        depth -= 1
+        if depth == 0:
+            break
+assert depth == 0, f"unbalanced machine-state block: {block[:200]}"
+for field in ("cpu-load-bp", "memory-total-bytes", "temperature-mc",
+              "throttle", "process-count"):
+    assert f"({field} " in block, f"missing field {field}"
+PY
+
+run ""
+if strings "$JOURNAL" | grep -q "machine-state"; then
+    echo "test_cli_machine: FAIL — machine state leaked into the default run" >&2
+    exit 1
+fi
+
+echo "test_cli_machine: PASS"

--- a/test/test_context.c
+++ b/test/test_context.c
@@ -1,22 +1,26 @@
 #include "geistshell/context.h"
+#include "geistshell/machine_state.h"
 
+#include <locale.h>
 #include <stdio.h>
 #include <string.h>
 
 static int test_budget_view(void) {
     const struct spg_run_config run = {
-        .budgets = {
-            .inference_steps = 10u,
-            .tokens          = 100u,
-            .shell_actions   = 2u,
-        },
+        .budgets =
+            {
+                .inference_steps = 10u,
+                .tokens          = 100u,
+                .shell_actions   = 2u,
+            },
     };
     const struct spg_policy_usage usage = {
-        .consumed = {
-            .inference_steps = 3u,
-            .tokens          = 125u,
-            .shell_actions   = 1u,
-        },
+        .consumed =
+            {
+                .inference_steps = 3u,
+                .tokens          = 125u,
+                .shell_actions   = 1u,
+            },
     };
     struct spg_context_graph_ref   graph_refs[1];
     struct spg_context_memory_ref  memory_refs[1];
@@ -45,36 +49,33 @@ static int test_budget_view(void) {
 }
 
 static int test_graph_ranking_and_truncation(void) {
-    const char text[] = "goal payload plan payload observation payload";
-    struct spg_graph graph = {};
+    const char         text[] = "goal payload plan payload observation payload";
+    struct spg_graph   graph  = {};
     struct spg_node_id observation = {};
-    struct spg_node_id goal = {};
-    struct spg_node_id plan = {};
+    struct spg_node_id goal        = {};
+    struct spg_node_id plan        = {};
     spg_graph_init(&graph);
-    if (spg_graph_add_node(
-            &graph, SPG_GRAPH_NODE_OBSERVATION, 1u,
-            (struct spg_text_span){.offset = 23u, .length = 19u},
-            &observation) != SPG_OK) {
+    if (spg_graph_add_node(&graph, SPG_GRAPH_NODE_OBSERVATION, 1u,
+                           (struct spg_text_span){.offset = 23u, .length = 19u},
+                           &observation) != SPG_OK) {
         return 1;
     }
-    if (spg_graph_add_node(
-            &graph, SPG_GRAPH_NODE_GOAL, 1u,
-            (struct spg_text_span){.offset = 0u, .length = 12u}, &goal) !=
-        SPG_OK) {
+    if (spg_graph_add_node(&graph, SPG_GRAPH_NODE_GOAL, 1u,
+                           (struct spg_text_span){.offset = 0u, .length = 12u},
+                           &goal) != SPG_OK) {
         return 1;
     }
-    if (spg_graph_add_node(
-            &graph, SPG_GRAPH_NODE_PLAN, 1u,
-            (struct spg_text_span){.offset = 13u, .length = 12u}, &plan) !=
-        SPG_OK) {
+    if (spg_graph_add_node(&graph, SPG_GRAPH_NODE_PLAN, 1u,
+                           (struct spg_text_span){.offset = 13u, .length = 12u},
+                           &plan) != SPG_OK) {
         return 1;
     }
     if (spg_graph_set_scores(
             &graph, plan,
-            (struct spg_graph_scores){.confidence = 0.9f,
-                                      .utility = 1.0f,
-                                      .risk = 0.0f,
-                                      .novelty = 0.8f,
+            (struct spg_graph_scores){.confidence    = 0.9f,
+                                      .utility       = 1.0f,
+                                      .risk          = 0.0f,
+                                      .novelty       = 0.8f,
                                       .cost_estimate = 0.1f}) != SPG_OK) {
         return 1;
     }
@@ -109,24 +110,24 @@ static int test_graph_ranking_and_truncation(void) {
 }
 
 static int test_memory_ranking_ignores_rejected(void) {
-    const char text[] = "host-a role server old fact";
-    struct spg_memory memory = {};
-    struct spg_fact_id old_fact = {};
+    const char         text[]     = "host-a role server old fact";
+    struct spg_memory  memory     = {};
+    struct spg_fact_id old_fact   = {};
     struct spg_fact_id constraint = {};
     spg_memory_init(&memory);
-    if (spg_memory_add_fact(
-            &memory, SPG_MEMORY_FACT_OBSERVATION,
-            (struct spg_text_span){.offset = 18u, .length = 8u},
-            (struct spg_text_span){}, (struct spg_text_span){}, 1u, false,
-            (struct spg_node_id){}, 1.0f, &old_fact) != SPG_OK) {
+    if (spg_memory_add_fact(&memory, SPG_MEMORY_FACT_OBSERVATION,
+                            (struct spg_text_span){.offset = 18u, .length = 8u},
+                            (struct spg_text_span){}, (struct spg_text_span){},
+                            1u, false, (struct spg_node_id){}, 1.0f,
+                            &old_fact) != SPG_OK) {
         return 1;
     }
-    if (spg_memory_add_fact(
-            &memory, SPG_MEMORY_FACT_CONSTRAINT,
-            (struct spg_text_span){.offset = 0u, .length = 6u},
-            (struct spg_text_span){.offset = 7u, .length = 4u},
-            (struct spg_text_span){.offset = 12u, .length = 6u}, 4000u,
-            false, (struct spg_node_id){}, 0.7f, &constraint) != SPG_OK) {
+    if (spg_memory_add_fact(&memory, SPG_MEMORY_FACT_CONSTRAINT,
+                            (struct spg_text_span){.offset = 0u, .length = 6u},
+                            (struct spg_text_span){.offset = 7u, .length = 4u},
+                            (struct spg_text_span){.offset = 12u, .length = 6u},
+                            4000u, false, (struct spg_node_id){}, 0.7f,
+                            &constraint) != SPG_OK) {
         return 1;
     }
     if (spg_memory_set_status(&memory, old_fact, SPG_MEMORY_FACT_REJECTED) !=
@@ -153,8 +154,8 @@ static int test_memory_ranking_ignores_rejected(void) {
     if (spg_context_build(&sources, &limits, &view) != SPG_OK) {
         return 1;
     }
-    if (view.memory_ref_count != 1u || view.memory_refs[0].fact.index !=
-                                           constraint.index) {
+    if (view.memory_ref_count != 1u ||
+        view.memory_refs[0].fact.index != constraint.index) {
         return 1;
     }
     return 0;
@@ -196,26 +197,24 @@ static int test_recent_events_are_chronological(void) {
 }
 
 static int test_render_and_limit(void) {
-    const char graph_text[]  = "deploy plan";
-    const char memory_text[] = "host-a is isolated";
-    struct spg_graph graph = {};
-    struct spg_memory memory = {};
-    struct spg_node_id node = {};
-    struct spg_fact_id fact = {};
+    const char         graph_text[]  = "deploy plan";
+    const char         memory_text[] = "host-a is isolated";
+    struct spg_graph   graph         = {};
+    struct spg_memory  memory        = {};
+    struct spg_node_id node          = {};
+    struct spg_fact_id fact          = {};
     spg_graph_init(&graph);
     spg_memory_init(&memory);
-    if (spg_graph_add_node(
-            &graph, SPG_GRAPH_NODE_PLAN, 9u,
-            (struct spg_text_span){.offset = 0u, .length = 11u}, &node) !=
-        SPG_OK) {
+    if (spg_graph_add_node(&graph, SPG_GRAPH_NODE_PLAN, 9u,
+                           (struct spg_text_span){.offset = 0u, .length = 11u},
+                           &node) != SPG_OK) {
         return 1;
     }
-    if (spg_memory_add_fact(
-            &memory, SPG_MEMORY_FACT_CONSTRAINT,
-            (struct spg_text_span){.offset = 0u, .length = 6u},
-            (struct spg_text_span){.offset = 7u, .length = 2u},
-            (struct spg_text_span){.offset = 10u, .length = 8u}, 2u, true,
-            node, 0.8f, &fact) != SPG_OK) {
+    if (spg_memory_add_fact(&memory, SPG_MEMORY_FACT_CONSTRAINT,
+                            (struct spg_text_span){.offset = 0u, .length = 6u},
+                            (struct spg_text_span){.offset = 7u, .length = 2u},
+                            (struct spg_text_span){.offset = 10u, .length = 8u},
+                            2u, true, node, 0.8f, &fact) != SPG_OK) {
         return 1;
     }
 
@@ -241,7 +240,7 @@ static int test_render_and_limit(void) {
     if (spg_context_build(&sources, &limits, &view) != SPG_OK) {
         return 1;
     }
-    char small[16];
+    char   small[16];
     size_t required = 0u;
     if (spg_context_render(&sources, &view, sizeof small, small, &required) !=
         SPG_E_LIMIT) {
@@ -277,7 +276,8 @@ static int test_render_memory_index(void) {
                           journal_refs);
     const struct spg_context_limits limits = {0};
 
-    /* With an index, the rendered context carries a (memory_index ...) block. */
+    /* With an index, the rendered context carries a (memory_index ...) block.
+     */
     const struct spg_context_sources with = {
         .memory_index = "- auth-flow: how login works\n",
     };
@@ -286,7 +286,8 @@ static int test_render_memory_index(void) {
     }
     char   buf[2048];
     size_t required = 0u;
-    if (spg_context_render(&with, &view, sizeof buf, buf, &required) != SPG_OK) {
+    if (spg_context_render(&with, &view, sizeof buf, buf, &required) !=
+        SPG_OK) {
         return 1;
     }
     /* Match the injected block (newline after the tag), not the contract's
@@ -309,7 +310,7 @@ static int test_invalid_args(void) {
     struct spg_context_graph_ref   graph_refs[1];
     struct spg_context_memory_ref  memory_refs[1];
     struct spg_context_journal_ref journal_refs[1];
-    struct spg_context_view        view = {};
+    struct spg_context_view        view    = {};
     struct spg_context_sources     sources = {
         .journal_header_count = 1u,
         .journal_headers      = nullptr,
@@ -414,7 +415,8 @@ static int test_goal_render(void) {
         return 1;
     }
 
-    /* A standing directive renders prominently as (directive "...") every step. */
+    /* A standing directive renders prominently as (directive "...") every step.
+     */
     sources.directive = "emit finish once the goal output is produced";
     if (spg_context_render(&sources, &view, sizeof buf, buf, &req) != SPG_OK ||
         strstr(buf, "(directive ") == nullptr ||
@@ -429,6 +431,157 @@ static int test_goal_render(void) {
     return 0;
 }
 
+/* Roadmap phase 3: the machine snapshot reaches the model context, bounded and
+ * deterministic, and is absent unless a caller supplies one. */
+static int test_machine_render(void) {
+    const struct spg_run_config    run   = {.budgets = {.tokens = 100u}};
+    const struct spg_policy_usage  usage = {};
+    struct spg_context_graph_ref   graph_refs[1];
+    struct spg_context_memory_ref  memory_refs[1];
+    struct spg_context_journal_ref journal_refs[1];
+    struct spg_context_view        view = {};
+    spg_context_view_init(&view, 1u, graph_refs, 1u, memory_refs, 1u,
+                          journal_refs);
+    const struct spg_context_limits limits = {
+        .graph_nodes = 1u, .memory_facts = 1u, .journal_events = 1u};
+
+    struct spg_machine_state machine = {
+        .timestamp_ns        = 7u,
+        .cpu_utilisation_bp  = 9200u,
+        .load                = {.avg_1_cbp = 175u},
+        .memory              = {.total_bytes = 1024u, .used_bytes = 512u},
+        .temperature_mc      = 78400,
+        .cpu_freq_khz        = 1500000u,
+        .throttle            = SPG_THROTTLE_NONE,
+        .process_count       = 200u,
+        .n_processes         = 2u,
+        .processes_truncated = true,
+    };
+    machine.processes[0] = (struct spg_process_sample){
+        .pid           = 11u,
+        .cpu_bp        = 5400u,
+        .rss_bytes     = 4096u,
+        .role          = SPG_PROCESS_ROLE_CRITICAL,
+        .profile_index = 0u,
+    };
+    memcpy(machine.processes[0].profile_id, "critical_app",
+           sizeof "critical_app");
+    machine.processes[1] = (struct spg_process_sample){
+        .pid           = 12u,
+        .cpu_bp        = 3100u,
+        .rss_bytes     = 8192u,
+        .role          = SPG_PROCESS_ROLE_BATCH,
+        .profile_index = 1u,
+    };
+    memcpy(machine.processes[1].profile_id, "batch_job", sizeof "batch_job");
+
+    struct spg_context_sources sources = {
+        .run = &run, .usage = &usage, .machine = &machine};
+    if (spg_context_build(&sources, &limits, &view) != SPG_OK) {
+        return 1;
+    }
+    char   buf[8192];
+    size_t req = 0u;
+    if (spg_context_render(&sources, &view, sizeof buf, buf, &req) != SPG_OK) {
+        return 1;
+    }
+    if (strstr(buf, "(machine-state ") == nullptr ||
+        strstr(buf, "(cpu-load-bp 9200)") == nullptr ||
+        strstr(buf, "(temperature-mc 78400)") == nullptr) {
+        return 1;
+    }
+    /* The process carries its profile id and role — that is what a phase-6
+     * action would target. */
+    if (strstr(buf, "(process (id \"batch_job\") (role batch)") == nullptr ||
+        strstr(buf, "(cpu-bp 3100)") == nullptr) {
+        return 1;
+    }
+    /* A truncated list must say so, or the model reads it as the whole
+     * machine. */
+    if (strstr(buf, "(processes-dropped 198)") == nullptr) {
+        return 1;
+    }
+
+    /* Byte-identical for the same snapshot. */
+    char   again[8192];
+    size_t req2 = 0u;
+    if (spg_context_render(&sources, &view, sizeof again, again, &req2) !=
+            SPG_OK ||
+        req != req2 || memcmp(buf, again, req) != 0) {
+        return 1;
+    }
+
+    /* Absent by default: without a snapshot the context is what it always was,
+     * which is what keeps the phase-0 journal freeze valid. */
+    sources.machine = nullptr;
+    if (spg_context_render(&sources, &view, sizeof again, again, &req2) !=
+        SPG_OK) {
+        return 1;
+    }
+    if (strstr(again, "machine-state") != nullptr) {
+        return 1;
+    }
+    return 0;
+}
+
+/* Missing telemetry must render as the symbol `unknown`, never as 0 — a model
+ * cannot tell a dead sensor from an idle machine otherwise. */
+static int test_machine_unknown_and_locale(void) {
+    const struct spg_run_config    run   = {.budgets = {.tokens = 100u}};
+    const struct spg_policy_usage  usage = {};
+    struct spg_context_graph_ref   graph_refs[1];
+    struct spg_context_memory_ref  memory_refs[1];
+    struct spg_context_journal_ref journal_refs[1];
+    struct spg_context_view        view = {};
+    spg_context_view_init(&view, 1u, graph_refs, 1u, memory_refs, 1u,
+                          journal_refs);
+    const struct spg_context_limits limits = {
+        .graph_nodes = 1u, .memory_facts = 1u, .journal_events = 1u};
+
+    const struct spg_machine_state machine = {
+        .cpu_utilisation_bp = SPG_MACHINE_UNKNOWN,
+        .load               = {.avg_1_cbp  = SPG_MACHINE_UNKNOWN,
+                               .avg_5_cbp  = SPG_MACHINE_UNKNOWN,
+                               .avg_15_cbp = SPG_MACHINE_UNKNOWN},
+        .memory             = {.total_bytes     = SPG_MACHINE_UNKNOWN,
+                               .used_bytes      = SPG_MACHINE_UNKNOWN,
+                               .swap_used_bytes = SPG_MACHINE_UNKNOWN},
+        .temperature_mc     = SPG_MACHINE_UNKNOWN_S,
+        .cpu_freq_khz       = SPG_MACHINE_UNKNOWN,
+        .throttle           = SPG_THROTTLE_UNKNOWN,
+        .process_count      = SPG_MACHINE_UNKNOWN,
+    };
+    const struct spg_context_sources sources = {
+        .run = &run, .usage = &usage, .machine = &machine};
+    if (spg_context_build(&sources, &limits, &view) != SPG_OK) {
+        return 1;
+    }
+    char   buf[8192];
+    size_t req = 0u;
+    if (spg_context_render(&sources, &view, sizeof buf, buf, &req) != SPG_OK) {
+        return 1;
+    }
+    if (strstr(buf, "(cpu-load-bp unknown)") == nullptr ||
+        strstr(buf, "(temperature-mc unknown)") == nullptr) {
+        return 1;
+    }
+
+    /* A locale with ',' as the decimal separator must not change one byte:
+     * the block is integers only, and byte-identical replay depends on it. */
+    char first[8192];
+    memcpy(first, buf, req);
+    (void)setlocale(LC_ALL, "de_DE.UTF-8");
+    size_t req2 = 0u;
+    if (spg_context_render(&sources, &view, sizeof buf, buf, &req2) != SPG_OK) {
+        return 1;
+    }
+    (void)setlocale(LC_ALL, "C");
+    if (req != req2 || memcmp(first, buf, req) != 0) {
+        return 1;
+    }
+    return 0;
+}
+
 int main(void) {
     if (test_exemplars_render() != 0) {
         fprintf(stderr, "test_exemplars_render failed\n");
@@ -436,6 +589,14 @@ int main(void) {
     }
     if (test_goal_render() != 0) {
         fprintf(stderr, "test_goal_render failed\n");
+        return 1;
+    }
+    if (test_machine_render() != 0) {
+        fprintf(stderr, "test_machine_render failed\n");
+        return 1;
+    }
+    if (test_machine_unknown_and_locale() != 0) {
+        fprintf(stderr, "test_machine_unknown_and_locale failed\n");
         return 1;
     }
     if (test_budget_view() != 0) {

--- a/test/test_machine_process.c
+++ b/test/test_machine_process.c
@@ -536,11 +536,11 @@ static int test_offer_keeps_best(void) {
  * nobody calls compiles fine and is useless. */
 static int test_sample_with_processes(void) {
     struct spg_machine_state first = {};
-    const enum spg_status    s1 =
-        spg_machine_sample_with_processes(1u, nullptr, 0u, nullptr, &first);
+    const enum spg_status    s1    = spg_machine_sample_with_processes(
+        1u, nullptr, 0u, nullptr, nullptr, &first);
     struct spg_machine_state second = {};
     const enum spg_status    s2     = spg_machine_sample_with_processes(
-        2u, &first.cpu, first.n_processes, first.processes, &second);
+        2u, &first.cpu, first.n_processes, first.processes, nullptr, &second);
     if (second.timestamp_ns != 2u) {
         return 1;
     }
@@ -578,8 +578,8 @@ static int test_sample_with_processes(void) {
     /* A non-empty prev list with a null pointer is a caller bug, not a crash.
      */
     struct spg_machine_state ignored = {};
-    if (spg_machine_sample_with_processes(3u, nullptr, 4u, nullptr, &ignored) !=
-        SPG_E_INVALID_ARG) {
+    if (spg_machine_sample_with_processes(3u, nullptr, 4u, nullptr, nullptr,
+                                          &ignored) != SPG_E_INVALID_ARG) {
         return 1;
     }
     return 0;

--- a/test/test_machine_telemetry.c
+++ b/test/test_machine_telemetry.c
@@ -306,6 +306,104 @@ static int test_render_unknown(void) {
     return 0;
 }
 
+/* Processes render inside the block, in snapshot order, with the profile id a
+ * phase-6 action would target. */
+static int test_render_processes(void) {
+    struct spg_machine_state s = sample_state();
+    s.n_processes              = 2u;
+    s.processes[0]             = (struct spg_process_sample){
+        .cpu_bp = 5400u, .rss_bytes = 4096u, .role = SPG_PROCESS_ROLE_CRITICAL};
+    memcpy(s.processes[0].profile_id, "critical_app", sizeof "critical_app");
+    /* Unmanaged: no profile id, so the name is shown instead — one shape —
+     * and no role, because a role only ever comes from the profile. */
+    s.processes[1] = (struct spg_process_sample){
+        .cpu_bp = 3100u, .rss_bytes = 8192u, .role = SPG_PROCESS_ROLE_UNKNOWN};
+    memcpy(s.processes[1].name, "python3", sizeof "python3");
+
+    char   buf[SPG_MACHINE_RENDER_CAP];
+    size_t required = 0u;
+    if (spg_machine_state_render(&s, sizeof buf, buf, &required) != SPG_OK) {
+        return 1;
+    }
+    if (strstr(buf, "(process (id \"critical_app\") (role critical)"
+                    " (cpu-bp 5400) (rss-bytes 4096))") == nullptr) {
+        printf("  rendered: %s\n", buf);
+        return 1;
+    }
+    if (strstr(buf, "(process (id \"python3\") (role unknown)") == nullptr) {
+        return 1;
+    }
+    /* Nothing dropped -> no marker at all. */
+    if (strstr(buf, "processes-dropped") != nullptr) {
+        return 1;
+    }
+    s.processes_truncated = true;
+    s.process_count       = 100u;
+    if (spg_machine_state_render(&s, sizeof buf, buf, &required) != SPG_OK ||
+        strstr(buf, "(processes-dropped 98)") == nullptr) {
+        return 1;
+    }
+    /* Unknown total: the marker still appears, without inventing a count. */
+    s.process_count = SPG_MACHINE_UNKNOWN;
+    if (spg_machine_state_render(&s, sizeof buf, buf, &required) != SPG_OK ||
+        strstr(buf, "(processes-dropped unknown)") == nullptr) {
+        return 1;
+    }
+    return 0;
+}
+
+/* A process name is attacker-influenced input by the time it reaches the model
+ * (phase 16, attack 12). Quotes and backslashes must not close the form. */
+static int test_render_escapes_names(void) {
+    struct spg_machine_state s = sample_state();
+    s.n_processes              = 1u;
+    s.processes[0]             = (struct spg_process_sample){.cpu_bp = 1u};
+    memcpy(s.processes[0].name, "ev\"il\\x", sizeof "ev\"il\\x");
+
+    char   buf[SPG_MACHINE_RENDER_CAP];
+    size_t required = 0u;
+    if (spg_machine_state_render(&s, sizeof buf, buf, &required) != SPG_OK) {
+        return 1;
+    }
+    if (strstr(buf, "(id \"ev\\\"il\\\\x\")") == nullptr) {
+        printf("  rendered: %s\n", buf);
+        return 1;
+    }
+    /* Parens must balance: an injected quote could otherwise end the block
+     * early and let the rest read as model instructions. */
+    int depth = 0;
+    for (const char *c = buf; *c != '\0'; c += 1) {
+        if (*c == '(') {
+            depth += 1;
+        } else if (*c == ')') {
+            depth -= 1;
+        }
+        if (depth < 0) {
+            return 1;
+        }
+    }
+    return depth == 0 ? 0 : 1;
+}
+
+/* The declared cap must actually hold a full snapshot, or a caller sizing a
+ * stack buffer from it silently loses the block. */
+static int test_render_cap_holds_full_snapshot(void) {
+    struct spg_machine_state s = sample_state();
+    s.n_processes              = SPG_MACHINE_MAX_PROCESSES;
+    s.processes_truncated      = true;
+    for (size_t i = 0u; i < SPG_MACHINE_MAX_PROCESSES; i += 1u) {
+        s.processes[i] = (struct spg_process_sample){
+            .cpu_bp = 9999u, .rss_bytes = UINT64_MAX - 1u};
+        memcpy(s.processes[i].profile_id, "0123456789abcdef0123456789abcde",
+               32u);
+    }
+    char   buf[SPG_MACHINE_RENDER_CAP];
+    size_t required = 0u;
+    return spg_machine_state_render(&s, sizeof buf, buf, &required) == SPG_OK
+               ? 0
+               : 1;
+}
+
 static int test_render_deterministic(void) {
     const struct spg_machine_state s = sample_state();
     char                           a[512];
@@ -420,6 +518,9 @@ int main(void) {
         {"utilisation", test_utilisation},
         {"render", test_render},
         {"render_unknown", test_render_unknown},
+        {"render_processes", test_render_processes},
+        {"render_escapes_names", test_render_escapes_names},
+        {"render_cap_holds_full_snapshot", test_render_cap_holds_full_snapshot},
         {"render_deterministic", test_render_deterministic},
         {"render_limit", test_render_limit},
         {"null_args", test_null_args},


### PR DESCRIPTION
Phase 3 der Roadmap (#63). Stapelt auf #83. Das Modell kann die Maschine beobachten, ohne dafür Shell-Zugriff zu bekommen. Keine Action.

## Der Block, gemessen auf dem Pi

```
(machine-state (cpu-load-bp unknown) (load-1-cbp 33) (memory-total-bytes 4245815296)
 (memory-used-bytes 1683259392) (swap-used-bytes 542523392) (temperature-mc 50700)
 (cpu-freq-khz 2200000) (throttle none) (process-count 167)
 (process (id "critical_app") (role critical) (cpu-bp unknown) (rss-bytes 849444864))
 (process (id "batch_job") (role batch) (cpu-bp unknown) (rss-bytes 360660992))
 (process (id "dockerd") (role unknown) (cpu-bp unknown) (rss-bytes 31211520))
 ...)
```

Gemanagte Prozesse zuerst mit ihrer Profil-ID, danach nach Speicher. Rund 2,7 KB.

## Standardmäßig abwesend

Ohne `--machine` ist der Context byte-identisch zu vorher. Das ist die Voraussetzung dafür, dass der Journal-Freeze aus Phase 0 weiter etwas aussagt — er prüft den Default-Pfad. `test/test_cli_machine.sh` fährt denselben Lauf zweimal und verlangt, dass der Block einmal wohlgeformt auftaucht und einmal gar nicht.

## Entscheidungen

**Eine Form für alle Prozesse:** `id` ist die Profil-ID, wenn gemanagt, sonst der Prozessname. Zwei Formen kosten ein kleines Modell Genauigkeit ohne Gegenwert.

**Die PID fehlt bewusst.** Das Modell braucht sie nie: eine Phase-6-Action zielt auf die Profil-ID, und der Executor validiert Identität selbst. Eine PID im Context wäre eine Zahl, die das Modell zu benutzen versucht und die zwischen Beobachtung und Ausführung ungültig wird.

**Trunkierung ist sichtbar** über `(processes-dropped N)`, bei unbekannter Gesamtzahl `unknown` statt einer erfundenen Zahl.

## Drei Befunde vom Pi

**1. 58 von 64 Kontextplätzen waren Rauschen.** Kernel-Threads mit `(rss-bytes 0)` füllten den Block — rund 4 KB, in denen kein Satz etwas aussagt. Prozesse ohne Speicher und ohne messbare CPU werden jetzt vor der Auswahl verworfen; gemanagte sind ausgenommen, weil ein pausierter Batch-Job genau das ist, was das Modell weiter sehen muss.

**2. Das Profil wurde nie angewendet.** `spg_process_select` sortiert gemanagte Prozesse nach vorn — aber niemand setzte die Rolle, bevor sortiert wurde. Die Regel aus Phase 2 war in der echten Pipeline wirkungslos, jeder Prozess trug `role unknown`. Das Profil wird jetzt während der Enumeration angewendet. Dazu ist `struct spg_process_profile` nach `machine_state.h` gewandert; die DSL-Parsing-API bleibt in `process_profile.h`.

**3. Der Linux-Zweig ist auf macOS nicht kompilierbar.** `enumerate_processes` fehlte der neue Parameter — lokal fiel das nicht auf, weil der ganze Block hinter `#if defined(__linux__)` liegt. Jede Änderung darin bleibt bis zum Pi-Build ungeprüft.

## Kontextkosten

| Inhalt | Bytes |
|---|---|
| Nur Systemfelder | 224 |
| + 8 Prozesse | 872 |
| + 64 Prozesse | 5240 |

64 Prozesse konkurrieren im Fenster eines kleinen Modells mit der Lesson-Injection aus P6 (#3). Welche Felder wirklich nötig sind, misst Phase 11 (#71).

## Bekannte Grenze

Mit einem Sample pro Lauf ist `cpu-bp` je Prozess `unknown` — CPU ist ein Delta. Das Modell sieht in dieser Phase Speicher, Temperatur und Rollen, aber keine Prozess-CPU. Ab Phase 7 (#67), die pro Tick neu beobachtet, ist der Wert da.

## Abweichung vom Ticket

Statt eines erweiterten Eval Case prüft ein CLI-Test den tatsächlich journalten Model-Input auf Wohlgeformtheit und Pflichtfelder — derselbe Nachweis, näher an der Realität.

## Verifikation

macOS arm64 und Pi 5 (aarch64, Kernel 6.18): `make test` grün, exit 0, 27 PASS, warnungsfrei, ASan/UBSan sauber. `test_cli_baseline` unverändert grün.

Doku: `docs/machine-intelligence/Context.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
