### PR TITLE
Phase 4: Diagnose-Benchmark — kann ein Modell die Ursache benennen?

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ SPG_SOURCES := \
     src/memory/mem_executor.c \
     src/memory/mem_store.c \
     src/memory/memory.c \
+    src/machine/machine_fixture.c \
     src/machine/process.c \
     src/machine/process_profile.c \
     src/machine/telemetry.c \

--- a/docs/machine-intelligence/Diagnosis-Benchmark.md
+++ b/docs/machine-intelligence/Diagnosis-Benchmark.md
@@ -83,6 +83,8 @@ die Metrik fest auf „korrekt" verdrahtet wäre. Deshalb gibt es
 | falsche Kategorie | Case scheitert | `correct=0`, `outcome=fail_observation` |
 | erfundener Prozess `ghost_job` bei richtiger Kategorie | erkannt | `hallucinated=1` |
 | Aktion vorgeschlagen statt nur diagnostiziert | gezählt | `action_proposed=1`, `steps=2` |
+| `batch_pressure [critical_app, batch_job]` (echte Gemma-Antwort) | **keine** Halluzination | `hallucinated=0` |
+| `healthy))` (echte Gemma-Antwort) | Kategorie erkannt | `emitted=healthy` |
 
 `test/test_cli_diagnosis.sh` fährt beide Suiten und schlägt fehl, wenn der
 Harness einen dieser Fälle durchgehen lässt. Er ist Teil von `make test`.
@@ -91,21 +93,81 @@ Harness einen dieser Fälle durchgehen lässt. Er ist Teil von `make test`.
 
 ### Scripted Ground Truth (deterministisch, in `make test`)
 
-| Methode | Known | Held-out | Halluzination | Unnötige Action |
-|---|---|---|---|---|
-| scripted baseline | 6/6 | 3/3 | 0 | 0 |
+| Methode | Known | Held-out | Halluzination | Unnötige Action | Parse |
+|---|---|---|---|---|---|
+| scripted baseline | 6/6 | 3/3 | 0 | 0 | 9/9 |
 
 Das ist keine Modellleistung, sondern der Nachweis, dass Harness und Metriken
 funktionieren.
 
-### Lokales Modell
+### Gemma4-E2B, lokal auf dem Pi 5
 
-_Wird beim Modelllauf eingetragen._
+`--constrained --samples 1`, Release-Build, aarch64.
+
+| Methode | Known | Held-out | Halluzination | Unnötige Action | Parse | Gate |
+|---|---|---|---|---|---|---|
+| Gemma4-E2B (Q4_K_M) | 2/6 | 1/3 | 0 | 0 | 9/9 | 9/9 |
+
+Die Antworten im Wortlaut:
+
+| Szenario | Erwartet | Geantwortet |
+|---|---|---|
+| batch_cpu | batch_pressure | `memory_pressure [critical_app, batch_job]` |
+| critical_cpu | critical_pressure | `critical_pressure [critical_app]` ✓ |
+| memory_batch | memory_pressure | `memory_pressure [critical_app, batch_job]` ✓ |
+| thermal | thermal_anomaly | `memory_pressure [critical_app, batch_job]` |
+| contradictory | inconclusive | `healthy))` |
+| healthy | healthy | `critical_pressure [critical_app]` |
+| heldout_thermal_batch | thermal_anomaly | `memory_pressure [critical_app, batch_job]` |
+| heldout_memory_critical | memory_pressure | `memory_pressure [critical_app, batch_job]` ✓ |
+| no_processes | inconclusive | `memory_pressure [unknown]` |
+
+**Das Modell diagnostiziert nicht, es rät ein Label.** In sechs von neun Fällen
+lautet die Antwort `memory_pressure`, unabhängig davon, ob Speicher überhaupt
+knapp ist — bei `thermal` sind 4,2 GB installiert und 1,1 GB belegt. Die
+Kategorie `thermal_anomaly` kam kein einziges Mal vor, obwohl zwei Szenarien sie
+verlangen und die Temperatur als eigenes Feld im Context steht.
+
+Der Vergleich, der das einordnet: wer **immer** `memory_pressure` antwortet,
+trifft 1/6 known und 1/3 held-out, also 2/9. Gemma erreicht 3/9. Der Abstand zu
+einer konstanten Antwort ist ein einziger Fall — und der (`critical_cpu`) ist
+schwer von Glück zu unterscheiden, weil dieselbe Antwort im `healthy`-Szenario
+falsch war.
+
+**Was gut funktioniert: die Form.** Parse 9/9 und Gate 9/9 mit dem constrained
+Decoder. Die Hypothese aus #53 hält hier — das Gerüst hebt die Parse-Rate
+unabhängig vom Modell, und die Frage verschiebt sich von „kann es die Form" zu
+„wählt es richtig". Die Antwort auf die zweite Frage ist auf dieser Suite: nein.
+
+Laufzeit: rund 25–30 Minuten für neun Fälle auf einem Pi 5 (Release-Build, vier
+Kerne). Die **Inferenzzeit pro Fall ist nicht instrumentiert** — der Harness
+misst sie nicht, und eine Uhr in den Eval-Pfad zu legen ist eine Änderung, die
+zu Phase 10 gehört, wo Latenz eine der Zielmetriken ist.
 
 ### Remote-Modell
 
-Nicht konfiguriert. Ein nicht verfügbares Remote-Modell wird als
-Fehler-Record ausgewiesen und **nicht** als bestanden gewertet.
+Nicht konfiguriert, also nicht gelaufen. Ein nicht verfügbares Remote-Modell
+wird als Fehler-Record ausgewiesen und **nicht** als bestanden gewertet.
+
+### Was die Halluzinationsmetrik erst falsch gemessen hat
+
+Die erste Fassung meldete für denselben Lauf **8 von 9 Halluzinationen**. Das
+war ein Artefakt: sie las nur das zweite Token des Reasons und verglich es mit
+den Prozess-IDs des Snapshots. Gemma schreibt aber
+`memory_pressure [critical_app, batch_job]` — das zweite Token ist
+`[critical_app,`, und die genannten Prozesse sind **beide** im Zustand
+vorhanden.
+
+Aufgefallen ist es erst, weil die Metrik den Reason im Klartext mit ausgibt.
+Eine Zahl, die niemand nachprüfen kann, ist eine Zahl, der niemand trauen
+sollte.
+
+Korrigiert wird jetzt jedes Token nach der Kategorie geprüft, befreit von
+`[](),`, und nur Tokens mit Unterstrich gelten als ID-Behauptung — die
+Namenskonvention der Profile (`critical_app`, `batch_job`), die Prosa nicht
+erfüllt. Beide echten Gemma-Antworten sind als Regressionsfälle in
+`diagnosis_negative.spg` eingefroren, ebenso `healthy))`, das die
+Kategorie-Extraktion an Satzzeichen scheitern ließ.
 
 ## Wo einfache Regeln offensichtlich genügen
 
@@ -114,6 +176,11 @@ mit drei Schwellwerten zu lösen — „CPU hoch **und** der Verursacher ist ein
 Batch-Prozess", „Speicher hoch **und** ein RSS dominiert", „alles unter
 Schwelle". Für diese Fälle ist ein Modell teurer, langsamer und weniger
 vorhersagbar als vier Zeilen C.
+
+Nach dem Gemma-Lauf ist die Frage schärfer gestellt: eine Regel, die nur
+`temperature-mc > 75000` prüft, löst die Fälle 4 und 7 sofort — Gemma löst
+keinen davon. Die Regel-Baseline aus Phase 5 tritt also nicht gegen ein starkes
+Modell an.
 
 Interessant sind die Fälle, in denen eine Regel eine Kollision hat:
 

--- a/docs/machine-intelligence/Diagnosis-Benchmark.md
+++ b/docs/machine-intelligence/Diagnosis-Benchmark.md
@@ -1,0 +1,148 @@
+# Diagnosis Benchmark — Phase 4
+
+Kann ein Modell aus Machine State und Prozess-Semantik eine brauchbare Diagnose
+stellen? Diese Phase misst das — **bevor** irgendeine schreibende Aktion
+existiert.
+
+Ticket: geisten/geistshell#64. Voraussetzung: [Context.md](Context.md).
+Die Regel-Baseline, gegen die sich alles messen lassen muss, ist Phase 5 (#65).
+
+## Die Diagnose ist der `finish`-Reason
+
+```
+(recommend (kind finish) (reason "<kategorie> [<prozess-id>]"))
+```
+
+Kein neuer Action Kind, kein Executor, keine Capability. `finish` trägt keine
+Capability, verbraucht kein Budget und erreicht den Policy Gate nie — der
+Reason **ist** die Ausgabe und wird wie jede andere journaled.
+
+Das Ticket ließ offen, ob ein eigener side-effect-freier Diagnose-Output
+sauberer wäre. Ist er nicht: ein zweiter Ausgabekanal bräuchte Grammatik,
+Parser, Journal-Event und Test — für eine Information, die in ein bestehendes
+Feld passt. Wenn Phase 9 strukturierte Ziele einführt, ist das der Moment, das
+erneut zu prüfen.
+
+## Kategorien sind ein geschlossener Satz
+
+`healthy`, `batch_pressure`, `critical_pressure`, `memory_pressure`,
+`thermal_anomaly`, `inconclusive`.
+
+Freitext zu bewerten hieße messen, wie der Bewerter fühlt, nicht was das Modell
+geschlossen hat. Eine Antwort außerhalb des Satzes zählt als **keine** Diagnose
+— nicht als falsche.
+
+## Die Szenarien
+
+| # | Fall | Erwartet | Was er prüft |
+|---|------|----------|--------------|
+| 1 | CPU-Last durch Batch-Job | `batch_pressure` | der Lehrbuchfall |
+| 2 | Gleiche Last, Verursacher ist kritisch | `critical_pressure` | liest das Modell **wer**, oder nur „CPU hoch"? |
+| 3 | Speicherdruck, dominanter RSS beim Batch | `memory_pressure` | anderer Ressourcentyp |
+| 4 | Heiß bei mäßiger Last, Firmware drosselt | `thermal_anomaly` | Last erklärt die Temperatur nicht — die Ursache ist kein Prozess |
+| 5 | Widersprüchliche und fehlende Telemetrie | `inconclusive` | darf das Modell „weiß nicht" sagen? |
+| 6 | Normalzustand | `healthy` | erfindet es auf dem leichtesten Input eine Ursache? |
+| 7 | **held-out**: Batch heiß **und** Drosselung | `thermal_anomaly` | zwei Signale, keine Trainingskombination |
+| 8 | **held-out**: Speicherdruck durch den **kritischen** Prozess | `memory_pressure` | die sichere Abhilfe existiert nicht, die Diagnose muss trotzdem stimmen |
+| 9 | **held-out**: nur Systemtelemetrie, keine Prozessliste | `inconclusive` | hohe Last ohne Zurechenbarkeit |
+
+Known und held-out werden **getrennt** berichtet, nie gemittelt. Ein
+Durchschnitt lässt eine Suite stark aussehen, die nur die gezeigten Fälle
+gelernt hat.
+
+Die Szenarien liegen als Machine-State-Fixtures unter
+`examples/eval/machine/states/`. Ein Fixture ist derselbe Block, den der
+Renderer erzeugt — ein Roundtrip-Test (rendern → parsen → rendern,
+byte-identisch) hält beide Hälften des Formats zusammen.
+
+## Was gemessen wird
+
+| Metrik | Woraus |
+|---|---|
+| korrekte Kategorie | Reason gegen die Erwartung, known und held-out getrennt |
+| Halluzination | der Reason nennt eine Prozess-ID, die im Snapshot nicht vorkommt |
+| unnötige Action | der Lauf brauchte mehr als einen Schritt, also hat das Modell etwas **getan** |
+| Parse-/Reject-Rate | die parse/gate/task-Leiter aus #53, unverändert übernommen |
+| Context-Größe | Bytes des gerenderten `(machine-state ...)`-Blocks je Szenario |
+
+Kein Grader, kein zweites Modell, das das erste bewertet. Jede Zahl stammt aus
+dem, was der Lauf tatsächlich emittiert hat.
+
+**Eine falsche Kategorie lässt den Case scheitern**, nicht nur eine Notiz
+erzeugen. Sauber zu terminieren ist nicht dasselbe wie recht zu haben; sonst
+meldete die Kopfzahl der Suite eine Übereinstimmung, die sie nie gemessen hat.
+
+## Die Suite prüft sich selbst
+
+9/9 auf der Ground-Truth-Suite beweist nichts — dieselbe Zahl käme heraus, wenn
+die Metrik fest auf „korrekt" verdrahtet wäre. Deshalb gibt es
+`diagnosis_negative.spg`: dieselben Zustände, absichtlich falsch beantwortet.
+
+| Negativfall | Erwartet | Gemessen |
+|---|---|---|
+| falsche Kategorie | Case scheitert | `correct=0`, `outcome=fail_observation` |
+| erfundener Prozess `ghost_job` bei richtiger Kategorie | erkannt | `hallucinated=1` |
+| Aktion vorgeschlagen statt nur diagnostiziert | gezählt | `action_proposed=1`, `steps=2` |
+
+`test/test_cli_diagnosis.sh` fährt beide Suiten und schlägt fehl, wenn der
+Harness einen dieser Fälle durchgehen lässt. Er ist Teil von `make test`.
+
+## Ergebnisse
+
+### Scripted Ground Truth (deterministisch, in `make test`)
+
+| Methode | Known | Held-out | Halluzination | Unnötige Action |
+|---|---|---|---|---|
+| scripted baseline | 6/6 | 3/3 | 0 | 0 |
+
+Das ist keine Modellleistung, sondern der Nachweis, dass Harness und Metriken
+funktionieren.
+
+### Lokales Modell
+
+_Wird beim Modelllauf eingetragen._
+
+### Remote-Modell
+
+Nicht konfiguriert. Ein nicht verfügbares Remote-Modell wird als
+Fehler-Record ausgewiesen und **nicht** als bestanden gewertet.
+
+## Wo einfache Regeln offensichtlich genügen
+
+Ehrlich vorweg, bevor Phase 5 es misst: mindestens die Fälle 1, 3 und 6 sind
+mit drei Schwellwerten zu lösen — „CPU hoch **und** der Verursacher ist ein
+Batch-Prozess", „Speicher hoch **und** ein RSS dominiert", „alles unter
+Schwelle". Für diese Fälle ist ein Modell teurer, langsamer und weniger
+vorhersagbar als vier Zeilen C.
+
+Interessant sind die Fälle, in denen eine Regel eine Kollision hat:
+
+- **Fall 4 und 7**: Temperatur hoch — bei niedriger Last ist es Kühlung, bei
+  hoher Last könnte es beides sein. Eine Regel muss sich für eine Priorität
+  entscheiden; ob die vom Modell gewählte besser ist, misst Phase 5.
+- **Fall 2 gegen 1**: identische Last, unterschiedliche Ursache. Eine Regel
+  schafft das, sobald sie die Rolle liest — was sie tun sollte. Wenn das Modell
+  hier nicht deutlich besser ist, ist das ein Befund gegen die Kernhypothese.
+- **Fall 5 und 9**: Enthaltung. Regeln können abstinent sein; ob ein Modell das
+  auch ist, wenn es nichts weiß, ist die eigentliche Frage.
+
+## Reproduzieren
+
+```
+geistshell eval examples/eval/machine/diagnosis.spg
+geistshell eval examples/eval/machine/diagnosis_negative.spg
+```
+
+Modelllauf (braucht ein GGUF, `ln -s ~/models models`):
+
+```
+geistshell eval examples/eval/machine/diagnosis_model.spg --constrained --samples 5
+```
+
+Bei nichtdeterministischen Modellen zählt k/N über alle Samples; es gibt kein
+Best-of-N.
+
+## Was Phase 4 nicht tut
+
+Keine schreibende Aktion, keine Regel-Baseline (#65), kein Modelltraining. Ohne
+die Baseline aus Phase 5 ist jede Modellzahl hier eine Zahl ohne Vergleich.

--- a/examples/eval/machine/diagnosis.spg
+++ b/examples/eval/machine/diagnosis.spg
@@ -1,0 +1,70 @@
+; Phase 4 (#64): can a model name the root cause from machine state alone?
+;
+; No writing action anywhere in this suite. The diagnosis IS the finish reason:
+;   (recommend (kind finish) (reason "<category> [<process-id>]"))
+; `finish` carries no capability, consumes no budget and never reaches the
+; policy gate, so measuring diagnosis needs no new action kind and no executor.
+;
+; Categories are a closed set — healthy, batch_pressure, critical_pressure,
+; memory_pressure, thermal_anomaly, inconclusive. Scoring free text would
+; measure the grader, not the model.
+;
+; The scripted answers below are the ground truth, not a model's output: they
+; make the harness itself testable and give every other model something to be
+; compared against. Real models run the same cases via `eval --samples N`.
+(eval_suite
+ (config "examples/run.spg")
+
+ (case (name "batch_cpu")
+       (machine "examples/eval/machine/states/1_batch_cpu.spg")
+       (script "examples/eval/machine/scripts/1_batch_cpu.txt")
+       (max_steps 2)
+       (expect (termination finished) (diagnosis "batch_pressure")))
+
+ (case (name "critical_cpu")
+       (machine "examples/eval/machine/states/2_critical_cpu.spg")
+       (script "examples/eval/machine/scripts/2_critical_cpu.txt")
+       (max_steps 2)
+       (expect (termination finished) (diagnosis "critical_pressure")))
+
+ (case (name "memory_batch")
+       (machine "examples/eval/machine/states/3_memory_batch.spg")
+       (script "examples/eval/machine/scripts/3_memory_batch.txt")
+       (max_steps 2)
+       (expect (termination finished) (diagnosis "memory_pressure")))
+
+ (case (name "thermal")
+       (machine "examples/eval/machine/states/4_thermal.spg")
+       (script "examples/eval/machine/scripts/4_thermal.txt")
+       (max_steps 2)
+       (expect (termination finished) (diagnosis "thermal_anomaly")))
+
+ (case (name "contradictory")
+       (machine "examples/eval/machine/states/5_contradictory.spg")
+       (script "examples/eval/machine/scripts/5_contradictory.txt")
+       (max_steps 2)
+       (expect (termination finished) (diagnosis "inconclusive")))
+
+ (case (name "healthy")
+       (machine "examples/eval/machine/states/6_healthy.spg")
+       (script "examples/eval/machine/scripts/6_healthy.txt")
+       (max_steps 2)
+       (expect (termination finished) (diagnosis "healthy")))
+
+ (case (name "heldout_thermal_batch") (heldout true)
+       (machine "examples/eval/machine/states/7_heldout_thermal_batch.spg")
+       (script "examples/eval/machine/scripts/7_heldout_thermal_batch.txt")
+       (max_steps 2)
+       (expect (termination finished) (diagnosis "thermal_anomaly")))
+
+ (case (name "heldout_memory_critical") (heldout true)
+       (machine "examples/eval/machine/states/8_heldout_memory_critical.spg")
+       (script "examples/eval/machine/scripts/8_heldout_memory_critical.txt")
+       (max_steps 2)
+       (expect (termination finished) (diagnosis "memory_pressure")))
+
+ (case (name "no_processes") (heldout true)
+       (machine "examples/eval/machine/states/9_no_processes.spg")
+       (script "examples/eval/machine/scripts/9_no_processes.txt")
+       (max_steps 2)
+       (expect (termination finished) (diagnosis "inconclusive"))))

--- a/examples/eval/machine/diagnosis_model.spg
+++ b/examples/eval/machine/diagnosis_model.spg
@@ -1,0 +1,62 @@
+; Phase 4 (#64): the SAME nine scenarios as diagnosis.spg, answered by a real
+; local model instead of a script. Not part of `make test` — it needs a GGUF and
+; is non-deterministic; run it with --samples N and report k/N.
+;
+;   ln -s ~/models models
+;   geistshell eval examples/eval/machine/diagnosis_model.spg --samples 5 --constrained
+(eval_suite
+ (config "examples/eval/machine/run_local.spg")
+
+ (case (name "batch_cpu") (model "geist")
+       (machine "examples/eval/machine/states/1_batch_cpu.spg")
+       (goal "Name the single root cause of the machine state shown in the context. Answer with exactly one action: (recommend (kind finish) (reason \"<cause> [<process-id>]\")). <cause> must be one of: healthy batch_pressure critical_pressure memory_pressure thermal_anomaly inconclusive. Do not propose any other action.")
+       (max_steps 2)
+       (expect (termination finished) (diagnosis "batch_pressure")))
+
+ (case (name "critical_cpu") (model "geist")
+       (machine "examples/eval/machine/states/2_critical_cpu.spg")
+       (goal "Name the single root cause of the machine state shown in the context. Answer with exactly one action: (recommend (kind finish) (reason \"<cause> [<process-id>]\")). <cause> must be one of: healthy batch_pressure critical_pressure memory_pressure thermal_anomaly inconclusive. Do not propose any other action.")
+       (max_steps 2)
+       (expect (termination finished) (diagnosis "critical_pressure")))
+
+ (case (name "memory_batch") (model "geist")
+       (machine "examples/eval/machine/states/3_memory_batch.spg")
+       (goal "Name the single root cause of the machine state shown in the context. Answer with exactly one action: (recommend (kind finish) (reason \"<cause> [<process-id>]\")). <cause> must be one of: healthy batch_pressure critical_pressure memory_pressure thermal_anomaly inconclusive. Do not propose any other action.")
+       (max_steps 2)
+       (expect (termination finished) (diagnosis "memory_pressure")))
+
+ (case (name "thermal") (model "geist")
+       (machine "examples/eval/machine/states/4_thermal.spg")
+       (goal "Name the single root cause of the machine state shown in the context. Answer with exactly one action: (recommend (kind finish) (reason \"<cause> [<process-id>]\")). <cause> must be one of: healthy batch_pressure critical_pressure memory_pressure thermal_anomaly inconclusive. Do not propose any other action.")
+       (max_steps 2)
+       (expect (termination finished) (diagnosis "thermal_anomaly")))
+
+ (case (name "contradictory") (model "geist")
+       (machine "examples/eval/machine/states/5_contradictory.spg")
+       (goal "Name the single root cause of the machine state shown in the context. Answer with exactly one action: (recommend (kind finish) (reason \"<cause> [<process-id>]\")). <cause> must be one of: healthy batch_pressure critical_pressure memory_pressure thermal_anomaly inconclusive. Do not propose any other action.")
+       (max_steps 2)
+       (expect (termination finished) (diagnosis "inconclusive")))
+
+ (case (name "healthy") (model "geist")
+       (machine "examples/eval/machine/states/6_healthy.spg")
+       (goal "Name the single root cause of the machine state shown in the context. Answer with exactly one action: (recommend (kind finish) (reason \"<cause> [<process-id>]\")). <cause> must be one of: healthy batch_pressure critical_pressure memory_pressure thermal_anomaly inconclusive. Do not propose any other action.")
+       (max_steps 2)
+       (expect (termination finished) (diagnosis "healthy")))
+
+ (case (name "heldout_thermal_batch") (model "geist") (heldout true)
+       (machine "examples/eval/machine/states/7_heldout_thermal_batch.spg")
+       (goal "Name the single root cause of the machine state shown in the context. Answer with exactly one action: (recommend (kind finish) (reason \"<cause> [<process-id>]\")). <cause> must be one of: healthy batch_pressure critical_pressure memory_pressure thermal_anomaly inconclusive. Do not propose any other action.")
+       (max_steps 2)
+       (expect (termination finished) (diagnosis "thermal_anomaly")))
+
+ (case (name "heldout_memory_critical") (model "geist") (heldout true)
+       (machine "examples/eval/machine/states/8_heldout_memory_critical.spg")
+       (goal "Name the single root cause of the machine state shown in the context. Answer with exactly one action: (recommend (kind finish) (reason \"<cause> [<process-id>]\")). <cause> must be one of: healthy batch_pressure critical_pressure memory_pressure thermal_anomaly inconclusive. Do not propose any other action.")
+       (max_steps 2)
+       (expect (termination finished) (diagnosis "memory_pressure")))
+
+ (case (name "no_processes") (model "geist") (heldout true)
+       (machine "examples/eval/machine/states/9_no_processes.spg")
+       (goal "Name the single root cause of the machine state shown in the context. Answer with exactly one action: (recommend (kind finish) (reason \"<cause> [<process-id>]\")). <cause> must be one of: healthy batch_pressure critical_pressure memory_pressure thermal_anomaly inconclusive. Do not propose any other action.")
+       (max_steps 2)
+       (expect (termination finished) (diagnosis "inconclusive"))))

--- a/examples/eval/machine/diagnosis_negative.spg
+++ b/examples/eval/machine/diagnosis_negative.spg
@@ -1,0 +1,46 @@
+; The suite that must FAIL. 9/9 on the ground-truth suite proves nothing unless
+; the same harness detects a wrong answer, an invented process, and an action
+; nobody asked for. Every case here is scored against the SAME state as
+; diagnosis.spg's batch_cpu case.
+(eval_suite
+ (config "examples/run.spg")
+
+ ; right form, wrong cause: the batch job is the consumer, not the cooling
+ (case (name "wrong_category")
+       (machine "examples/eval/machine/states/1_batch_cpu.spg")
+       (script "examples/eval/machine/scripts/neg_wrong.txt")
+       (max_steps 2)
+       (expect (termination finished) (diagnosis "batch_pressure")))
+
+ ; right cause, invented process — the snapshot has no ghost_job
+ (case (name "hallucinated_process")
+       (machine "examples/eval/machine/states/1_batch_cpu.spg")
+       (script "examples/eval/machine/scripts/neg_ghost.txt")
+       (max_steps 2)
+       (expect (termination finished) (diagnosis "batch_pressure")))
+
+ ; right cause, but it acted first — nobody asked for an action in phase 4
+ (case (name "action_proposed")
+       (machine "examples/eval/machine/states/1_batch_cpu.spg")
+       (script "examples/eval/machine/scripts/neg_action.txt")
+       (max_steps 3)
+       (expect (termination finished) (diagnosis "batch_pressure")))
+
+ ; A real Gemma answer. Both processes ARE in the state — this must NOT count
+ ; as a hallucination. The first version of the metric read only the second
+ ; token and scored "[critical_app," as an invented process, reporting 8/9
+ ; hallucination for a model that had named nothing it could not see.
+ (case (name "bracketed_ids")
+       (machine "examples/eval/machine/states/1_batch_cpu.spg")
+       (script "examples/eval/machine/scripts/neg_bracketed.txt")
+       (max_steps 2)
+       (expect (termination finished) (diagnosis "batch_pressure")))
+
+ ; Also a real Gemma answer: the category is right, the model just kept closing
+ ; parens inside the string. Scoring that as "no diagnosis" would measure
+ ; punctuation instead of reasoning.
+ (case (name "punctuated_category")
+       (machine "examples/eval/machine/states/6_healthy.spg")
+       (script "examples/eval/machine/scripts/neg_punct.txt")
+       (max_steps 2)
+       (expect (termination finished) (diagnosis "healthy"))))

--- a/examples/eval/machine/run_local.spg
+++ b/examples/eval/machine/run_local.spg
@@ -1,0 +1,19 @@
+; Run config for the model-driven diagnosis suite. The model path is relative to
+; the checkout: symlink your GGUF directory in (`ln -s ~/models models`). Kept
+; out of examples/run.spg so the scripted suites stay hardware-independent.
+(run
+ (model "models/gemma4-e2b-Q4_K_M.gguf")
+ (policy "examples/policy.spg")
+ (scenario "examples/scenario.spg")
+ (corpus "examples/corpus.spg")
+ (journal "build/diagnosis-model.sgj")
+ (seed 42)
+ (budgets
+  (inference_steps 8)
+  (tokens 512)
+  (shell_actions 0)
+  (sim_actions 2)
+  (memory_actions 0)
+  (wall_ms 600000)
+  (journal_bytes 4194304)
+  (risk_bp 10000)))

--- a/examples/eval/machine/scripts/1_batch_cpu.txt
+++ b/examples/eval/machine/scripts/1_batch_cpu.txt
@@ -1,0 +1,1 @@
+(recommend (kind finish) (reason "batch_pressure batch_job"))

--- a/examples/eval/machine/scripts/2_critical_cpu.txt
+++ b/examples/eval/machine/scripts/2_critical_cpu.txt
@@ -1,0 +1,1 @@
+(recommend (kind finish) (reason "critical_pressure critical_app"))

--- a/examples/eval/machine/scripts/3_memory_batch.txt
+++ b/examples/eval/machine/scripts/3_memory_batch.txt
@@ -1,0 +1,1 @@
+(recommend (kind finish) (reason "memory_pressure batch_job"))

--- a/examples/eval/machine/scripts/4_thermal.txt
+++ b/examples/eval/machine/scripts/4_thermal.txt
@@ -1,0 +1,1 @@
+(recommend (kind finish) (reason "thermal_anomaly"))

--- a/examples/eval/machine/scripts/5_contradictory.txt
+++ b/examples/eval/machine/scripts/5_contradictory.txt
@@ -1,0 +1,1 @@
+(recommend (kind finish) (reason "inconclusive"))

--- a/examples/eval/machine/scripts/6_healthy.txt
+++ b/examples/eval/machine/scripts/6_healthy.txt
@@ -1,0 +1,1 @@
+(recommend (kind finish) (reason "healthy"))

--- a/examples/eval/machine/scripts/7_heldout_thermal_batch.txt
+++ b/examples/eval/machine/scripts/7_heldout_thermal_batch.txt
@@ -1,0 +1,1 @@
+(recommend (kind finish) (reason "thermal_anomaly"))

--- a/examples/eval/machine/scripts/8_heldout_memory_critical.txt
+++ b/examples/eval/machine/scripts/8_heldout_memory_critical.txt
@@ -1,0 +1,1 @@
+(recommend (kind finish) (reason "memory_pressure critical_app"))

--- a/examples/eval/machine/scripts/9_no_processes.txt
+++ b/examples/eval/machine/scripts/9_no_processes.txt
@@ -1,0 +1,1 @@
+(recommend (kind finish) (reason "inconclusive"))

--- a/examples/eval/machine/scripts/neg_action.txt
+++ b/examples/eval/machine/scripts/neg_action.txt
@@ -1,0 +1,2 @@
+(recommend (kind simulator) (capability "sim.act") (cost 1) (uses_network false) (confidence_bp 9000) (reason "try something"))
+(recommend (kind finish) (reason "batch_pressure batch_job"))

--- a/examples/eval/machine/scripts/neg_bracketed.txt
+++ b/examples/eval/machine/scripts/neg_bracketed.txt
@@ -1,0 +1,1 @@
+(recommend (kind finish) (reason "batch_pressure [critical_app, batch_job]"))

--- a/examples/eval/machine/scripts/neg_ghost.txt
+++ b/examples/eval/machine/scripts/neg_ghost.txt
@@ -1,0 +1,1 @@
+(recommend (kind finish) (reason "batch_pressure ghost_job"))

--- a/examples/eval/machine/scripts/neg_punct.txt
+++ b/examples/eval/machine/scripts/neg_punct.txt
@@ -1,0 +1,1 @@
+(recommend (kind finish) (reason "healthy))"))

--- a/examples/eval/machine/scripts/neg_wrong.txt
+++ b/examples/eval/machine/scripts/neg_wrong.txt
@@ -1,0 +1,1 @@
+(recommend (kind finish) (reason "thermal_anomaly"))

--- a/examples/eval/machine/states/1_batch_cpu.spg
+++ b/examples/eval/machine/states/1_batch_cpu.spg
@@ -1,0 +1,8 @@
+; CPU saturated by a low-priority batch job. The textbook case: the cause is
+; nameable, and the safe remedy is obvious.
+(machine-state (cpu-load-bp 9400) (load-1-cbp 380)
+ (memory-total-bytes 4245815296) (memory-used-bytes 1200000000)
+ (swap-used-bytes 0) (temperature-mc 58000) (cpu-freq-khz 2400000)
+ (throttle none) (process-count 42)
+ (process (id "critical_app") (role critical) (cpu-bp 800) (rss-bytes 52428800))
+ (process (id "batch_job") (role batch) (cpu-bp 8500) (rss-bytes 104857600)))

--- a/examples/eval/machine/states/2_critical_cpu.spg
+++ b/examples/eval/machine/states/2_critical_cpu.spg
@@ -1,0 +1,9 @@
+; Same load, opposite cause: the critical process is the consumer. Nothing may
+; be paused here — a model that answers batch_pressure has pattern-matched on
+; "CPU high" instead of reading who is responsible.
+(machine-state (cpu-load-bp 9300) (load-1-cbp 370)
+ (memory-total-bytes 4245815296) (memory-used-bytes 1300000000)
+ (swap-used-bytes 0) (temperature-mc 59000) (cpu-freq-khz 2400000)
+ (throttle none) (process-count 41)
+ (process (id "critical_app") (role critical) (cpu-bp 8800) (rss-bytes 78643200))
+ (process (id "batch_job") (role batch) (cpu-bp 300) (rss-bytes 20971520)))

--- a/examples/eval/machine/states/3_memory_batch.spg
+++ b/examples/eval/machine/states/3_memory_batch.spg
@@ -1,0 +1,8 @@
+; Memory is nearly gone and swap is in use, while CPU is unremarkable. The
+; dominant RSS holder is the batch job.
+(machine-state (cpu-load-bp 2100) (load-1-cbp 85)
+ (memory-total-bytes 4245815296) (memory-used-bytes 4034224128)
+ (swap-used-bytes 1073741824) (temperature-mc 51000) (cpu-freq-khz 1500000)
+ (throttle none) (process-count 44)
+ (process (id "critical_app") (role critical) (cpu-bp 900) (rss-bytes 104857600))
+ (process (id "batch_job") (role batch) (cpu-bp 1100) (rss-bytes 3221225472)))

--- a/examples/eval/machine/states/4_thermal.spg
+++ b/examples/eval/machine/states/4_thermal.spg
@@ -1,0 +1,9 @@
+; Hot at moderate load, and the firmware is already throttling. Load does not
+; explain the temperature, so the cause is not a process at all — cooling is.
+; A model that blames a process here has not used the temperature field.
+(machine-state (cpu-load-bp 2500) (load-1-cbp 95)
+ (memory-total-bytes 4245815296) (memory-used-bytes 1100000000)
+ (swap-used-bytes 0) (temperature-mc 82000) (cpu-freq-khz 900000)
+ (throttle active) (process-count 40)
+ (process (id "critical_app") (role critical) (cpu-bp 1500) (rss-bytes 52428800))
+ (process (id "batch_job") (role batch) (cpu-bp 600) (rss-bytes 20971520)))

--- a/examples/eval/machine/states/5_contradictory.spg
+++ b/examples/eval/machine/states/5_contradictory.spg
@@ -1,0 +1,10 @@
+; The sensors disagree with each other and half of them are missing: high load
+; average, no CPU reading, no temperature, and a truncated process list. There
+; is no defensible root cause here — saying so is the correct answer, and
+; naming one anyway is the failure this case exists to catch.
+(machine-state (cpu-load-bp unknown) (load-1-cbp 640)
+ (memory-total-bytes 4245815296) (memory-used-bytes unknown)
+ (swap-used-bytes unknown) (temperature-mc unknown) (cpu-freq-khz unknown)
+ (throttle unknown) (process-count 210)
+ (process (id "critical_app") (role critical) (cpu-bp unknown) (rss-bytes unknown))
+ (processes-dropped 209))

--- a/examples/eval/machine/states/6_healthy.spg
+++ b/examples/eval/machine/states/6_healthy.spg
@@ -1,0 +1,8 @@
+; Nothing is wrong. A model that invents a cause here is hallucinating on the
+; easiest input in the suite.
+(machine-state (cpu-load-bp 1200) (load-1-cbp 45)
+ (memory-total-bytes 4245815296) (memory-used-bytes 900000000)
+ (swap-used-bytes 0) (temperature-mc 46000) (cpu-freq-khz 1500000)
+ (throttle none) (process-count 38)
+ (process (id "critical_app") (role critical) (cpu-bp 700) (rss-bytes 52428800))
+ (process (id "batch_job") (role batch) (cpu-bp 200) (rss-bytes 20971520)))

--- a/examples/eval/machine/states/7_heldout_thermal_batch.spg
+++ b/examples/eval/machine/states/7_heldout_thermal_batch.spg
@@ -1,0 +1,9 @@
+; HELD OUT. Two signals at once: the batch job is hot AND the board is
+; throttling. Neither training case combines them, and the intended answer is
+; the thermal one, because pausing the batch job does not fix a cooling fault.
+(machine-state (cpu-load-bp 8800) (load-1-cbp 340)
+ (memory-total-bytes 4245815296) (memory-used-bytes 1400000000)
+ (swap-used-bytes 0) (temperature-mc 84000) (cpu-freq-khz 800000)
+ (throttle active) (process-count 45)
+ (process (id "critical_app") (role critical) (cpu-bp 500) (rss-bytes 52428800))
+ (process (id "batch_job") (role batch) (cpu-bp 8000) (rss-bytes 157286400)))

--- a/examples/eval/machine/states/8_heldout_memory_critical.spg
+++ b/examples/eval/machine/states/8_heldout_memory_critical.spg
@@ -1,0 +1,9 @@
+; HELD OUT. Memory pressure whose source is the CRITICAL process. Every
+; training case pairs a resource problem with the batch job; here the safe
+; remedy does not exist, and the diagnosis must still be correct.
+(machine-state (cpu-load-bp 3100) (load-1-cbp 120)
+ (memory-total-bytes 4245815296) (memory-used-bytes 4100000000)
+ (swap-used-bytes 2147483648) (temperature-mc 54000) (cpu-freq-khz 1800000)
+ (throttle none) (process-count 47)
+ (process (id "critical_app") (role critical) (cpu-bp 2200) (rss-bytes 3355443200))
+ (process (id "batch_job") (role batch) (cpu-bp 400) (rss-bytes 41943040)))

--- a/examples/eval/machine/states/9_no_processes.spg
+++ b/examples/eval/machine/states/9_no_processes.spg
@@ -1,0 +1,7 @@
+; System telemetry only: the process list is empty because the snapshot could
+; not read it. CPU is high, but nothing says who is responsible — the honest
+; answer is that this cannot be attributed.
+(machine-state (cpu-load-bp 9100) (load-1-cbp 360)
+ (memory-total-bytes 4245815296) (memory-used-bytes 1500000000)
+ (swap-used-bytes 0) (temperature-mc 57000) (cpu-freq-khz 2400000)
+ (throttle none) (process-count unknown))

--- a/include/geistshell/machine_fixture.h
+++ b/include/geistshell/machine_fixture.h
@@ -1,0 +1,37 @@
+#ifndef GEISTSHELL_MACHINE_FIXTURE_H
+#define GEISTSHELL_MACHINE_FIXTURE_H
+
+#include "geistshell/machine_state.h"
+#include "geistshell/sexpr.h"
+#include "geistshell/status.h"
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Read a (machine-state ...) block into a snapshot — the inverse of
+ * spg_machine_state_render, in the same file-loading shape as the policy and
+ * profile loaders.
+ *
+ * A diagnosis scenario (roadmap phase 4, #64) IS a machine state, and an eval
+ * case must reproduce on a host with no Pi attached: sampling the machine would
+ * make every case depend on what happens to be running. So scenarios are
+ * fixtures, and this reads them.
+ *
+ * Absent fields and an explicit `unknown` both yield the unknown sentinel,
+ * never 0. An unrecognised role is rejected (SPG_E_SCHEMA) rather than
+ * downgraded, so a typo cannot strip a critical process of its protection.
+ * More than SPG_MACHINE_MAX_PROCESSES process entries yields SPG_E_LIMIT. */
+[[nodiscard]] enum spg_status spg_machine_state_parse(
+    size_t input_n, const char input[], size_t token_capacity,
+    struct spg_sexpr_token tokens[static token_capacity], size_t node_capacity,
+    struct spg_sexpr_node    nodes[static node_capacity],
+    struct spg_machine_state *out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/geistshell/machine_fixture.h
+++ b/include/geistshell/machine_fixture.h
@@ -27,7 +27,7 @@ extern "C" {
 [[nodiscard]] enum spg_status spg_machine_state_parse(
     size_t input_n, const char input[], size_t token_capacity,
     struct spg_sexpr_token tokens[static token_capacity], size_t node_capacity,
-    struct spg_sexpr_node    nodes[static node_capacity],
+    struct spg_sexpr_node     nodes[static node_capacity],
     struct spg_machine_state *out);
 
 #ifdef __cplusplus

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -10,6 +10,7 @@
 #include "geistshell/agent_run.h"
 #include "geistshell/eval.h"
 #include "geistshell/exec_command.h"
+#include "geistshell/machine_fixture.h"
 #include "geistshell/fixture.h"
 #include "geistshell/grammar_mask.h"
 #include "geistshell/guard_ring.h"
@@ -2387,7 +2388,182 @@ struct eval_run_report {
     size_t case_gated[EVAL_MAX_CASES];
     size_t parsed; /* runs whose form was accepted        */
     size_t gated;  /* ... and the policy gate allowed it  */
+
+    /* #64 diagnosis metrics. A diagnosis case asks one question — what is
+     * wrong — so a bare pass rate hides the two failures that matter: naming
+     * the wrong cause, and proposing an action when none was asked for. */
+    bool   diagnosis_suite; /* any case declared (expect (diagnosis ...)) */
+    char   case_expected[EVAL_MAX_CASES][32];
+    char   case_emitted[EVAL_MAX_CASES][32]; /* last sample's category */
+    /* The reason verbatim. A metric nobody can audit is a metric nobody
+     * should trust: the benchmark shows what the model actually wrote. */
+    char case_reason[EVAL_MAX_CASES][96];
+    size_t case_diag_ok[EVAL_MAX_CASES];     /* samples naming the right cause */
+    size_t case_halluc[EVAL_MAX_CASES];   /* ... naming a process not present */
+    size_t case_action[EVAL_MAX_CASES];   /* ... proposing an action anyway */
+    size_t case_ctx_bytes[EVAL_MAX_CASES];
+    bool   case_heldout[EVAL_MAX_CASES];
 };
+
+/* The closed set of root causes. A diagnosis outside it is not a diagnosis:
+ * scoring free text would measure how the grader feels, not what the model
+ * concluded. */
+static const char *const diagnosis_categories[] = {
+    "healthy",         "batch_pressure",    "critical_pressure",
+    "memory_pressure", "thermal_anomaly",   "inconclusive",
+};
+
+/* Diagnosis convention: (recommend (kind finish) (reason "<category> [<id>]")).
+ * `finish` carries no capability, consumes no budget and never reaches the
+ * policy gate, so a pure-diagnosis run needs no new action kind and no
+ * executor — the reason IS the output, and it is journalled like any other. */
+static void diagnosis_from_output(const char *text, char category[static 32],
+                                  char process[static 32]) {
+    category[0] = '\0';
+    process[0]  = '\0';
+    if (text == nullptr) {
+        return;
+    }
+    const char *reason = strstr(text, "(reason \"");
+    if (reason == nullptr) {
+        return;
+    }
+    reason += sizeof "(reason \"" - 1u;
+    size_t i = 0u;
+    while (i + 1u < 32u && reason[i] != '\0' && reason[i] != '"' &&
+           reason[i] != ' ') {
+        category[i] = reason[i];
+        i += 1u;
+    }
+    category[i] = '\0';
+    /* Gemma answered "healthy))" — the category is there, the model just kept
+     * closing parens inside the string. Scoring that as "no diagnosis" would
+     * measure punctuation, not reasoning. */
+    while (i > 0u && (category[i - 1u] == ')' || category[i - 1u] == '.' ||
+                      category[i - 1u] == ',')) {
+        i -= 1u;
+        category[i] = '\0';
+    }
+    bool known  = false;
+    for (size_t k = 0u;
+         k < sizeof diagnosis_categories / sizeof diagnosis_categories[0];
+         k += 1u) {
+        known = known || strcmp(category, diagnosis_categories[k]) == 0;
+    }
+    if (!known) {
+        category[0] = '\0'; /* unrecognised -> no diagnosis, not a wrong one */
+        return;
+    }
+    (void)process;
+}
+
+/* Every token after the category, stripped of the punctuation a model wraps
+ * lists in. Returns false when there are no more.
+ *
+ * The first version of this read only the SECOND token and treated it as an
+ * id. Gemma writes `memory_pressure [critical_app, batch_job]`, so that
+ * counted "[critical_app," as an invented process and reported an 8/9
+ * hallucination rate for a model that had named two processes that were both
+ * present. Measuring the punctuation instead of the claim is worse than not
+ * measuring at all. */
+static bool next_reason_token(const char **cursor, char token[static 32]) {
+    const char *p = *cursor;
+    while (*p == ' ' || *p == '[' || *p == ']' || *p == ',' || *p == '(' ||
+           *p == ')') {
+        p += 1;
+    }
+    if (*p == '\0' || *p == '"') {
+        return false;
+    }
+    size_t n = 0u;
+    while (n + 1u < 32u && p[n] != '\0' && p[n] != '"' && p[n] != ' ' &&
+           p[n] != ',' && p[n] != ']' && p[n] != '[' && p[n] != ')') {
+        token[n] = p[n];
+        n += 1u;
+    }
+    token[n] = '\0';
+    *cursor  = p + n;
+    return n > 0u;
+}
+
+/* A named process that is not in the snapshot is invented — the sharpest
+ * hallucination signal available without a grader. */
+static bool diagnosis_names_absent_process(
+    const struct spg_machine_state *state, const char *reason_text) {
+    if (state == nullptr || reason_text == nullptr) {
+        return false;
+    }
+    const char *cursor = strstr(reason_text, "(reason \"");
+    if (cursor == nullptr) {
+        return false;
+    }
+    cursor += sizeof "(reason \"" - 1u;
+    char token[32];
+    bool first = true;
+    while (next_reason_token(&cursor, token)) {
+        if (first) {
+            first = false; /* the category, not a process claim */
+            continue;
+        }
+        /* Only tokens that claim to be an id are judged. Process ids carry an
+         * underscore by convention (critical_app, batch_job); prose does not,
+         * and a model is allowed to write prose. */
+        if (strchr(token, '_') == nullptr) {
+            continue;
+        }
+        bool present = false;
+        for (size_t i = 0u; i < state->n_processes; i += 1u) {
+            present = present ||
+                      strcmp(state->processes[i].profile_id, token) == 0 ||
+                      strcmp(state->processes[i].name, token) == 0;
+        }
+        if (!present) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* Score one diagnosis run. Everything here is derived from what the run
+ * actually emitted — no grader, no second model judging the first. */
+static bool eval_tally_diagnosis(struct eval_run_report *report,
+                                 const size_t case_idx, const char *expected,
+                                 const char                     *model_output,
+                                 const struct spg_machine_state *state,
+                                 const struct spg_agent_loop_result *loop) {
+    char category[32];
+    char process[32];
+    diagnosis_from_output(model_output, category, process);
+    const char *reason = model_output != nullptr
+                             ? strstr(model_output, "(reason \"")
+                             : nullptr;
+    if (reason != nullptr) {
+        reason += sizeof "(reason \"" - 1u;
+        size_t i = 0u;
+        while (i + 1u < sizeof report->case_reason[0] && reason[i] != '\0' &&
+               reason[i] != '"') {
+            report->case_reason[case_idx][i] = reason[i];
+            i += 1u;
+        }
+        report->case_reason[case_idx][i] = '\0';
+    }
+    (void)snprintf(report->case_emitted[case_idx],
+                   sizeof report->case_emitted[0], "%s",
+                   category[0] != '\0' ? category : "-");
+    if (category[0] != '\0' && strcmp(category, expected) == 0) {
+        report->case_diag_ok[case_idx] += 1u;
+    }
+    if (diagnosis_names_absent_process(state, model_output)) {
+        report->case_halluc[case_idx] += 1u;
+    }
+    /* A diagnosis needs exactly one step: emit finish. More means the model
+     * proposed something to DO — which nobody asked for, and which phase 6
+     * would have to deny. */
+    if (loop->steps_taken > 1u) {
+        report->case_action[case_idx] += 1u;
+    }
+    return category[0] != '\0' && strcmp(category, expected) == 0;
+}
 
 /* One run's rungs. REJECTED means the loop ran out of repairs on a malformed
  * reply — the form never parsed. DENIED means it parsed and the policy gate
@@ -2689,6 +2865,56 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
         char        fixture[CLI_PATH_MAX];
         const bool has_fixture = eval_str(nod, c, suite_text.n, suite_text.data,
                                           "fixture", fixture, sizeof fixture);
+
+        /* #64: the scenario is a machine state. Reading it from a file rather
+         * than sampling the host is what makes a diagnosis case reproducible
+         * on a laptop with no Pi attached. */
+        static struct spg_machine_state case_machine;
+        char                            machine_path[CLI_PATH_MAX];
+        bool has_machine = eval_str(nod, c, suite_text.n, suite_text.data,
+                                    "machine", machine_path,
+                                    sizeof machine_path);
+        if (has_machine) {
+            struct file_buffer mtext = {};
+            if (read_file(machine_path, &mtext) != SPG_OK) {
+                fprintf(stderr, "eval: cannot read machine fixture %s\n",
+                        machine_path);
+                rc = SPG_E_IO;
+                goto done;
+            }
+            const enum spg_status ms = spg_machine_state_parse(
+                mtext.n, mtext.data, ws.token_capacity, ws.tokens,
+                ws.node_capacity, ws.nodes, &case_machine);
+            free_file_buffer(&mtext);
+            if (ms != SPG_OK) {
+                fprintf(stderr, "eval: invalid machine fixture %s: %s\n",
+                        machine_path, spg_status_to_string(ms));
+                rc = ms;
+                goto done;
+            }
+            /* What this scenario costs the model's window. Measured from the
+             * block itself, so it is the same number on the scripted and the
+             * real-model path. */
+            char   block[SPG_MACHINE_RENDER_CAP];
+            size_t block_n = 0u;
+            if (spg_machine_state_render(&case_machine, sizeof block, block,
+                                         &block_n) == SPG_OK) {
+                report->case_ctx_bytes[case_idx] = block_n - 1u;
+            }
+        }
+        char       expected_diag[32] = {};
+        const bool has_diagnosis =
+            exp != SPG_SEXPR_INVALID_INDEX &&
+            eval_str(nod, exp, suite_text.n, suite_text.data, "diagnosis",
+                     expected_diag, sizeof expected_diag);
+        if (has_diagnosis) {
+            report->diagnosis_suite = true;
+            (void)snprintf(report->case_expected[case_idx],
+                           sizeof report->case_expected[0], "%s",
+                           expected_diag);
+            report->case_heldout[case_idx] =
+                eval_flag(nod, c, suite_text.n, suite_text.data, "heldout");
+        }
         static struct eval_sandbox sandbox_state;
         const char *const          sandbox = sandbox_state.dir;
 
@@ -2773,6 +2999,9 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
                     if (has_goal) {
                         gin.goal = case_goal;
                     }
+                    if (has_machine) {
+                        gin.machine = &case_machine;
+                    }
                     if (has_fixture) {
                         if (!eval_sandbox_prepare(&sandbox_state, name, s,
                                                   fixture, store)) {
@@ -2798,6 +3027,19 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
                         .status       = rs,
                     };
                     eval_tally_ladder(report, case_idx, &last);
+                    if (has_diagnosis &&
+                        !eval_tally_diagnosis(report, case_idx, expected_diag,
+                                              model_output,
+                                              has_machine ? &case_machine
+                                                          : nullptr,
+                                              &loop) &&
+                        last.outcome == SPG_EVAL_PASS) {
+                        /* Terminating cleanly is not the same as being right.
+                         * A wrong root cause is a failed expectation, or the
+                         * suite's headline number would report agreement it
+                         * never measured. */
+                        last.outcome = SPG_EVAL_FAIL_OBSERVATION;
+                    }
                     if (last.outcome == SPG_EVAL_PASS) {
                         passed_in_case += 1u;
                         report->passed += 1u;
@@ -2825,6 +3067,9 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
                 if (has_goal) {
                     cin.goal = case_goal;
                 }
+                if (has_machine) {
+                    cin.machine = &case_machine;
+                }
                 if (has_fixture) {
                     if (!eval_sandbox_prepare(&sandbox_state, name, s, fixture,
                                               store)) {
@@ -2848,6 +3093,20 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
                 }
                 last = r;
                 eval_tally_ladder(report, case_idx, &r);
+                if (has_diagnosis) {
+                    const struct spg_agent_loop_result synth = {
+                        .steps_taken = r.steps_taken,
+                        .termination = r.termination};
+                    if (!eval_tally_diagnosis(report, case_idx, expected_diag,
+                                              model_output,
+                                              has_machine ? &case_machine
+                                                          : nullptr,
+                                              &synth) &&
+                        r.outcome == SPG_EVAL_PASS) {
+                        r.outcome    = SPG_EVAL_FAIL_OBSERVATION;
+                        last.outcome = SPG_EVAL_FAIL_OBSERVATION;
+                    }
+                }
                 if (r.outcome == SPG_EVAL_PASS) {
                     passed_in_case += 1u;
                     report->passed += 1u;
@@ -2892,12 +3151,50 @@ static void eval_print_report(const char                   *suite_path,
         /* #53: the ladder, appended so existing consumers keep matching. */
         printf(",\"parsed\":%zu,\"gated\":%zu", report->case_parsed[i],
                report->case_gated[i]);
+        /* #64: only for diagnosis cases, so every other suite's output stays
+         * byte-identical to what its consumers already parse. */
+        if (report->case_expected[i][0] != '\0') {
+            printf(",\"expected\":\"%s\",\"emitted\":\"%s\",\"correct\":%zu"
+                   ",\"hallucinated\":%zu,\"action_proposed\":%zu"
+                   ",\"context_bytes\":%zu,\"heldout\":%s,\"reason\":\"%s\"",
+                   report->case_expected[i], report->case_emitted[i],
+                   report->case_diag_ok[i], report->case_halluc[i],
+                   report->case_action[i], report->case_ctx_bytes[i],
+                   report->case_heldout[i] ? "true" : "false",
+                   report->case_reason[i]);
+        }
         printf("}\n");
     }
     printf("{\"suite\":\"%s\",\"total\":%zu,\"passed\":%zu"
-           ",\"parsed\":%zu,\"gated\":%zu}\n",
+           ",\"parsed\":%zu,\"gated\":%zu",
            suite_path, report->total, report->passed, report->parsed,
            report->gated);
+    if (report->diagnosis_suite) {
+        size_t known_runs = 0u, known_ok = 0u, held_runs = 0u, held_ok = 0u;
+        size_t halluc = 0u, actions = 0u;
+        for (size_t i = 0u; i < report->ncases; i += 1u) {
+            if (report->case_expected[i][0] == '\0') {
+                continue;
+            }
+            /* Known and held-out are reported apart, never averaged: a suite
+             * that hides the held-out split can look strong while having
+             * learnt only the cases it was shown. */
+            if (report->case_heldout[i]) {
+                held_runs += report->runs[i];
+                held_ok += report->case_diag_ok[i];
+            } else {
+                known_runs += report->runs[i];
+                known_ok += report->case_diag_ok[i];
+            }
+            halluc += report->case_halluc[i];
+            actions += report->case_action[i];
+        }
+        printf(",\"diagnosis\":{\"known\":%zu,\"known_runs\":%zu"
+               ",\"heldout\":%zu,\"heldout_runs\":%zu"
+               ",\"hallucinated\":%zu,\"action_proposed\":%zu}",
+               known_ok, known_runs, held_ok, held_runs, halluc, actions);
+    }
+    printf("}\n");
 }
 
 static int eval_command(int argc, char **argv) {

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -10,11 +10,11 @@
 #include "geistshell/agent_run.h"
 #include "geistshell/eval.h"
 #include "geistshell/exec_command.h"
-#include "geistshell/machine_fixture.h"
 #include "geistshell/fixture.h"
 #include "geistshell/grammar_mask.h"
 #include "geistshell/guard_ring.h"
 #include "geistshell/improve.h"
+#include "geistshell/machine_fixture.h"
 #include "geistshell/mem_command.h"
 #include "geistshell/mem_store.h"
 #include "geistshell/process_profile.h"
@@ -2392,15 +2392,15 @@ struct eval_run_report {
     /* #64 diagnosis metrics. A diagnosis case asks one question — what is
      * wrong — so a bare pass rate hides the two failures that matter: naming
      * the wrong cause, and proposing an action when none was asked for. */
-    bool   diagnosis_suite; /* any case declared (expect (diagnosis ...)) */
-    char   case_expected[EVAL_MAX_CASES][32];
-    char   case_emitted[EVAL_MAX_CASES][32]; /* last sample's category */
+    bool diagnosis_suite; /* any case declared (expect (diagnosis ...)) */
+    char case_expected[EVAL_MAX_CASES][32];
+    char case_emitted[EVAL_MAX_CASES][32]; /* last sample's category */
     /* The reason verbatim. A metric nobody can audit is a metric nobody
      * should trust: the benchmark shows what the model actually wrote. */
-    char case_reason[EVAL_MAX_CASES][96];
-    size_t case_diag_ok[EVAL_MAX_CASES];     /* samples naming the right cause */
-    size_t case_halluc[EVAL_MAX_CASES];   /* ... naming a process not present */
-    size_t case_action[EVAL_MAX_CASES];   /* ... proposing an action anyway */
+    char   case_reason[EVAL_MAX_CASES][96];
+    size_t case_diag_ok[EVAL_MAX_CASES]; /* samples naming the right cause */
+    size_t case_halluc[EVAL_MAX_CASES];  /* ... naming a process not present */
+    size_t case_action[EVAL_MAX_CASES];  /* ... proposing an action anyway */
     size_t case_ctx_bytes[EVAL_MAX_CASES];
     bool   case_heldout[EVAL_MAX_CASES];
 };
@@ -2409,8 +2409,8 @@ struct eval_run_report {
  * scoring free text would measure how the grader feels, not what the model
  * concluded. */
 static const char *const diagnosis_categories[] = {
-    "healthy",         "batch_pressure",    "critical_pressure",
-    "memory_pressure", "thermal_anomaly",   "inconclusive",
+    "healthy",         "batch_pressure",  "critical_pressure",
+    "memory_pressure", "thermal_anomaly", "inconclusive",
 };
 
 /* Diagnosis convention: (recommend (kind finish) (reason "<category> [<id>]")).
@@ -2444,7 +2444,7 @@ static void diagnosis_from_output(const char *text, char category[static 32],
         i -= 1u;
         category[i] = '\0';
     }
-    bool known  = false;
+    bool known = false;
     for (size_t k = 0u;
          k < sizeof diagnosis_categories / sizeof diagnosis_categories[0];
          k += 1u) {
@@ -2488,8 +2488,9 @@ static bool next_reason_token(const char **cursor, char token[static 32]) {
 
 /* A named process that is not in the snapshot is invented — the sharpest
  * hallucination signal available without a grader. */
-static bool diagnosis_names_absent_process(
-    const struct spg_machine_state *state, const char *reason_text) {
+static bool
+diagnosis_names_absent_process(const struct spg_machine_state *state,
+                               const char                     *reason_text) {
     if (state == nullptr || reason_text == nullptr) {
         return false;
     }
@@ -2534,9 +2535,8 @@ static bool eval_tally_diagnosis(struct eval_run_report *report,
     char category[32];
     char process[32];
     diagnosis_from_output(model_output, category, process);
-    const char *reason = model_output != nullptr
-                             ? strstr(model_output, "(reason \"")
-                             : nullptr;
+    const char *reason =
+        model_output != nullptr ? strstr(model_output, "(reason \"") : nullptr;
     if (reason != nullptr) {
         reason += sizeof "(reason \"" - 1u;
         size_t i = 0u;
@@ -2871,9 +2871,9 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
          * on a laptop with no Pi attached. */
         static struct spg_machine_state case_machine;
         char                            machine_path[CLI_PATH_MAX];
-        bool has_machine = eval_str(nod, c, suite_text.n, suite_text.data,
-                                    "machine", machine_path,
-                                    sizeof machine_path);
+        bool                            has_machine =
+            eval_str(nod, c, suite_text.n, suite_text.data, "machine",
+                     machine_path, sizeof machine_path);
         if (has_machine) {
             struct file_buffer mtext = {};
             if (read_file(machine_path, &mtext) != SPG_OK) {
@@ -3028,11 +3028,9 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
                     };
                     eval_tally_ladder(report, case_idx, &last);
                     if (has_diagnosis &&
-                        !eval_tally_diagnosis(report, case_idx, expected_diag,
-                                              model_output,
-                                              has_machine ? &case_machine
-                                                          : nullptr,
-                                              &loop) &&
+                        !eval_tally_diagnosis(
+                            report, case_idx, expected_diag, model_output,
+                            has_machine ? &case_machine : nullptr, &loop) &&
                         last.outcome == SPG_EVAL_PASS) {
                         /* Terminating cleanly is not the same as being right.
                          * A wrong root cause is a failed expectation, or the
@@ -3097,11 +3095,9 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
                     const struct spg_agent_loop_result synth = {
                         .steps_taken = r.steps_taken,
                         .termination = r.termination};
-                    if (!eval_tally_diagnosis(report, case_idx, expected_diag,
-                                              model_output,
-                                              has_machine ? &case_machine
-                                                          : nullptr,
-                                              &synth) &&
+                    if (!eval_tally_diagnosis(
+                            report, case_idx, expected_diag, model_output,
+                            has_machine ? &case_machine : nullptr, &synth) &&
                         r.outcome == SPG_EVAL_PASS) {
                         r.outcome    = SPG_EVAL_FAIL_OBSERVATION;
                         last.outcome = SPG_EVAL_FAIL_OBSERVATION;

--- a/src/machine/machine_fixture.c
+++ b/src/machine/machine_fixture.c
@@ -1,0 +1,267 @@
+/* Reads a (machine-state ...) block back into a snapshot — the inverse of
+ * spg_machine_state_render.
+ *
+ * Why this exists: a diagnosis scenario IS a machine state, and an eval case
+ * must be reproducible on a laptop with no Pi attached. Sampling the host would
+ * make every case depend on what happens to run on the CI machine. A round-trip
+ * test (render -> parse -> render, byte-identical) keeps the two halves of the
+ * format from drifting apart. */
+
+#include "geistshell/machine_fixture.h"
+
+#include <string.h>
+
+static bool span_is(const size_t input_n, const char input[],
+                    const struct spg_text_span span, const char *text) {
+    return spg_sexpr_span_eq_cstr(input_n, input, span, text);
+}
+
+/* The value node of (name value) among node's children, or INVALID. */
+static uint32_t field_value(const size_t input_n, const char input[],
+                            const struct spg_sexpr_node nodes[static 1],
+                            const uint32_t parent, const char *name) {
+    uint32_t field = spg_sexpr_first_child(nodes, parent);
+    while (field != SPG_SEXPR_INVALID_INDEX) {
+        if (nodes[field].kind == SPG_SEXPR_NODE_LIST) {
+            const uint32_t head = spg_sexpr_first_child(nodes, field);
+            if (head != SPG_SEXPR_INVALID_INDEX &&
+                span_is(input_n, input, nodes[head].span, name)) {
+                return spg_sexpr_second_child(nodes, field);
+            }
+        }
+        field = nodes[field].next_sibling;
+    }
+    return SPG_SEXPR_INVALID_INDEX;
+}
+
+/* An absent field and an explicit `unknown` mean the same thing: no value. The
+ * sentinel is never 0 — a consumer must not read a dead sensor as an idle
+ * machine. */
+static enum spg_status read_u64(const size_t input_n, const char input[],
+                                const struct spg_sexpr_node nodes[static 1],
+                                const uint32_t parent, const char *name,
+                                uint64_t *out) {
+    const uint32_t value = field_value(input_n, input, nodes, parent, name);
+    if (value == SPG_SEXPR_INVALID_INDEX) {
+        *out = SPG_MACHINE_UNKNOWN;
+        return SPG_OK;
+    }
+    if (span_is(input_n, input, nodes[value].span, "unknown")) {
+        *out = SPG_MACHINE_UNKNOWN;
+        return SPG_OK;
+    }
+    return spg_sexpr_parse_uint64_span(input_n, input, nodes[value].span, out);
+}
+
+static enum spg_status read_i64(const size_t input_n, const char input[],
+                                const struct spg_sexpr_node nodes[static 1],
+                                const uint32_t parent, const char *name,
+                                int64_t *out) {
+    const uint32_t value = field_value(input_n, input, nodes, parent, name);
+    if (value == SPG_SEXPR_INVALID_INDEX ||
+        span_is(input_n, input, nodes[value].span, "unknown")) {
+        *out = SPG_MACHINE_UNKNOWN_S;
+        return SPG_OK;
+    }
+    struct spg_text_span span   = nodes[value].span;
+    bool                 negate = false;
+    if (span.length > 0u && span.offset < input_n && input[span.offset] == '-') {
+        negate = true;
+        span.offset += 1u;
+        span.length -= 1u;
+    }
+    uint64_t              magnitude = 0u;
+    const enum spg_status status =
+        spg_sexpr_parse_uint64_span(input_n, input, span, &magnitude);
+    if (status != SPG_OK) {
+        return status;
+    }
+    if (magnitude > (uint64_t)INT64_MAX) {
+        return SPG_E_OVERFLOW;
+    }
+    *out = negate ? -(int64_t)magnitude : (int64_t)magnitude;
+    return SPG_OK;
+}
+
+static enum spg_status read_role(const size_t input_n, const char input[],
+                                 const struct spg_sexpr_node nodes[static 1],
+                                 const uint32_t         parent,
+                                 enum spg_process_role *out) {
+    const uint32_t value = field_value(input_n, input, nodes, parent, "role");
+    if (value == SPG_SEXPR_INVALID_INDEX ||
+        span_is(input_n, input, nodes[value].span, "unknown")) {
+        *out = SPG_PROCESS_ROLE_UNKNOWN;
+        return SPG_OK;
+    }
+    if (span_is(input_n, input, nodes[value].span, "critical")) {
+        *out = SPG_PROCESS_ROLE_CRITICAL;
+        return SPG_OK;
+    }
+    if (span_is(input_n, input, nodes[value].span, "batch")) {
+        *out = SPG_PROCESS_ROLE_BATCH;
+        return SPG_OK;
+    }
+    /* A misspelt role must not quietly become `unknown` and strip a critical
+     * process of its protection — same rule as the profile parser. */
+    return SPG_E_SCHEMA;
+}
+
+static enum spg_throttle_state read_throttle(
+    const size_t input_n, const char input[],
+    const struct spg_sexpr_node nodes[static 1], const uint32_t parent) {
+    const uint32_t value =
+        field_value(input_n, input, nodes, parent, "throttle");
+    if (value == SPG_SEXPR_INVALID_INDEX) {
+        return SPG_THROTTLE_UNKNOWN;
+    }
+    if (span_is(input_n, input, nodes[value].span, "none")) {
+        return SPG_THROTTLE_NONE;
+    }
+    if (span_is(input_n, input, nodes[value].span, "active")) {
+        return SPG_THROTTLE_ACTIVE;
+    }
+    if (span_is(input_n, input, nodes[value].span, "past")) {
+        return SPG_THROTTLE_PAST;
+    }
+    return SPG_THROTTLE_UNKNOWN;
+}
+
+static enum spg_status read_process(const size_t input_n, const char input[],
+                                    const struct spg_sexpr_node nodes[static 1],
+                                    const uint32_t             entry,
+                                    struct spg_process_sample *out) {
+    *out = (struct spg_process_sample){
+        .cpu_bp        = SPG_MACHINE_UNKNOWN,
+        .rss_bytes     = SPG_MACHINE_UNKNOWN,
+        .profile_index = SPG_PROCESS_NO_PROFILE,
+    };
+    const uint32_t id = field_value(input_n, input, nodes, entry, "id");
+    struct spg_text_span span = {};
+    if (id == SPG_SEXPR_INVALID_INDEX ||
+        !spg_sexpr_string_payload_span(&nodes[id], &span) ||
+        !spg_sexpr_span_valid(input_n, span) || span.length == 0u ||
+        span.length + 1u > SPG_PROCESS_ID_CAP) {
+        return SPG_E_SCHEMA;
+    }
+    memcpy(out->profile_id, input + span.offset, span.length);
+    out->profile_id[span.length] = '\0';
+    /* A fixture describes what the context shows, so the id doubles as the
+     * name; the role decides whether it counts as managed. */
+    const size_t name_n = span.length + 1u > SPG_PROCESS_NAME_CAP
+                              ? SPG_PROCESS_NAME_CAP - 1u
+                              : span.length;
+    memcpy(out->name, input + span.offset, name_n);
+    out->name[name_n] = '\0';
+
+    enum spg_status status = read_role(input_n, input, nodes, entry, &out->role);
+    if (status != SPG_OK) {
+        return status;
+    }
+    if (out->role != SPG_PROCESS_ROLE_UNKNOWN) {
+        out->profile_index = 0u; /* managed: ranks ahead of the rest */
+        out->may_pause     = out->role == SPG_PROCESS_ROLE_BATCH;
+        out->may_stop      = out->role == SPG_PROCESS_ROLE_BATCH;
+    } else {
+        out->profile_id[0] = '\0';
+    }
+    status = read_u64(input_n, input, nodes, entry, "cpu-bp", &out->cpu_bp);
+    if (status != SPG_OK) {
+        return status;
+    }
+    return read_u64(input_n, input, nodes, entry, "rss-bytes",
+                    &out->rss_bytes);
+}
+
+enum spg_status spg_machine_state_parse(
+    const size_t input_n, const char input[], const size_t token_capacity,
+    struct spg_sexpr_token tokens[static token_capacity],
+    const size_t           node_capacity,
+    struct spg_sexpr_node nodes[static node_capacity],
+    struct spg_machine_state *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = (struct spg_machine_state){};
+
+    size_t                 token_count = 0u;
+    size_t                 node_count  = 0u;
+    struct spg_sexpr_error error       = {};
+    enum spg_status        status      = spg_sexpr_parse_text(
+        input_n, input, token_capacity, tokens, node_capacity, nodes,
+        &token_count, &node_count, &error);
+    if (status != SPG_OK) {
+        return status;
+    }
+    if (node_count == 0u) {
+        return SPG_E_FORMAT;
+    }
+    const uint32_t root = 0u;
+    const uint32_t head = spg_sexpr_first_child(nodes, root);
+    if (nodes[root].kind != SPG_SEXPR_NODE_LIST ||
+        head == SPG_SEXPR_INVALID_INDEX ||
+        !span_is(input_n, input, nodes[head].span, "machine-state")) {
+        return SPG_E_SCHEMA;
+    }
+
+    struct {
+        const char *name;
+        uint64_t   *slot;
+    } const u64_fields[] = {
+        {"cpu-load-bp", &out->cpu_utilisation_bp},
+        {"load-1-cbp", &out->load.avg_1_cbp},
+        {"memory-total-bytes", &out->memory.total_bytes},
+        {"memory-used-bytes", &out->memory.used_bytes},
+        {"swap-used-bytes", &out->memory.swap_used_bytes},
+        {"cpu-freq-khz", &out->cpu_freq_khz},
+        {"process-count", &out->process_count},
+    };
+    for (size_t i = 0u; i < sizeof u64_fields / sizeof u64_fields[0]; i += 1u) {
+        status = read_u64(input_n, input, nodes, root, u64_fields[i].name,
+                          u64_fields[i].slot);
+        if (status != SPG_OK) {
+            return status;
+        }
+    }
+    /* The 5- and 15-minute averages are not in the rendered block; a fixture
+     * that omits them says unknown, not zero. */
+    out->load.avg_5_cbp  = SPG_MACHINE_UNKNOWN;
+    out->load.avg_15_cbp = SPG_MACHINE_UNKNOWN;
+    status = read_i64(input_n, input, nodes, root, "temperature-mc",
+                      &out->temperature_mc);
+    if (status != SPG_OK) {
+        return status;
+    }
+    out->throttle = read_throttle(input_n, input, nodes, root);
+
+    uint64_t dropped = 0u;
+    status = read_u64(input_n, input, nodes, root, "processes-dropped",
+                      &dropped);
+    if (status != SPG_OK) {
+        return status;
+    }
+    out->processes_truncated =
+        field_value(input_n, input, nodes, root, "processes-dropped") !=
+        SPG_SEXPR_INVALID_INDEX;
+
+    for (uint32_t entry = nodes[head].next_sibling;
+         entry != SPG_SEXPR_INVALID_INDEX; entry = nodes[entry].next_sibling) {
+        if (nodes[entry].kind != SPG_SEXPR_NODE_LIST) {
+            continue;
+        }
+        const uint32_t entry_head = spg_sexpr_first_child(nodes, entry);
+        if (entry_head == SPG_SEXPR_INVALID_INDEX ||
+            !span_is(input_n, input, nodes[entry_head].span, "process")) {
+            continue;
+        }
+        if (out->n_processes >= SPG_MACHINE_MAX_PROCESSES) {
+            return SPG_E_LIMIT;
+        }
+        status = read_process(input_n, input, nodes, entry,
+                              &out->processes[out->n_processes]);
+        if (status != SPG_OK) {
+            return status;
+        }
+        out->n_processes += 1u;
+    }
+    return SPG_OK;
+}

--- a/src/machine/machine_fixture.c
+++ b/src/machine/machine_fixture.c
@@ -65,7 +65,8 @@ static enum spg_status read_i64(const size_t input_n, const char input[],
     }
     struct spg_text_span span   = nodes[value].span;
     bool                 negate = false;
-    if (span.length > 0u && span.offset < input_n && input[span.offset] == '-') {
+    if (span.length > 0u && span.offset < input_n &&
+        input[span.offset] == '-') {
         negate = true;
         span.offset += 1u;
         span.length -= 1u;
@@ -85,8 +86,8 @@ static enum spg_status read_i64(const size_t input_n, const char input[],
 
 static enum spg_status read_role(const size_t input_n, const char input[],
                                  const struct spg_sexpr_node nodes[static 1],
-                                 const uint32_t         parent,
-                                 enum spg_process_role *out) {
+                                 const uint32_t              parent,
+                                 enum spg_process_role      *out) {
     const uint32_t value = field_value(input_n, input, nodes, parent, "role");
     if (value == SPG_SEXPR_INVALID_INDEX ||
         span_is(input_n, input, nodes[value].span, "unknown")) {
@@ -106,9 +107,10 @@ static enum spg_status read_role(const size_t input_n, const char input[],
     return SPG_E_SCHEMA;
 }
 
-static enum spg_throttle_state read_throttle(
-    const size_t input_n, const char input[],
-    const struct spg_sexpr_node nodes[static 1], const uint32_t parent) {
+static enum spg_throttle_state
+read_throttle(const size_t input_n, const char input[],
+              const struct spg_sexpr_node nodes[static 1],
+              const uint32_t              parent) {
     const uint32_t value =
         field_value(input_n, input, nodes, parent, "throttle");
     if (value == SPG_SEXPR_INVALID_INDEX) {
@@ -128,14 +130,14 @@ static enum spg_throttle_state read_throttle(
 
 static enum spg_status read_process(const size_t input_n, const char input[],
                                     const struct spg_sexpr_node nodes[static 1],
-                                    const uint32_t             entry,
-                                    struct spg_process_sample *out) {
+                                    const uint32_t              entry,
+                                    struct spg_process_sample  *out) {
     *out = (struct spg_process_sample){
         .cpu_bp        = SPG_MACHINE_UNKNOWN,
         .rss_bytes     = SPG_MACHINE_UNKNOWN,
         .profile_index = SPG_PROCESS_NO_PROFILE,
     };
-    const uint32_t id = field_value(input_n, input, nodes, entry, "id");
+    const uint32_t       id   = field_value(input_n, input, nodes, entry, "id");
     struct spg_text_span span = {};
     if (id == SPG_SEXPR_INVALID_INDEX ||
         !spg_sexpr_string_payload_span(&nodes[id], &span) ||
@@ -153,7 +155,8 @@ static enum spg_status read_process(const size_t input_n, const char input[],
     memcpy(out->name, input + span.offset, name_n);
     out->name[name_n] = '\0';
 
-    enum spg_status status = read_role(input_n, input, nodes, entry, &out->role);
+    enum spg_status status =
+        read_role(input_n, input, nodes, entry, &out->role);
     if (status != SPG_OK) {
         return status;
     }
@@ -168,16 +171,16 @@ static enum spg_status read_process(const size_t input_n, const char input[],
     if (status != SPG_OK) {
         return status;
     }
-    return read_u64(input_n, input, nodes, entry, "rss-bytes",
-                    &out->rss_bytes);
+    return read_u64(input_n, input, nodes, entry, "rss-bytes", &out->rss_bytes);
 }
 
-enum spg_status spg_machine_state_parse(
-    const size_t input_n, const char input[], const size_t token_capacity,
-    struct spg_sexpr_token tokens[static token_capacity],
-    const size_t           node_capacity,
-    struct spg_sexpr_node nodes[static node_capacity],
-    struct spg_machine_state *out) {
+enum spg_status
+spg_machine_state_parse(const size_t input_n, const char input[],
+                        const size_t              token_capacity,
+                        struct spg_sexpr_token    tokens[static token_capacity],
+                        const size_t              node_capacity,
+                        struct spg_sexpr_node     nodes[static node_capacity],
+                        struct spg_machine_state *out) {
     if (out == nullptr) {
         return SPG_E_INVALID_ARG;
     }
@@ -234,8 +237,8 @@ enum spg_status spg_machine_state_parse(
     out->throttle = read_throttle(input_n, input, nodes, root);
 
     uint64_t dropped = 0u;
-    status = read_u64(input_n, input, nodes, root, "processes-dropped",
-                      &dropped);
+    status =
+        read_u64(input_n, input, nodes, root, "processes-dropped", &dropped);
     if (status != SPG_OK) {
         return status;
     }
@@ -243,7 +246,7 @@ enum spg_status spg_machine_state_parse(
         field_value(input_n, input, nodes, root, "processes-dropped") !=
         SPG_SEXPR_INVALID_INDEX;
 
-    for (uint32_t entry = nodes[head].next_sibling;
+    for (uint32_t entry                          = nodes[head].next_sibling;
          entry != SPG_SEXPR_INVALID_INDEX; entry = nodes[entry].next_sibling) {
         if (nodes[entry].kind != SPG_SEXPR_NODE_LIST) {
             continue;

--- a/test/test_cli_diagnosis.sh
+++ b/test/test_cli_diagnosis.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Roadmap phase 4 (#64): the diagnosis harness, checked in both directions.
+#
+# The ground-truth suite passing 9/9 proves nothing on its own — it would pass
+# just as happily if the metrics were hard-wired to "correct". So the negative
+# suite runs the SAME states with deliberately wrong answers, and this test
+# fails unless the harness catches each one.
+set -eu
+
+SPG_BIN=${SPG_BIN:-build/host-debug/bin/geistshell}
+
+"$SPG_BIN" eval examples/eval/machine/diagnosis.spg >build/diagnosis.jsonl
+"$SPG_BIN" eval examples/eval/machine/diagnosis_negative.spg \
+    >build/diagnosis-negative.jsonl || true
+
+python3 - build/diagnosis.jsonl build/diagnosis-negative.jsonl <<'PY'
+import json, sys
+
+def load(path):
+    rows = [json.loads(l) for l in open(path)]
+    return rows[:-1], rows[-1]
+
+cases, summary = load(sys.argv[1])
+assert len(cases) == 9, cases
+assert summary["passed"] == 9, summary
+d = summary["diagnosis"]
+# Known and held-out are counted apart: an average would let a suite look
+# strong while having learnt only the cases it was shown.
+assert d["known"] == 6 and d["known_runs"] == 6, d
+assert d["heldout"] == 3 and d["heldout_runs"] == 3, d
+assert d["hallucinated"] == 0 and d["action_proposed"] == 0, d
+for c in cases:
+    assert c["emitted"] == c["expected"], c
+    assert c["context_bytes"] > 0, c
+
+neg, nsummary = load(sys.argv[2])
+by = {c["name"]: c for c in neg}
+# a wrong root cause must fail the case, not merely be noted
+assert by["wrong_category"]["correct"] == 0, by["wrong_category"]
+assert by["wrong_category"]["outcome"] == "fail_observation", by["wrong_category"]
+# an invented process is caught even when the category is right
+assert by["hallucinated_process"]["hallucinated"] == 1, by["hallucinated_process"]
+# acting when only a diagnosis was asked for is counted
+assert by["action_proposed"]["action_proposed"] == 1, by["action_proposed"]
+# Both of these are verbatim Gemma answers. Neither is a hallucination and
+# neither is a missing diagnosis — the metric must not measure punctuation.
+assert by["bracketed_ids"]["hallucinated"] == 0, by["bracketed_ids"]
+assert by["bracketed_ids"]["correct"] == 1, by["bracketed_ids"]
+assert by["punctuated_category"]["emitted"] == "healthy", by["punctuated_category"]
+assert nsummary["passed"] == 4, nsummary
+PY
+
+echo "test_cli_diagnosis: PASS"

--- a/test/test_machine_fixture.c
+++ b/test/test_machine_fixture.c
@@ -109,7 +109,8 @@ static int test_unknown_is_not_zero(void) {
         return 1;
     }
     /* An explicit `unknown` reads the same as an absent field. */
-    if (load(LIT("(machine-state (cpu-load-bp unknown) (temperature-mc unknown))"),
+    if (load(LIT("(machine-state (cpu-load-bp unknown) (temperature-mc "
+                 "unknown))"),
              &s) != SPG_OK) {
         return 1;
     }

--- a/test/test_machine_fixture.c
+++ b/test/test_machine_fixture.c
@@ -1,0 +1,200 @@
+/* Phase 4: machine-state fixtures. A diagnosis scenario is a machine state, so
+ * the eval suite reads them from files instead of sampling the host. */
+
+#include "geistshell/machine_fixture.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define LIT(s) (sizeof(s) - 1u), (s)
+
+static enum spg_status load(const size_t n, const char text[],
+                            struct spg_machine_state *out) {
+    struct spg_sexpr_token tokens[512];
+    struct spg_sexpr_node  nodes[512];
+    return spg_machine_state_parse(n, text, 512u, tokens, 512u, nodes, out);
+}
+
+static const char fixture[] =
+    "(machine-state (cpu-load-bp 9200) (load-1-cbp 175)\n"
+    " (memory-total-bytes 4245815296) (memory-used-bytes 1682931712)\n"
+    " (swap-used-bytes 0) (temperature-mc 78400) (cpu-freq-khz 1500000)\n"
+    " (throttle none) (process-count 167)\n"
+    " (process (id \"critical_app\") (role critical) (cpu-bp 5400)"
+    " (rss-bytes 4096))\n"
+    " (process (id \"batch_job\") (role batch) (cpu-bp 3100)"
+    " (rss-bytes 8192)))\n";
+
+static int test_parse(void) {
+    struct spg_machine_state s = {};
+    if (load(LIT(fixture), &s) != SPG_OK) {
+        return 1;
+    }
+    if (s.cpu_utilisation_bp != 9200u || s.load.avg_1_cbp != 175u ||
+        s.memory.total_bytes != 4245815296u || s.temperature_mc != 78400 ||
+        s.cpu_freq_khz != 1500000u || s.throttle != SPG_THROTTLE_NONE ||
+        s.process_count != 167u) {
+        return 1;
+    }
+    if (s.n_processes != 2u) {
+        return 1;
+    }
+    if (strcmp(s.processes[0].profile_id, "critical_app") != 0 ||
+        s.processes[0].role != SPG_PROCESS_ROLE_CRITICAL ||
+        s.processes[0].cpu_bp != 5400u || s.processes[0].rss_bytes != 4096u) {
+        return 1;
+    }
+    /* A managed process must outrank the rest, exactly as after a real
+     * profile match — otherwise a fixture would exercise a different code
+     * path than the machine does. */
+    if (s.processes[0].profile_index == SPG_PROCESS_NO_PROFILE) {
+        return 1;
+    }
+    /* A critical process is never pausable, whatever the fixture says. */
+    if (s.processes[0].may_pause || s.processes[0].may_stop) {
+        return 1;
+    }
+    if (!s.processes[1].may_pause) {
+        return 1;
+    }
+    return 0;
+}
+
+/* The renderer and the parser are two halves of one format. If they drift, a
+ * scenario stops describing what the model actually sees. */
+static int test_roundtrip(void) {
+    struct spg_machine_state parsed = {};
+    if (load(LIT(fixture), &parsed) != SPG_OK) {
+        return 1;
+    }
+    char   first[SPG_MACHINE_RENDER_CAP];
+    size_t first_n = 0u;
+    if (spg_machine_state_render(&parsed, sizeof first, first, &first_n) !=
+        SPG_OK) {
+        return 1;
+    }
+    struct spg_machine_state reparsed = {};
+    if (load(first_n - 1u, first, &reparsed) != SPG_OK) {
+        printf("  re-parse failed on: %s\n", first);
+        return 1;
+    }
+    char   second[SPG_MACHINE_RENDER_CAP];
+    size_t second_n = 0u;
+    if (spg_machine_state_render(&reparsed, sizeof second, second, &second_n) !=
+        SPG_OK) {
+        return 1;
+    }
+    if (first_n != second_n || memcmp(first, second, first_n) != 0) {
+        printf("  drift:\n   %s\n   %s\n", first, second);
+        return 1;
+    }
+    return 0;
+}
+
+static int test_unknown_is_not_zero(void) {
+    struct spg_machine_state s = {};
+    /* Only two fields present: everything else must read unknown, because a
+     * scenario that omits the temperature is not a scenario at 0 mC. */
+    if (load(LIT("(machine-state (cpu-load-bp 100) (throttle active))"), &s) !=
+        SPG_OK) {
+        return 1;
+    }
+    if (s.cpu_utilisation_bp != 100u || s.throttle != SPG_THROTTLE_ACTIVE) {
+        return 1;
+    }
+    if (s.memory.total_bytes != SPG_MACHINE_UNKNOWN ||
+        s.temperature_mc != SPG_MACHINE_UNKNOWN_S ||
+        s.cpu_freq_khz != SPG_MACHINE_UNKNOWN ||
+        s.load.avg_1_cbp != SPG_MACHINE_UNKNOWN) {
+        return 1;
+    }
+    /* An explicit `unknown` reads the same as an absent field. */
+    if (load(LIT("(machine-state (cpu-load-bp unknown) (temperature-mc unknown))"),
+             &s) != SPG_OK) {
+        return 1;
+    }
+    if (s.cpu_utilisation_bp != SPG_MACHINE_UNKNOWN ||
+        s.temperature_mc != SPG_MACHINE_UNKNOWN_S) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_negative_temperature(void) {
+    struct spg_machine_state s = {};
+    if (load(LIT("(machine-state (temperature-mc -5000))"), &s) != SPG_OK) {
+        return 1;
+    }
+    return s.temperature_mc == -5000 ? 0 : 1;
+}
+
+static int test_rejects(void) {
+    struct spg_machine_state s = {};
+    if (load(LIT(""), &s) == SPG_OK) {
+        return 1;
+    }
+    if (load(LIT("(policy (network_default deny))"), &s) != SPG_E_SCHEMA) {
+        return 1;
+    }
+    if (load(LIT("(machine-state (cpu-load-bp 1"), &s) == SPG_OK) {
+        return 1;
+    }
+    /* A misspelt role is refused, not silently demoted to unknown. */
+    if (load(LIT("(machine-state (process (id \"a\") (role criticl)))"), &s) !=
+        SPG_E_SCHEMA) {
+        return 1;
+    }
+    /* A process without an id has nothing an action could target. */
+    if (load(LIT("(machine-state (process (role batch) (cpu-bp 1)))"), &s) !=
+        SPG_E_SCHEMA) {
+        return 1;
+    }
+    if (load(LIT("(machine-state (cpu-load-bp notanumber))"), &s) == SPG_OK) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_truncation_flag(void) {
+    struct spg_machine_state s = {};
+    if (load(LIT("(machine-state (process-count 200) (process (id \"a\") "
+                 "(role batch) (cpu-bp 1) (rss-bytes 2)) "
+                 "(processes-dropped 199))"),
+             &s) != SPG_OK) {
+        return 1;
+    }
+    if (!s.processes_truncated) {
+        return 1;
+    }
+    /* Without the marker the list is complete. */
+    if (load(LIT("(machine-state (process (id \"a\") (role batch)))"), &s) !=
+        SPG_OK) {
+        return 1;
+    }
+    return s.processes_truncated ? 1 : 0;
+}
+
+int main(void) {
+    const struct {
+        const char *name;
+        int (*fn)(void);
+    } cases[] = {
+        {"parse", test_parse},
+        {"roundtrip", test_roundtrip},
+        {"unknown_is_not_zero", test_unknown_is_not_zero},
+        {"negative_temperature", test_negative_temperature},
+        {"rejects", test_rejects},
+        {"truncation_flag", test_truncation_flag},
+    };
+    int failures = 0;
+    for (size_t i = 0u; i < sizeof cases / sizeof cases[0]; i += 1u) {
+        if (cases[i].fn() != 0) {
+            printf("test_machine_fixture: FAIL %s\n", cases[i].name);
+            failures += 1;
+        }
+    }
+    if (failures == 0) {
+        printf("test_machine_fixture: PASS\n");
+    }
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Phase 4 der Roadmap (#64). Stapelt auf #84. Neun Szenarien, sieben known und drei held-out, bewertet nach der genannten Ursache. Keine schreibende Aktion.

## Die Diagnose ist der `finish`-Reason

```
(recommend (kind finish) (reason "<kategorie> [<prozess-id>]"))
```

Kein neuer Action Kind, kein Executor. `finish` trägt keine Capability, verbraucht kein Budget und erreicht den Policy Gate nie. Das Ticket ließ offen, ob ein eigener Diagnose-Output sauberer wäre — er ist es nicht: ein zweiter Ausgabekanal bräuchte Grammatik, Parser, Journal-Event und Tests für eine Information, die in ein bestehendes Feld passt.

Kategorien sind ein geschlossener Satz. Freitext zu bewerten hieße messen, wie der Bewerter fühlt.

## Szenarien sind Fixtures, keine Samples

`spg_machine_state_parse` liest denselben Block zurück, den der Renderer erzeugt. Ein Fall reproduziert damit auf einem Laptop ohne Pi, statt davon abzuhängen, was gerade läuft. Ein Roundtrip-Test (rendern → parsen → rendern, byte-identisch) hält beide Hälften des Formats zusammen.

## Eine falsche Kategorie lässt den Case scheitern

Sauber zu terminieren ist nicht dasselbe wie recht zu haben — sonst meldet die Kopfzahl der Suite eine Übereinstimmung, die sie nie gemessen hat.

Und 9/9 auf der Ground Truth beweist nichts: `diagnosis_negative.spg` fährt dieselben Zustände mit absichtlich falschen Antworten, `test/test_cli_diagnosis.sh` scheitert, wenn der Harness einen davon durchgehen lässt — falsche Ursache, erfundener Prozess, Aktion statt Diagnose.

## Gemessen: Gemma4-E2B auf dem Pi 5

`--constrained --samples 1`, Release-Build.

| Methode | Known | Held-out | Halluzination | Unnötige Action | Parse | Gate |
|---|---|---|---|---|---|---|
| scripted ground truth | 6/6 | 3/3 | 0 | 0 | 9/9 | 9/9 |
| Gemma4-E2B (Q4_K_M) | **2/6** | **1/3** | 0 | 0 | 9/9 | 9/9 |

Die Antworten:

| Szenario | Erwartet | Geantwortet |
|---|---|---|
| batch_cpu | batch_pressure | `memory_pressure [critical_app, batch_job]` |
| critical_cpu | critical_pressure | `critical_pressure [critical_app]` ✓ |
| memory_batch | memory_pressure | `memory_pressure [critical_app, batch_job]` ✓ |
| thermal | thermal_anomaly | `memory_pressure [critical_app, batch_job]` |
| contradictory | inconclusive | `healthy))` |
| healthy | healthy | `critical_pressure [critical_app]` |
| heldout_thermal_batch | thermal_anomaly | `memory_pressure [critical_app, batch_job]` |
| heldout_memory_critical | memory_pressure | `memory_pressure [critical_app, batch_job]` ✓ |
| no_processes | inconclusive | `memory_pressure [unknown]` |

**Das Modell diagnostiziert nicht, es rät ein Label.** Sechs von neun Antworten lauten `memory_pressure`, unabhängig vom Zustand — bei `thermal` sind 1,1 von 4,2 GB belegt. `thermal_anomaly` kam kein einziges Mal vor, obwohl zwei Szenarien es verlangen und die Temperatur ein eigenes Feld im Context ist.

Wer **immer** `memory_pressure` antwortet, erreicht 2/9. Gemma erreicht 3/9.

Was funktioniert: die Form. Parse 9/9, Gate 9/9 mit dem constrained Decoder — die Hypothese aus #53 hält, die Frage verschiebt sich von „kann es die Form" zu „wählt es richtig". Auf dieser Suite lautet die Antwort auf die zweite Frage: nein.

## Die Halluzinationsmetrik hat zuerst falsch gemessen

Erste Fassung: **8 von 9 Halluzinationen** für denselben Lauf. Artefakt — sie las nur das zweite Token und Gemma schreibt `memory_pressure [critical_app, batch_job]`, also wurde `[critical_app,` als erfundener Prozess gezählt, während beide genannten Prozesse vorhanden waren.

Sichtbar wurde das nur, weil die Metrik den Reason im Klartext mit ausgibt. Eine Zahl, die niemand nachprüfen kann, ist eine Zahl, der niemand trauen sollte. Jetzt wird jedes Token nach der Kategorie geprüft, von `[](),` befreit, und nur Tokens mit Unterstrich gelten als ID-Behauptung. Beide echten Gemma-Antworten sind als Regressionsfälle eingefroren.

## Nicht gemessen

Inferenzzeit pro Fall — der Harness instrumentiert sie nicht. Ein Lauf über neun Fälle dauert auf dem Pi 5 rund 25–30 Minuten. Eine Uhr in den Eval-Pfad gehört zu Phase 10, wo Latenz Zielmetrik ist.

Remote-Modell: nicht konfiguriert, also nicht gelaufen und nicht als bestanden gewertet.

## Verifikation

macOS arm64 und Pi 5: `make test` grün, exit 0, 29 PASS, warnungsfrei, ASan/UBSan sauber.

Doku: `docs/machine-intelligence/Diagnosis-Benchmark.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
