### PR TITLE
Phase 6: Typed pause/resume hinter dem Policy Gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ SPG_SOURCES := \
     src/exec/shell_executor.c \
     src/improve/improve.c \
     src/executor/executor_boundary.c \
+    src/executor/machine_executor.c \
     src/graph/graph.c \
     src/journal/journal.c \
     src/journal/journal_sign.c \
@@ -128,6 +129,10 @@ endif
 CLI_SOURCES := src/cli/main.c
 CHAT_SOURCES := src/chat/main.c
 TEST_SOURCES := $(wildcard test/test_*.c)
+# Not a test_*.c: it forks a child and drives real signals, so the shell
+# wrapper decides when running it is meaningful (see test_cli_machine_action.sh).
+PROBE_SOURCES := test/machine_action_probe.c
+PROBE_BINS := $(patsubst test/%.c,$(TEST_DIR)/%,$(PROBE_SOURCES))
 CLI_TESTS := $(wildcard test/test_cli_*.sh)
 
 SPG_OBJECTS := $(patsubst %.c,$(OBJ_DIR)/%.o,$(SPG_SOURCES))
@@ -190,7 +195,7 @@ $(OBJ_DIR)/%.o: %.c
 	@mkdir -p $(@D)
 	$(CC) $(CFLAGS) -MMD -MP -c $< -o $@
 
-test: $(TEST_BINS) $(SPG_BIN)
+test: $(TEST_BINS) $(PROBE_BINS) $(SPG_BIN)
 	@status=0; \
 	for t in $(TEST_BINS); do \
 		echo "$$t"; \

--- a/docs/machine-intelligence/Actions.md
+++ b/docs/machine-intelligence/Actions.md
@@ -1,12 +1,12 @@
-# Actions — Phase 6
+# Actions — Phasen 6 und 6b
 
 Der Agent kann eine **reversible** Aktion ausführen, ohne Governance oder
 Safety zu umgehen: `pause` und `resume` auf Prozessen, die das Profil explizit
 verwaltet.
 
-Ticket: geisten/geistshell#66. Voraussetzungen: [Processes.md](Processes.md),
-[Context.md](Context.md). Offene Folgelücke: **#80** — pausierte Prozesse
-garantiert wieder freigeben.
+Tickets: geisten/geistshell#66 (die Aktion) und #80 (die Garantie, dass nichts
+pausiert bleibt). Voraussetzungen: [Processes.md](Processes.md),
+[Context.md](Context.md).
 
 ## Kein `local_shell`
 
@@ -87,7 +87,7 @@ Journal:
 
 ```
 (machine_action (kind machine_pause_process) (target "batch_job")
-                (pid 4711) (outcome ok))
+                (pid 4711) (identity 987654) (outcome ok))
 ```
 
 Auch ein `refused` steht dort. Eine Ablehnung ohne Spur ist eine Ablehnung, die
@@ -130,9 +130,68 @@ Ohne `--process-profile` ist nichts gemanagt und jede Machine Action wird
 abgelehnt. Ohne `--allow-exec` erreicht sie den Executor, der `unsupported`
 meldet, statt zu signalisieren.
 
+## Nichts bleibt pausiert (Phase 6b, #80)
+
+Eine Pause ist nur reversibel, solange sich jemand an sie erinnert. Ohne das
+Folgende hinterlässt ein Lauf, der nach `SIGSTOP` stirbt, einen dauerhaft
+gestoppten Prozess — der einzige Weg, auf dem diese Runtime bleibenden Schaden
+anrichtet, ohne dass eine Policy verletzt wurde.
+
+### Erste Linie: das Ledger
+
+Jede erfolgreiche Pause wird mit PID **und** Startzeit in einem Ledger fester
+Größe vermerkt. Am Ende **jedes** Laufs — finish, Fehler, max steps, Budget,
+Policy-Deny, Interrupt — wird alles darin wieder freigegeben.
+
+**Eine Pause, die nicht vermerkt werden kann, findet nicht statt.** Kein Ledger
+oder ein volles Ledger ⇒ `refused`, bevor das Signal gesendet wird. Die
+Alternative wäre ein gestoppter Prozess, dem niemand ein Resume schuldet.
+
+`SIGINT`/`SIGTERM` setzen nur ein `volatile sig_atomic_t`-Flag. Der Handler
+gibt selbst nichts frei — das hieße, aus einem Signal-Handler zu journalen. Die
+Freigabe macht der normale Aufräumpfad, und `SA_RESTART` ist bewusst **nicht**
+gesetzt, damit ein blockierender Read mit `EINTR` zurückkommt, statt zu warten,
+während ein Prozess gestoppt bleibt.
+
+### Zweite Linie: Recovery aus dem Journal
+
+`SIGKILL` und Stromausfall sind nicht abfangbar; das Ledger stirbt mit dem
+Prozess. Übrig bleibt das Journal. Beim nächsten Start paart
+`spg_machine_recover_journal()` Pausen mit Resumes und gibt frei, was offen
+blieb — **bevor** der neue Lauf beobachtet, damit der Snapshot nicht einen
+Zustand zeigt, den wir selbst hinterlassen haben.
+
+Deshalb steht die Startzeit im Journal-Payload: eine PID allein ist keine
+Identität, und Recovery muss einen wiederverwendeten PID überspringen statt ihn
+zu wecken.
+
+Recovery ist **wiederholbar**, nicht idempotent im engeren Sinn: ein `SIGCONT`
+auf einen laufenden Prozess ist harmlos. Genau das macht es sicher, sie bei
+jedem Start bedingungslos auszuführen.
+
+### Verbleibende Lücke, benannt
+
+Zwischen `SIGKILL` und dem nächsten Start bleibt der Prozess gestoppt. Dagegen
+hilft nur ein externer Watchdog, und der ist bewusst nicht gebaut — er wäre ein
+zweiter Lebenszyklus mit eigenen Fehlermodi für ein Zeitfenster, das ein
+Neustart schließt.
+
+Ebenfalls offen: zwei parallele Läufe teilen sich das Journal nicht. Recovery
+eines Laufs sieht die Pausen des anderen und könnte sie freigeben. Für einen
+Agenten pro Maschine ist das kein Problem; für mehrere wäre es eines.
+
+### Auf Hardware verifiziert
+
+Pi 5. `machine_action_probe` pausiert ein Kind mit aktivem Journal, lässt das
+Ledger fallen (die simulierte Katastrophe), ruft Recovery — und das Kind läuft
+wieder. Der Absturz wird durch Weglassen der Freigabe simuliert, nicht durch
+Töten des Agenten mitten im Signal: das wäre ein Race, und ein Race im Test ist
+ein Flake.
+
+`test_cli_machine_recovery.sh` prüft die erste Linie über die CLI: nach einem
+Lauf, der pausiert hat, meldet er `released=1` und das Kind läuft.
+
 ## Was Phase 6 nicht tut
 
 Kein Closed Loop (#67) — der Agent beobachtet die Wirkung seiner Aktion noch
-nicht, weil der Snapshot einmal pro Lauf entsteht. Kein `set_nice`. Und
-insbesondere **keine Garantie, dass ein pausierter Prozess wieder freigegeben
-wird**, wenn der Run stirbt: das ist #80 und sollte vor #67 kommen.
+nicht, weil der Snapshot einmal pro Lauf entsteht. Kein `set_nice`.

--- a/docs/machine-intelligence/Actions.md
+++ b/docs/machine-intelligence/Actions.md
@@ -169,16 +169,39 @@ Recovery ist **wiederholbar**, nicht idempotent im engeren Sinn: ein `SIGCONT`
 auf einen laufenden Prozess ist harmlos. Genau das macht es sicher, sie bei
 jedem Start bedingungslos auszuführen.
 
-### Verbleibende Lücke, benannt
+### Dritte Linie: der Wächter
 
-Zwischen `SIGKILL` und dem nächsten Start bleibt der Prozess gestoppt. Dagegen
-hilft nur ein externer Watchdog, und der ist bewusst nicht gebaut — er wäre ein
-zweiter Lebenszyklus mit eigenen Fehlermodi für ein Zeitfenster, das ein
-Neustart schließt.
+`SIGKILL` lässt den sterbenden Prozess nichts mehr ausführen. Helfen kann nur
+etwas, das **schon lief**: bei jeder Pause forkt der Executor einen Wächter, der
+das Leseende einer Pipe hält und darauf blockiert.
 
-Ebenfalls offen: zwei parallele Läufe teilen sich das Journal nicht. Recovery
-eines Laufs sieht die Pausen des anderen und könnte sie freigeben. Für einen
-Agenten pro Maschine ist das kein Problem; für mehrere wäre es eines.
+- Kommt ein Byte an, haben wir die Pause selbst zurückgenommen — der Wächter
+  endet, ohne zu handeln.
+- Schließt die Pipe, weil wir gestorben sind, prüft er die Identität und sendet
+  `SIGCONT`.
+
+Kein Timer, kein Heartbeat, kein Zustand: dass der Kernel unsere Deskriptoren
+schließt, **ist** das Signal. Der Wächter wird **vor** dem Stopp scharfgestellt —
+ein Absturz dazwischen hinterließe sonst genau den vergessenen gestoppten
+Prozess, den er verhindern soll. Lässt er sich nicht forken, findet die Pause
+nicht statt.
+
+Damit ist das Fenster zwischen `SIGKILL` und dem nächsten Agentenstart
+geschlossen. Recovery aus dem Journal bleibt als zweite Absicherung für den
+Fall, dass auch der Wächter stirbt — Stromausfall, `kill -9` auf die ganze
+Prozessgruppe, OOM-Killer.
+
+### Ein Lauf pro Journal
+
+Zwei Läufe am selben Journal würden ihre Records in **eine** Hash-Chain
+verschränken und sie damit zerstören — ein Fehler, den bisher nur niemand
+getroffen hatte. Zusätzlich sähe die Recovery des einen die Pausen des anderen.
+
+Ein Machine-Run nimmt deshalb ein `flock` auf `<journal>.lock`. Advisory und
+nicht blockierend: der zweite Lauf wird auf ein eigenes Journal verwiesen,
+statt auf einen Lauf zu warten, der Stunden dauern kann. Das Lock fällt
+**nach** der Freigabe der Pausen, damit kein zweiter Lauf Recovery startet,
+während dieser noch Prozesse zurückgibt.
 
 ### Auf Hardware verifiziert
 
@@ -188,8 +211,12 @@ wieder. Der Absturz wird durch Weglassen der Freigabe simuliert, nicht durch
 Töten des Agenten mitten im Signal: das wäre ein Race, und ein Race im Test ist
 ein Flake.
 
-`test_cli_machine_recovery.sh` prüft die erste Linie über die CLI: nach einem
-Lauf, der pausiert hat, meldet er `released=1` und das Kind läuft.
+Der Wächter wird ebenso hart geprüft: ein Ersatz-Agent pausiert ein Ziel und
+wird dann mit `SIGKILL` getötet. Kurz darauf läuft das Ziel wieder — ohne dass
+ein neuer Agentenstart beteiligt war.
+
+`test_cli_machine_recovery.sh` prüft die erste Linie über die CLI (`released=1`,
+Kind läuft) und dass ein zweiter Lauf am selben Journal abgewiesen wird.
 
 ## Was Phase 6 nicht tut
 

--- a/docs/machine-intelligence/Actions.md
+++ b/docs/machine-intelligence/Actions.md
@@ -1,0 +1,138 @@
+# Actions — Phase 6
+
+Der Agent kann eine **reversible** Aktion ausführen, ohne Governance oder
+Safety zu umgehen: `pause` und `resume` auf Prozessen, die das Profil explizit
+verwaltet.
+
+Ticket: geisten/geistshell#66. Voraussetzungen: [Processes.md](Processes.md),
+[Context.md](Context.md). Offene Folgelücke: **#80** — pausierte Prozesse
+garantiert wieder freigeben.
+
+## Kein `local_shell`
+
+```
+(recommend (kind machine_pause_process)
+           (capability "machine.process.pause")
+           (target "batch_job")
+           (cost 1) (uses_network false) (confidence_bp 9000)
+           (reason "..."))
+```
+
+Die Grammatik **verbietet** ein `command`-Feld für Machine Actions. Das ist der
+Punkt eines geschlossenen Action Space: es gibt kein Feld, durch das ein
+Shell-String einen Executor erreichen könnte. Ein Test prüft genau das —
+dieselbe Empfehlung mit `command` wird vom Parser abgelehnt, nicht erst vom
+Gate.
+
+`target` ist eine **Profil-ID**, nie eine PID. Das Modell sieht keine PIDs
+([Context.md](Context.md)) und kann folglich keine nennen.
+
+## Zwei Schichten, zwei Fragen
+
+**Der Gate entscheidet, OB.** Rolle, Berechtigung, und ob das Ziel überhaupt
+beobachtet wurde — alles in `spg_policy_gate_step`, nicht im Executor. Eine
+Sicherheitseigenschaft, die erst hinter dem Gate durchgesetzt wird, ist eine,
+von der das Journal nicht zeigen kann, dass sie geprüft wurde.
+
+**Der Executor entscheidet, OB ES NOCH DERSELBE IST.** Diese Frage kann der
+Gate nicht beantworten: zwischen Entscheidung und Syscall kann eine PID
+wiederverwendet werden. Deshalb liest der Executor `/proc/<pid>/stat` unmittelbar
+vor `kill()` erneut und vergleicht PID **und** Startzeit.
+
+| Situation | Ergebnis | Wo entschieden |
+|---|---|---|
+| gemanagter Batch-Prozess, `may_pause true` | ALLOW | Gate |
+| `role critical` bzw. `may_pause false` | `DENY_PROCESS_PROTECTED` | Gate |
+| Prozess nicht im Profil | `DENY_UNMANAGED_PROCESS` | Gate |
+| kein Profil konfiguriert | `DENY_UNMANAGED_PROCESS` | Gate |
+| Ziel nicht im aktuellen Snapshot | `DENY_PROCESS_IDENTITY` | Gate |
+| Capability fehlt oder falsch | `DENY_UNKNOWN_CAPABILITY` | Gate |
+| Budget erschöpft | `DENY_*_BUDGET` | Gate |
+| PID gehört inzwischen jemand anderem | `identity_changed`, **kein Signal** | Executor |
+| Prozess ist weg (`ESRCH`) | `gone` | Executor |
+| kein Recht (`EPERM`) | `forbidden` | Executor |
+| PID 1, eigene PID, Elternprozess | `refused` | Executor |
+| kein `/proc` (macOS, BSD) | `unsupported`, **kein Signal** | Executor |
+
+**Schutz geht vor Budget.** Ein geschützter Prozess wird abgelehnt, *bevor*
+Capability und Budget geprüft werden. Sonst würde ein Ablehnungsgrund im
+Journal stehen, der nicht der eigentliche ist — „Budget erschöpft" statt „das
+darfst du nicht".
+
+## Resume braucht keine Erlaubnis
+
+`may_pause` gilt für das Pausieren. Resume ist für jeden gemanagten Prozess
+erlaubt, weil es nur den Zustand wiederherstellen kann, den die Maschine vor
+unserem Eingriff hatte. Es zu verweigern hieße, einen von uns gestoppten
+Prozess gestoppt zu lassen.
+
+Restrisiko, benannt: ein `SIGCONT` an einen Prozess, den ein Operator
+absichtlich gestoppt hat, würde diese Absicht überschreiben. Nur gemanagte
+Prozesse sind betroffen, und die hat der Operator selbst deklariert.
+
+## Nur Linux signalisiert
+
+Der Executor sendet ausschließlich auf Linux Signale — nicht aus
+Portabilitätsgründen, sondern weil die Identitätsprüfung `/proc` liest. Ein
+Executor, der nicht verifizieren kann, was er gleich stoppt, darf nichts
+stoppen. Jede andere Plattform meldet `unsupported`.
+
+Kein `system()`, kein `popen()`, keine Shell. `kill(pid, SIGSTOP)` und
+`kill(pid, SIGCONT)`, sonst nichts.
+
+## Alles wird journaled
+
+Jede Entscheidung — ALLOW wie DENY — und jeder Executor-Ausgang landet im
+Journal:
+
+```
+(machine_action (kind machine_pause_process) (target "batch_job")
+                (pid 4711) (outcome ok))
+```
+
+Auch ein `refused` steht dort. Eine Ablehnung ohne Spur ist eine Ablehnung, die
+niemand prüfen kann. Replay reproduziert den Verlauf.
+
+## Auf Hardware verifiziert
+
+Pi 5, Kernel 6.18. `test/machine_action_probe.c` forkt ein Kind und treibt den
+Executor dagegen:
+
+- `pause` → der Prozesszustand in `/proc` wird `T`
+- `resume` → er läuft wieder
+- Snapshot mit veränderter Startzeit → `identity_changed`, und der Prozess
+  bleibt **unangetastet**
+
+Der letzte Punkt ist der wichtigste Test dieser Phase. Regressiert er,
+signalisiert der Agent fremde Prozesse.
+
+`test/test_cli_machine_run.sh` fährt dasselbe über die CLI: pausiert ein echtes
+`sleep`, prüft den Zustand, und verlangt für einen `critical`-Prozess
+`SPG_POLICY_DENY_PROCESS_PROTECTED` im Journal — „denied" allein würde nicht
+zwischen Schutz und Budgetende unterscheiden.
+
+Auf macOS läuft derselbe Test gegen die Verweigerung: ohne Snapshot kein
+beobachteter Prozess, also `DENY_PROCESS_IDENTITY` statt eines stillen No-ops.
+
+## Konfiguration
+
+`examples/machine-policy.spg` aktiviert `machine.process.pause` und
+`machine.process.resume` — und **kein** `local_shell`. Das ist Absicht: ein
+Modell, dem eine Pause verweigert wurde, soll nicht auf `kill` ausweichen
+können. Der Bypass-Test in Phase 7 (#67) hängt daran.
+
+```
+geistshell agent --config examples/machine-run.spg \
+  --machine --process-profile <profil.spg> --allow-exec
+```
+
+Ohne `--process-profile` ist nichts gemanagt und jede Machine Action wird
+abgelehnt. Ohne `--allow-exec` erreicht sie den Executor, der `unsupported`
+meldet, statt zu signalisieren.
+
+## Was Phase 6 nicht tut
+
+Kein Closed Loop (#67) — der Agent beobachtet die Wirkung seiner Aktion noch
+nicht, weil der Snapshot einmal pro Lauf entsteht. Kein `set_nice`. Und
+insbesondere **keine Garantie, dass ein pausierter Prozess wieder freigegeben
+wird**, wenn der Run stirbt: das ist #80 und sollte vor #67 kommen.

--- a/examples/machine-policy.spg
+++ b/examples/machine-policy.spg
@@ -1,0 +1,19 @@
+; Policy for a machine run: pause and resume are enabled, everything that could
+; be used to work around them is not. local_shell in particular is absent, so a
+; model that gets denied a pause cannot reach for `kill` instead — the phase-7
+; bypass test depends on this file saying no.
+(policy
+ (network_default deny)
+ (budgets
+  (inference_steps 8)
+  (tokens 256)
+  (shell_actions 0)
+  (sim_actions 0)
+  (memory_actions 0)
+  (wall_ms 10000)
+  (journal_bytes 1048576)
+  (risk_bp 10000)
+  (machine_actions 4))
+ (capability
+  ((name machine.process.pause) (kind machine_process) (enabled true) (budget 2))
+  ((name machine.process.resume) (kind machine_process) (enabled true) (budget 2))))

--- a/examples/machine-run.spg
+++ b/examples/machine-run.spg
@@ -1,0 +1,19 @@
+; Run config for a machine agent: the machine policy, and a journal of its own
+; so a machine run never overwrites the phase-0 freeze journal.
+(run
+ (model "fake.gguf")
+ (policy "examples/machine-policy.spg")
+ (scenario "examples/scenario.spg")
+ (corpus "examples/corpus.spg")
+ (journal "build/machine-demo.sgj")
+ (seed 42)
+ (budgets
+  (inference_steps 8)
+  (tokens 256)
+  (shell_actions 0)
+  (sim_actions 0)
+  (memory_actions 0)
+  (wall_ms 10000)
+  (journal_bytes 1048576)
+  (risk_bp 10000)
+  (machine_actions 4)))

--- a/include/geistshell/agent_run.h
+++ b/include/geistshell/agent_run.h
@@ -44,6 +44,9 @@ struct spg_agent_run_inputs {
      * Null = none, the default: the context is then byte-identical to before
      * machine state existed, which the phase-0 journal freeze relies on. */
     const struct spg_machine_state *machine;
+    /* Process profile for machine actions (roadmap phase 6). Null = every
+     * machine action is denied as unmanaged, which is the right default. */
+    const struct spg_process_profile *profile;
 };
 
 struct spg_agent_run_config {

--- a/include/geistshell/agent_run.h
+++ b/include/geistshell/agent_run.h
@@ -47,6 +47,10 @@ struct spg_agent_run_inputs {
     /* Process profile for machine actions (roadmap phase 6). Null = every
      * machine action is denied as unmanaged, which is the right default. */
     const struct spg_process_profile *profile;
+    /* Ledger of pauses this run owes a resume for (phase 6b, #80). Null means
+     * machine pauses are refused: stopping a process nobody promised to
+     * restart is the failure mode this exists to prevent. */
+    struct spg_machine_pause_ledger *pause_ledger;
 };
 
 struct spg_agent_run_config {

--- a/include/geistshell/machine_executor.h
+++ b/include/geistshell/machine_executor.h
@@ -47,6 +47,16 @@ enum spg_machine_exec_outcome {
 
 struct spg_machine_paused_entry {
     uint64_t pid;
+    /* Write end of a pipe to a guardian child that resumes this process if we
+     * die without releasing it. -1 when there is none (non-Linux, or the fork
+     * failed — in which case the pause does not happen at all).
+     *
+     * This closes the one window the ledger cannot: SIGKILL and power loss are
+     * not catchable, so between the kill and the next agent start the process
+     * would otherwise stay stopped indefinitely. The guardian is not a second
+     * lifecycle to manage — it holds no state, waits on one pipe, and exits as
+     * soon as either end of the story is told. */
+    int guard_fd;
     /* Recorded so the release can refuse to signal a recycled pid. A cleanup
      * path that resumes strangers is worse than one that resumes nothing. */
     uint64_t start_identity;

--- a/include/geistshell/machine_executor.h
+++ b/include/geistshell/machine_executor.h
@@ -36,11 +36,37 @@ enum spg_machine_exec_outcome {
     SPG_MACHINE_EXEC_UNSUPPORTED, /* no process signals on this platform */
 };
 
+/* Every pause this run performed and has not undone (roadmap phase 6b, #80).
+ *
+ * A pause is only reversible while somebody remembers it happened. Without
+ * this, a run that dies after SIGSTOP — crash, SIGKILL, budget end, an
+ * experiment runner cut short — leaves the process stopped forever, and that
+ * is the one way this runtime can do lasting damage without any policy being
+ * violated. */
+#define SPG_MACHINE_MAX_PAUSED 16u
+
+struct spg_machine_paused_entry {
+    uint64_t pid;
+    /* Recorded so the release can refuse to signal a recycled pid. A cleanup
+     * path that resumes strangers is worse than one that resumes nothing. */
+    uint64_t start_identity;
+    char     profile_id[SPG_PROCESS_ID_CAP];
+};
+
+struct spg_machine_pause_ledger {
+    size_t                          count;
+    struct spg_machine_paused_entry entries[SPG_MACHINE_MAX_PAUSED];
+};
+
 struct spg_machine_executor_state {
     /* The snapshot the decision was made on. The executor resolves the target
      * id here rather than trusting anything in the recommendation. */
     const struct spg_machine_state *machine;
     struct spg_journal_writer      *journal;
+    /* Caller-owned, so the run that performs a pause is the run that owes the
+     * resume. Null means pauses are not tracked — and an untracked pause is
+     * refused rather than performed. */
+    struct spg_machine_pause_ledger *ledger;
 };
 
 struct spg_machine_executor_config {
@@ -61,6 +87,7 @@ struct spg_machine_executor_workspace {
 struct spg_machine_executor_result {
     enum spg_machine_exec_outcome outcome;
     uint64_t                      pid;      /* what was signalled, or 0 */
+    uint64_t                      identity; /* its start time, for recovery */
     uint64_t                      sequence; /* journal sequence, or 0 */
     size_t                        payload_used;
     bool                          payload_truncated;
@@ -89,6 +116,30 @@ spg_machine_executor_run(const struct spg_machine_executor_state  *state,
                          const struct spg_machine_executor_workspace *workspace,
                          struct spg_machine_executor_result           results[],
                          size_t                                      *out_done);
+
+/* Resume everything still in the ledger, identity-checked, and empty it.
+ * Called on every path out of a run — success, failure, max steps, budget,
+ * policy denial, interrupt. Returns SPG_OK even when individual processes are
+ * gone; *out_resumed counts the ones that were actually signalled. */
+[[nodiscard]] enum spg_status spg_machine_ledger_release(
+    struct spg_machine_pause_ledger             *ledger,
+    const struct spg_machine_executor_state     *state,
+    const struct spg_machine_executor_config    *config,
+    const struct spg_machine_executor_workspace *workspace,
+    size_t                                      *out_resumed);
+
+/* Second line of defence, for the case the first cannot cover: SIGKILL and
+ * power loss are not catchable, so a pause can outlive the process that owed
+ * the resume. Reads a journal, pairs pauses with resumes, and resumes what was
+ * left hanging — identity-checked, so a recycled pid is skipped rather than
+ * woken.
+ *
+ * Returns SPG_OK on a missing or short journal (nothing to recover is not an
+ * error); *out_resumed counts what was signalled. */
+[[nodiscard]] enum spg_status spg_machine_recover_journal(
+    const char *journal_path, const struct spg_machine_executor_config *config,
+    const struct spg_machine_executor_workspace *workspace,
+    struct spg_journal_writer *journal, size_t *out_resumed);
 
 [[nodiscard]] const char *
 spg_machine_exec_outcome_to_string(enum spg_machine_exec_outcome outcome);

--- a/include/geistshell/machine_executor.h
+++ b/include/geistshell/machine_executor.h
@@ -1,0 +1,100 @@
+#ifndef GEISTSHELL_MACHINE_EXECUTOR_H
+#define GEISTSHELL_MACHINE_EXECUTOR_H
+
+#include "geistshell/journal.h"
+#include "geistshell/machine_state.h"
+#include "geistshell/policy.h"
+#include "geistshell/recommendation.h"
+#include "geistshell/status.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Executes an ALLOW'd machine action (roadmap phase 6, #66): SIGSTOP or
+ * SIGCONT to a process the policy gate already cleared.
+ *
+ * No shell, no system(), no popen(). The model never produces a command for
+ * this path — it names a profile id, and the id is resolved here against the
+ * snapshot the gate saw. */
+
+enum spg_machine_exec_outcome {
+    SPG_MACHINE_EXEC_OK = 0,
+    /* The pid is still there but is no longer the process we observed. This is
+     * the case the whole identity apparatus exists for: pids get recycled, and
+     * signalling the new owner would be the worst bug this module could have.
+     */
+    SPG_MACHINE_EXEC_IDENTITY_CHANGED,
+    SPG_MACHINE_EXEC_GONE,        /* ESRCH: it exited on its own */
+    SPG_MACHINE_EXEC_FORBIDDEN,   /* EPERM: not ours to signal */
+    SPG_MACHINE_EXEC_NOT_FOUND,   /* the target id is not in the snapshot */
+    SPG_MACHINE_EXEC_REFUSED,     /* self, pid 1, or a nonsensical pid */
+    SPG_MACHINE_EXEC_UNSUPPORTED, /* no process signals on this platform */
+};
+
+struct spg_machine_executor_state {
+    /* The snapshot the decision was made on. The executor resolves the target
+     * id here rather than trusting anything in the recommendation. */
+    const struct spg_machine_state *machine;
+    struct spg_journal_writer      *journal;
+};
+
+struct spg_machine_executor_config {
+    uint32_t actor_id;
+    uint64_t timestamp_ns;
+    uint64_t parent_sequence;
+    bool     write_journal;
+    /* Off by default: a run that has not asked to touch the machine gets
+     * SPG_MACHINE_EXEC_UNSUPPORTED rather than a signal. */
+    bool execution_enabled;
+};
+
+struct spg_machine_executor_workspace {
+    size_t payload_capacity; /* journal-event s-expression buffer */
+    char  *payload;
+};
+
+struct spg_machine_executor_result {
+    enum spg_machine_exec_outcome outcome;
+    uint64_t                      pid;      /* what was signalled, or 0 */
+    uint64_t                      sequence; /* journal sequence, or 0 */
+    size_t                        payload_used;
+    bool                          payload_truncated;
+};
+
+/* Run one action. `target` is the profile id, NUL-terminated. */
+[[nodiscard]] enum spg_status spg_machine_executor_step(
+    const struct spg_machine_executor_state  *state,
+    const struct spg_machine_executor_config *config, enum spg_action_kind kind,
+    const char *target, const struct spg_machine_executor_workspace *workspace,
+    struct spg_machine_executor_result *result);
+
+/* Batch form, count before the array as everywhere else in the codebase.
+ * `actions[]` rather than `actions[static n]`: an empty batch is legitimate
+ * and [static 0] is undefined behaviour. Stops at the first action that fails
+ * to execute; *out_done receives how many ran. */
+struct spg_machine_action {
+    enum spg_action_kind kind;
+    const char          *target;
+};
+
+[[nodiscard]] enum spg_status
+spg_machine_executor_run(const struct spg_machine_executor_state  *state,
+                         const struct spg_machine_executor_config *config,
+                         size_t n, const struct spg_machine_action actions[],
+                         const struct spg_machine_executor_workspace *workspace,
+                         struct spg_machine_executor_result           results[],
+                         size_t                                      *out_done);
+
+[[nodiscard]] const char *
+spg_machine_exec_outcome_to_string(enum spg_machine_exec_outcome outcome);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/geistshell/orchestrator.h
+++ b/include/geistshell/orchestrator.h
@@ -2,6 +2,7 @@
 #define GEISTSHELL_ORCHESTRATOR_H
 
 #include "geistshell/actor.h"
+#include "geistshell/machine_executor.h"
 #include "geistshell/mem_executor.h"
 #include "geistshell/policy_gate.h"
 #include "geistshell/recommendation.h"
@@ -29,14 +30,18 @@ enum spg_orchestrator_stage {
     SPG_ORCHESTRATOR_STAGE_SIM_EXECUTED,
     SPG_ORCHESTRATOR_STAGE_MEMORY_EXECUTED,
     SPG_ORCHESTRATOR_STAGE_SHELL_EXECUTED,
+    SPG_ORCHESTRATOR_STAGE_MACHINE_EXECUTED,
 };
 
 struct spg_orchestrator_state {
     struct spg_graph          *graph;
     struct spg_memory         *memory;
     struct spg_journal_writer *journal;
-    /* Optional machine snapshot for the context (roadmap phase 3). */
-    const struct spg_machine_state *machine;
+    /* Optional machine snapshot for the context (roadmap phase 3) and the
+     * process profile the gate judges machine actions against (phase 6).
+     * Without a profile every machine action is denied as unmanaged. */
+    const struct spg_machine_state   *machine;
+    const struct spg_process_profile *profile;
     struct spg_model_adapter  *model;
     struct spg_sim_config     *sim;
     struct spg_mem_store      *store;
@@ -132,7 +137,8 @@ struct spg_orchestrator_result {
     struct spg_policy_gate_result    policy_gate;
     struct spg_sim_executor_result   sim;
     struct spg_mem_executor_result   memory;
-    struct spg_shell_executor_result shell;
+    struct spg_shell_executor_result   shell;
+    struct spg_machine_executor_result machine_action;
 };
 
 [[nodiscard]] enum spg_status
@@ -167,6 +173,11 @@ spg_orchestrator_memory_executed(const struct spg_orchestrator_result *result);
 /* A local_shell action executed this tick (ran or was boundary-denied). */
 [[nodiscard]] bool
 spg_orchestrator_shell_executed(const struct spg_orchestrator_result *result);
+
+/* A machine action reached the executor (roadmap phase 6). True regardless of
+ * the outcome: a refused signal still spent the decision. */
+[[nodiscard]] bool
+spg_orchestrator_machine_executed(const struct spg_orchestrator_result *result);
 
 /* The agent emitted `finish`: the loop should terminate as task-complete. */
 [[nodiscard]] bool

--- a/include/geistshell/orchestrator.h
+++ b/include/geistshell/orchestrator.h
@@ -42,6 +42,10 @@ struct spg_orchestrator_state {
      * Without a profile every machine action is denied as unmanaged. */
     const struct spg_machine_state   *machine;
     const struct spg_process_profile *profile;
+    /* Where pauses are recorded so the run can undo them (phase 6b, #80).
+     * Null means a pause cannot be tracked, and an untracked pause is refused
+     * rather than performed. */
+    struct spg_machine_pause_ledger *pause_ledger;
     struct spg_model_adapter  *model;
     struct spg_sim_config     *sim;
     struct spg_mem_store      *store;

--- a/include/geistshell/policy.h
+++ b/include/geistshell/policy.h
@@ -21,6 +21,12 @@ enum spg_action_kind {
     SPG_ACTION_MEMORY_SAVE,
     SPG_ACTION_MEMORY_DELETE,
     SPG_ACTION_MEMORY_READ,
+    /* Machine actions (roadmap phase 6, #66). Typed and closed: the model
+     * never gets a shell for these. Both are reversible, which is why they are
+     * the first two — an irreversible action would need a stronger story than
+     * "the policy said yes". */
+    SPG_ACTION_MACHINE_PAUSE,
+    SPG_ACTION_MACHINE_RESUME,
     /* Control action: the agent declares the task complete. Carries no
      * capability and consumes no budget; the loop terminates on it and it never
      * reaches the policy gate. */
@@ -41,6 +47,15 @@ enum spg_policy_deny_reason {
     SPG_POLICY_DENY_CAPABILITY_BUDGET,
     SPG_POLICY_DENY_GLOBAL_BUDGET,
     SPG_POLICY_DENY_INVALID_REQUEST,
+    /* The target is not in the process profile. An unmanaged process is never
+     * actionable — not a no-op, a denial, so the model learns the difference. */
+    SPG_POLICY_DENY_UNMANAGED_PROCESS,
+    /* The profile manages it and forbids this action (role critical, or
+     * may_pause/may_stop false). Checked here rather than in the executor:
+     * the prompt cannot argue with the policy layer. */
+    SPG_POLICY_DENY_PROCESS_PROTECTED,
+    /* The pid no longer belongs to the process that was observed. */
+    SPG_POLICY_DENY_PROCESS_IDENTITY,
 };
 
 struct spg_action_request {

--- a/include/geistshell/policy_config.h
+++ b/include/geistshell/policy_config.h
@@ -25,6 +25,8 @@ enum spg_policy_capability_kind {
     SPG_POLICY_CAP_SSH_AUTH_PROBE,
     SPG_POLICY_CAP_SIMULATOR,
     SPG_POLICY_CAP_MEMORY,
+    /* machine.process.pause / machine.process.resume */
+    SPG_POLICY_CAP_MACHINE_PROCESS,
 };
 
 struct spg_policy_capability {

--- a/include/geistshell/policy_gate.h
+++ b/include/geistshell/policy_gate.h
@@ -3,6 +3,7 @@
 
 #include "geistshell/graph.h"
 #include "geistshell/journal.h"
+#include "geistshell/process_profile.h"
 #include "geistshell/policy.h"
 #include "geistshell/policy_config.h"
 #include "geistshell/recommendation.h"
@@ -26,6 +27,16 @@ struct spg_policy_gate_state {
 
     struct spg_journal_writer *journal;
     struct spg_graph          *graph;
+
+    /* Roadmap phase 6 (#66). A machine action names a profile id; whether it
+     * may be performed depends on the profile's role and permissions, and on
+     * the process still being where it was observed. Both live HERE rather
+     * than in the executor: a safety property enforced downstream of the gate
+     * is one the journal cannot show was checked. Null = machine actions are
+     * denied outright, which is the right default for a run that never
+     * configured a profile. */
+    const struct spg_process_profile *profile;
+    const struct spg_machine_state   *machine;
 };
 
 struct spg_policy_gate_config {

--- a/include/geistshell/run_config.h
+++ b/include/geistshell/run_config.h
@@ -16,7 +16,8 @@ struct spg_run_budgets {
     uint64_t tokens;
     uint64_t shell_actions;
     uint64_t sim_actions;
-    uint64_t memory_actions; /* optional in config; defaults to unlimited */
+    uint64_t memory_actions;  /* optional in config; defaults to unlimited */
+    uint64_t machine_actions; /* optional in config; defaults to unlimited */
     uint64_t wall_ms;
     uint64_t journal_bytes;
     uint64_t risk_bp;

--- a/src/actor/recommendation.c
+++ b/src/actor/recommendation.c
@@ -124,6 +124,16 @@ static bool parse_action_kind(const size_t input_n, const char input[],
         *out = SPG_ACTION_MEMORY_READ;
         return true;
     }
+    if (spg_sexpr_span_eq_cstr(input_n, input, span,
+                               "machine_pause_process")) {
+        *out = SPG_ACTION_MACHINE_PAUSE;
+        return true;
+    }
+    if (spg_sexpr_span_eq_cstr(input_n, input, span,
+                               "machine_resume_process")) {
+        *out = SPG_ACTION_MACHINE_RESUME;
+        return true;
+    }
     if (spg_sexpr_span_eq_cstr(input_n, input, span, "finish")) {
         *out = SPG_ACTION_FINISH;
         return true;
@@ -162,6 +172,14 @@ static bool kind_fields_match(const struct spg_recommendation *out) {
         /* delete/read need only a slug. */
         return !out->action.uses_network && !out->has_command &&
                !out->has_target && out->has_slug && !out->has_description &&
+               !out->has_body;
+    case SPG_ACTION_MACHINE_PAUSE:
+    case SPG_ACTION_MACHINE_RESUME:
+        /* A machine action names a target and nothing else. No command field:
+         * the whole point of a typed action is that the model cannot hand the
+         * executor a string to run. */
+        return !out->action.uses_network && !out->has_command &&
+               out->has_target && !out->has_slug && !out->has_description &&
                !out->has_body;
     case SPG_ACTION_FINISH:
         /* finish carries no side-effect fields. */

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -142,6 +142,8 @@ policy_capability_kind_name(const enum spg_policy_capability_kind kind) {
         return "simulator";
     case SPG_POLICY_CAP_MEMORY:
         return "memory";
+    case SPG_POLICY_CAP_MACHINE_PROCESS:
+        return "machine_process";
     }
     return "unknown";
 }
@@ -2179,6 +2181,10 @@ static int agent_command(int argc, char **argv) {
          * to before this phase, which is what keeps the phase-0 freeze valid.
          */
         .machine = with_machine ? &machine : nullptr,
+        /* No profile means nothing is managed, and the gate denies every
+         * machine action as unmanaged. That is the right default: a run that
+         * never declared what it may touch may not touch anything. */
+        .profile = profile_path != nullptr ? &profile : nullptr,
     };
     const struct spg_agent_run_config rcfg = {
         .max_steps   = max_steps,

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -24,6 +24,7 @@
 
 #include <errno.h>
 #include <math.h> /* isfinite: --temperature validation */
+#include <signal.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -696,6 +697,29 @@ latest_result_sequence(const struct spg_orchestrator_result *result,
         return result->actor.model_input_sequence;
     }
     return fallback_sequence;
+}
+
+/* Set by SIGINT/SIGTERM and read by the cleanup path. A handler may only touch
+ * a volatile sig_atomic_t and call async-signal-safe functions; resuming
+ * processes from inside it would mean journalling from a signal handler, so the
+ * handler does the one safe thing and the normal path does the work. */
+static volatile sig_atomic_t interrupt_requested = 0;
+
+static void note_interrupt(int signum) {
+    (void)signum;
+    interrupt_requested = 1;
+}
+
+static void install_interrupt_handler(void) {
+    struct sigaction sa = {};
+    sa.sa_handler       = note_interrupt;
+    (void)sigemptyset(&sa.sa_mask);
+    /* No SA_RESTART on purpose: a blocking read should return EINTR so the run
+     * unwinds to the cleanup path instead of sitting there while a process
+     * stays stopped. */
+    sa.sa_flags = 0;
+    (void)sigaction(SIGINT, &sa, nullptr);
+    (void)sigaction(SIGTERM, &sa, nullptr);
 }
 
 static void update_run_usage(struct spg_policy_usage              *usage,
@@ -2161,6 +2185,30 @@ static int agent_command(int argc, char **argv) {
             return 2;
         }
     }
+    static struct spg_machine_pause_ledger      pause_ledger;
+    char                                        machine_payload[1024];
+    const struct spg_machine_executor_workspace release_ws = {
+        .payload_capacity = sizeof machine_payload, .payload = machine_payload};
+    if (with_machine) {
+        install_interrupt_handler();
+        /* Second line of defence first: a previous run may have been killed
+         * between a pause and its resume, and that process is still stopped
+         * right now. Recover before observing, so the snapshot this run reasons
+         * about is not one we ourselves left broken. */
+        const struct spg_machine_executor_config recover_cfg = {
+            .actor_id          = 1u,
+            .timestamp_ns      = 1u,
+            .write_journal     = false,
+            .execution_enabled = true,
+        };
+        size_t recovered = 0u;
+        if (spg_machine_recover_journal(journal_path, &recover_cfg, &release_ws,
+                                        nullptr, &recovered) == SPG_OK &&
+            recovered > 0u) {
+            printf("recovered=%zu (processes left paused by an earlier run)\n",
+                   recovered);
+        }
+    }
     if (with_machine) {
         (void)spg_machine_sample_with_processes(
             1u, nullptr, 0u, nullptr,
@@ -2184,7 +2232,8 @@ static int agent_command(int argc, char **argv) {
         /* No profile means nothing is managed, and the gate denies every
          * machine action as unmanaged. That is the right default: a run that
          * never declared what it may touch may not touch anything. */
-        .profile = profile_path != nullptr ? &profile : nullptr,
+        .profile      = profile_path != nullptr ? &profile : nullptr,
+        .pause_ledger = with_machine ? &pause_ledger : nullptr,
     };
     const struct spg_agent_run_config rcfg = {
         .max_steps   = max_steps,
@@ -2261,6 +2310,29 @@ static int agent_command(int argc, char **argv) {
     }
 
 done:
+    /* Nothing stays paused. Every path lands here — success, failure, max
+     * steps, budget, policy denial, interrupt — so the promise does not depend
+     * on how the run ended. */
+    if (with_machine) {
+        const struct spg_machine_executor_state release_state = {
+            .machine = &machine,
+            .journal = journal_open ? &journal : nullptr,
+            .ledger  = &pause_ledger,
+        };
+        const struct spg_machine_executor_config release_cfg = {
+            .actor_id          = 1u,
+            .timestamp_ns      = 1u,
+            .write_journal     = journal_open,
+            .execution_enabled = true,
+        };
+        size_t resumed = 0u;
+        (void)spg_machine_ledger_release(&pause_ledger, &release_state,
+                                         &release_cfg, &release_ws, &resumed);
+        if (resumed > 0u) {
+            printf("released=%zu%s\n", resumed,
+                   interrupt_requested ? " (interrupted)" : "");
+        }
+    }
     if (journal_open) {
         (void)spg_journal_writer_close(&journal);
     }

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -23,6 +23,7 @@
 #include <geist.h>
 
 #include <errno.h>
+#include <fcntl.h>
 #include <math.h> /* isfinite: --temperature validation */
 #include <signal.h>
 #include <stdbool.h>
@@ -30,6 +31,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/file.h>
 #include <unistd.h> /* mkstemp/write/close/unlink: the guard-gate temp suite */
 
 #define CLI_TOKEN_CAPACITY 1024u
@@ -720,6 +722,33 @@ static void install_interrupt_handler(void) {
     sa.sa_flags = 0;
     (void)sigaction(SIGINT, &sa, nullptr);
     (void)sigaction(SIGTERM, &sa, nullptr);
+}
+
+/* One machine run per journal, enforced by an advisory lock on a sibling file.
+ *
+ * Recovery reads the journal and resumes whatever looks stranded — with two
+ * runs sharing a journal it would resume the other run's pauses mid-flight.
+ * The lock also prevents something that was already broken and simply had not
+ * been hit: two writers appending to one hash-chained journal interleave their
+ * records and destroy the chain.
+ *
+ * Advisory and non-blocking: a second run is told to use its own journal
+ * rather than made to wait for a run that may take hours. Returns -1 when the
+ * lock is held elsewhere. */
+static int lock_machine_journal(const char *journal_path) {
+    char path[4096];
+    if (snprintf(path, sizeof path, "%s.lock", journal_path) < 0) {
+        return -1;
+    }
+    const int fd = open(path, O_RDWR | O_CREAT | O_CLOEXEC, 0600);
+    if (fd < 0) {
+        return -1;
+    }
+    if (flock(fd, LOCK_EX | LOCK_NB) != 0) {
+        (void)close(fd);
+        return -1;
+    }
+    return fd;
 }
 
 static void update_run_usage(struct spg_policy_usage              *usage,
@@ -1855,6 +1884,9 @@ static int agent_command(int argc, char **argv) {
     uint64_t seed_override = 0u; /* per-attempt seed for best-of-N sampling */
     size_t   best_of       = 1u; /* #2: verifier-guided best-of-N attempts */
     bool     with_machine  = false; /* roadmap phase 3: (machine-state ...) */
+    /* Declared up here because every early `goto done` must find it defined —
+     * the cleanup path releases it. */
+    int         machine_lock = -1;
     const char *profile_path = nullptr; /* (process-profile ...) file */
     for (int i = 2; i < argc; i += 1) {
         if ((strcmp(argv[i], "--config") == 0 ||
@@ -2190,6 +2222,15 @@ static int agent_command(int argc, char **argv) {
     const struct spg_machine_executor_workspace release_ws = {
         .payload_capacity = sizeof machine_payload, .payload = machine_payload};
     if (with_machine) {
+        machine_lock = lock_machine_journal(journal_path);
+        if (machine_lock < 0) {
+            fprintf(stderr,
+                    "agent: another machine run holds %s — give this one its "
+                    "own journal\n",
+                    journal_path);
+            rc = 2;
+            goto done;
+        }
         install_interrupt_handler();
         /* Second line of defence first: a previous run may have been killed
          * between a pause and its resume, and that process is still stopped
@@ -2332,6 +2373,11 @@ done:
             printf("released=%zu%s\n", resumed,
                    interrupt_requested ? " (interrupted)" : "");
         }
+    }
+    if (machine_lock >= 0) {
+        /* Released after the pauses are: a second run must not start recovery
+         * while this one is still handing processes back. */
+        (void)close(machine_lock);
     }
     if (journal_open) {
         (void)spg_journal_writer_close(&journal);

--- a/src/core/budget_config.c
+++ b/src/core/budget_config.c
@@ -25,6 +25,12 @@ static const struct budget_field budget_fields[] = {
     {"sim_actions", offsetof(struct spg_run_budgets, sim_actions), false, 0u},
     {"memory_actions", offsetof(struct spg_run_budgets, memory_actions), true,
      UINT64_MAX},
+    /* Optional like memory_actions: a config written before machine actions
+     * existed must keep loading, and an absent budget means unlimited rather
+     * than zero — zero would silently disable a capability the operator
+     * explicitly enabled. */
+    {"machine_actions", offsetof(struct spg_run_budgets, machine_actions), true,
+     UINT64_MAX},
     {"wall_ms", offsetof(struct spg_run_budgets, wall_ms), false, 0u},
     {"journal_bytes", offsetof(struct spg_run_budgets, journal_bytes), false,
      0u},

--- a/src/core/run_config.c
+++ b/src/core/run_config.c
@@ -46,7 +46,7 @@ static const struct spg_schema_field_rule run_fields[] = {
     {.name       = "budgets",
      .value_kind = SPG_SCHEMA_VALUE_LIST,
      .min_values = 7u,
-     .max_values = 8u, /* 7 required + optional memory_actions */
+     .max_values = 9u, /* 7 required + optional memory/machine_actions */
      .required   = true,
      .unique     = true},
     /* Optional success criterion (docs/LEARNING.md P1): a substring the

--- a/src/executor/machine_executor.c
+++ b/src/executor/machine_executor.c
@@ -1,0 +1,223 @@
+/* SIGSTOP / SIGCONT to a process the policy gate already cleared.
+ *
+ * The gate decided WHETHER. This decides whether the process is still the one
+ * that was decided about — and that second question cannot be answered
+ * earlier, because a pid can be recycled between the decision and the syscall.
+ * Everything here exists for that gap. */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include "geistshell/machine_executor.h"
+
+#include "geistshell/machine_fixture.h"
+#include "geistshell/sexpr.h"
+
+#include <string.h>
+
+/* Linux only, and not for portability reasons: the identity re-check reads
+ * /proc/<pid>/stat, and without it a signal goes out on a pid that may have
+ * been recycled since the snapshot. An executor that cannot verify what it is
+ * about to stop must not stop anything, so every other platform reports
+ * UNSUPPORTED rather than acting blind. */
+#if defined(__linux__)
+#    include <errno.h>
+#    include <signal.h>
+#    include <stdio.h>
+#    include <unistd.h>
+#    define SPG_MACHINE_SIGNALS 1
+#endif
+
+const char *spg_machine_exec_outcome_to_string(
+    const enum spg_machine_exec_outcome outcome) {
+    switch (outcome) {
+    case SPG_MACHINE_EXEC_OK:
+        return "ok";
+    case SPG_MACHINE_EXEC_IDENTITY_CHANGED:
+        return "identity_changed";
+    case SPG_MACHINE_EXEC_GONE:
+        return "gone";
+    case SPG_MACHINE_EXEC_FORBIDDEN:
+        return "forbidden";
+    case SPG_MACHINE_EXEC_NOT_FOUND:
+        return "not_found";
+    case SPG_MACHINE_EXEC_REFUSED:
+        return "refused";
+    case SPG_MACHINE_EXEC_UNSUPPORTED:
+        return "unsupported";
+    }
+    return "unsupported";
+}
+
+static const struct spg_process_sample *
+find_target(const struct spg_machine_state *machine, const char *target) {
+    if (machine == nullptr || target == nullptr || target[0] == '\0') {
+        return nullptr;
+    }
+    for (size_t i = 0u; i < machine->n_processes; i += 1u) {
+        if (strcmp(machine->processes[i].profile_id, target) == 0) {
+            return &machine->processes[i];
+        }
+    }
+    return nullptr;
+}
+
+#if defined(SPG_MACHINE_SIGNALS)
+/* Re-read the identity from /proc immediately before signalling. Returns false
+ * when the pid is gone or now belongs to somebody else.
+ *
+ * This is deliberately a fresh read rather than a cached value: the snapshot
+ * could be a tick old, and a tick is long enough for a pid to be reused. */
+static bool identity_still_matches(const uint64_t pid,
+                                   const uint64_t start_identity) {
+    char path[64];
+    if (snprintf(path, sizeof path, "/proc/%llu/stat",
+                 (unsigned long long)pid) < 0) {
+        return false;
+    }
+    FILE *f = fopen(path, "rbe");
+    if (f == nullptr) {
+        return false;
+    }
+    char         buf[2048];
+    const size_t n = fread(buf, 1u, sizeof buf, f);
+    (void)fclose(f);
+    if (n == 0u) {
+        return false;
+    }
+    struct spg_process_sample now = {};
+    if (spg_process_parse_stat(n, buf, 4096u, &now) != SPG_OK) {
+        return false;
+    }
+    return now.pid == pid && now.start_identity == start_identity;
+}
+#endif
+
+static enum spg_machine_exec_outcome
+send_signal(const uint64_t pid, const uint64_t start_identity,
+            const enum spg_action_kind kind) {
+#if defined(SPG_MACHINE_SIGNALS)
+    /* Never the agent itself, never init, never a wildcard: kill(0, ...) hits
+     * the whole process group and kill(-1, ...) hits everything the user owns.
+     * Neither is expressible through the profile, but the executor is the last
+     * line and does not assume the layers above it are perfect. */
+    if (pid <= 1u || pid == (uint64_t)getpid() || pid == (uint64_t)getppid() ||
+        pid > (uint64_t)INT32_MAX) {
+        return SPG_MACHINE_EXEC_REFUSED;
+    }
+    if (!identity_still_matches(pid, start_identity)) {
+        /* Distinguish "it left" from "somebody else has the pid now": the
+         * first is normal, the second is the one worth alarming about. */
+        return kill((pid_t)pid, 0) == 0 ? SPG_MACHINE_EXEC_IDENTITY_CHANGED
+                                        : SPG_MACHINE_EXEC_GONE;
+    }
+    const int sig = kind == SPG_ACTION_MACHINE_PAUSE ? SIGSTOP : SIGCONT;
+    if (kill((pid_t)pid, sig) == 0) {
+        return SPG_MACHINE_EXEC_OK;
+    }
+    switch (errno) {
+    case ESRCH:
+        return SPG_MACHINE_EXEC_GONE;
+    case EPERM:
+        return SPG_MACHINE_EXEC_FORBIDDEN;
+    default:
+        return SPG_MACHINE_EXEC_REFUSED;
+    }
+#else
+    (void)pid;
+    (void)start_identity;
+    (void)kind;
+    return SPG_MACHINE_EXEC_UNSUPPORTED;
+#endif
+}
+
+static void
+journal_action(const struct spg_machine_executor_state  *state,
+               const struct spg_machine_executor_config *config,
+               const enum spg_action_kind kind, const char *target,
+               const struct spg_machine_executor_workspace *workspace,
+               struct spg_machine_executor_result          *result) {
+    struct spg_sexpr_writer w;
+    spg_sexpr_writer_init(&w, workspace->payload_capacity, workspace->payload);
+    (void)spg_sexpr_writer_append_text(&w, "(machine_action (kind ");
+    (void)spg_sexpr_writer_append_text(&w, spg_action_kind_to_string(kind));
+    (void)spg_sexpr_writer_append_text(&w, ") (target \"");
+    (void)spg_sexpr_writer_append_text(&w, target);
+    (void)spg_sexpr_writer_append_text(&w, "\") (pid ");
+    (void)spg_sexpr_writer_append_u64(&w, result->pid);
+    (void)spg_sexpr_writer_append_text(&w, ") (outcome ");
+    (void)spg_sexpr_writer_append_text(
+        &w, spg_machine_exec_outcome_to_string(result->outcome));
+    (void)spg_sexpr_writer_append_text(&w, "))");
+    result->payload_used      = w.used;
+    result->payload_truncated = w.truncated;
+
+    if (!config->write_journal || state->journal == nullptr) {
+        return;
+    }
+    /* Journalled whatever the outcome. A refusal that leaves no record is a
+     * refusal nobody can audit. */
+    uint64_t sequence = 0u;
+    (void)spg_journal_writer_append(
+        state->journal, config->timestamp_ns, config->parent_sequence,
+        SPG_JOURNAL_EVENT_ACTION,
+        result->outcome == SPG_MACHINE_EXEC_OK ? SPG_OK : SPG_E_INVALID_STATE,
+        w.used, (const uint8_t *)workspace->payload, &sequence);
+    result->sequence = sequence;
+}
+
+enum spg_status spg_machine_executor_step(
+    const struct spg_machine_executor_state  *state,
+    const struct spg_machine_executor_config *config,
+    const enum spg_action_kind kind, const char *target,
+    const struct spg_machine_executor_workspace *workspace,
+    struct spg_machine_executor_result          *result) {
+    if (state == nullptr || config == nullptr || workspace == nullptr ||
+        result == nullptr || workspace->payload == nullptr ||
+        workspace->payload_capacity == 0u || target == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    if (kind != SPG_ACTION_MACHINE_PAUSE && kind != SPG_ACTION_MACHINE_RESUME) {
+        return SPG_E_INVALID_ARG;
+    }
+    *result = (struct spg_machine_executor_result){};
+
+    const struct spg_process_sample *p = find_target(state->machine, target);
+    if (p == nullptr) {
+        result->outcome = SPG_MACHINE_EXEC_NOT_FOUND;
+    } else if (!config->execution_enabled) {
+        result->pid     = p->pid;
+        result->outcome = SPG_MACHINE_EXEC_UNSUPPORTED;
+    } else {
+        result->pid     = p->pid;
+        result->outcome = send_signal(p->pid, p->start_identity, kind);
+    }
+    journal_action(state, config, kind, target, workspace, result);
+    return SPG_OK;
+}
+
+enum spg_status spg_machine_executor_run(
+    const struct spg_machine_executor_state  *state,
+    const struct spg_machine_executor_config *config, const size_t n,
+    const struct spg_machine_action              actions[],
+    const struct spg_machine_executor_workspace *workspace,
+    struct spg_machine_executor_result results[], size_t *out_done) {
+    if (out_done == nullptr ||
+        (n > 0u && (actions == nullptr || results == nullptr))) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out_done = 0u;
+    for (size_t i = 0u; i < n; i += 1u) {
+        const enum spg_status status = spg_machine_executor_step(
+            state, config, actions[i].kind, actions[i].target, workspace,
+            &results[i]);
+        if (status != SPG_OK) {
+            return status;
+        }
+        *out_done += 1u;
+        if (results[i].outcome != SPG_MACHINE_EXEC_OK) {
+            break; /* a batch stops at the first refusal, so a later action
+                    * cannot depend on an effect that never happened */
+        }
+    }
+    return SPG_OK;
+}

--- a/src/executor/machine_executor.c
+++ b/src/executor/machine_executor.c
@@ -92,6 +92,65 @@ static bool identity_still_matches(const uint64_t pid,
 }
 #endif
 
+#if defined(SPG_MACHINE_SIGNALS)
+/* Fork a guardian that outlives us if we are killed.
+ *
+ * It holds the read end of a pipe and blocks on it. Two things can happen:
+ * a byte arrives (we released the pause ourselves) and it exits without acting,
+ * or the pipe closes because we died and it resumes the process. No timer, no
+ * heartbeat, no state — the kernel closing our fds IS the signal.
+ *
+ * Returns the write end, or -1 when no guardian could be created. A pause with
+ * no guardian is refused by the caller: an unguarded stop is exactly the
+ * damage this is here to prevent. */
+static int spawn_guardian(const uint64_t pid, const uint64_t start_identity) {
+    int fds[2];
+    if (pipe(fds) != 0) {
+        return -1;
+    }
+    const pid_t child = fork();
+    if (child < 0) {
+        (void)close(fds[0]);
+        (void)close(fds[1]);
+        return -1;
+    }
+    if (child == 0) {
+        (void)close(fds[1]);
+        char    byte = 0;
+        ssize_t n    = 0;
+        do {
+            n = read(fds[0], &byte, 1u);
+        } while (n < 0 && errno == EINTR);
+        if (n == 0) {
+            /* The parent died without releasing. Re-check identity first: a
+             * guardian that wakes a recycled pid is worse than one that does
+             * nothing. */
+            if (identity_still_matches(pid, start_identity)) {
+                (void)kill((pid_t)pid, SIGCONT);
+            }
+        }
+        _exit(0);
+    }
+    (void)close(fds[0]);
+    return fds[1];
+}
+
+/* Tell a guardian to stand down. Writing the byte is what distinguishes "we
+ * handled it" from "we died"; closing alone would look like death. */
+static void dismiss_guardian(int *fd) {
+    if (fd == nullptr || *fd < 0) {
+        return;
+    }
+    const char byte = 1;
+    ssize_t    n    = 0;
+    do {
+        n = write(*fd, &byte, 1u);
+    } while (n < 0 && errno == EINTR);
+    (void)close(*fd);
+    *fd = -1;
+}
+#endif
+
 /* Ledger bookkeeping. A pause that cannot be recorded is not performed: the
  * alternative is a stopped process nobody owes a resume for. */
 static bool ledger_remember(struct spg_machine_pause_ledger *ledger,
@@ -113,9 +172,27 @@ static bool ledger_remember(struct spg_machine_pause_ledger *ledger,
     e->start_identity                  = p->start_identity;
     memcpy(e->profile_id, p->profile_id, SPG_PROCESS_ID_CAP);
     e->profile_id[SPG_PROCESS_ID_CAP - 1u] = '\0';
+    e->guard_fd                            = -1;
     ledger->count += 1u;
     return true;
 }
+
+#if defined(SPG_MACHINE_SIGNALS)
+static void ledger_set_guard(struct spg_machine_pause_ledger *ledger,
+                             const uint64_t pid, const uint64_t start_identity,
+                             const int fd) {
+    if (ledger == nullptr) {
+        return;
+    }
+    for (size_t i = 0u; i < ledger->count; i += 1u) {
+        if (ledger->entries[i].pid == pid &&
+            ledger->entries[i].start_identity == start_identity) {
+            ledger->entries[i].guard_fd = fd;
+            return;
+        }
+    }
+}
+#endif
 
 static void ledger_forget(struct spg_machine_pause_ledger *ledger,
                           const uint64_t pid, const uint64_t start_identity) {
@@ -125,6 +202,11 @@ static void ledger_forget(struct spg_machine_pause_ledger *ledger,
     for (size_t i = 0u; i < ledger->count; i += 1u) {
         if (ledger->entries[i].pid == pid &&
             ledger->entries[i].start_identity == start_identity) {
+#if defined(SPG_MACHINE_SIGNALS)
+            /* Dismissed, not just dropped: a guardian left waiting would
+             * resume this process again when we exit normally. */
+            dismiss_guardian(&ledger->entries[i].guard_fd);
+#endif
             ledger->entries[i] = ledger->entries[ledger->count - 1u];
             ledger->count -= 1u;
             return;
@@ -242,7 +324,22 @@ enum spg_status spg_machine_executor_step(
     } else {
         result->pid      = p->pid;
         result->identity = p->start_identity;
-        result->outcome  = send_signal(p->pid, p->start_identity, kind);
+#if defined(SPG_MACHINE_SIGNALS)
+        if (kind == SPG_ACTION_MACHINE_PAUSE) {
+            /* Armed BEFORE the stop, not after: a crash in between would
+             * otherwise leave exactly the stopped-and-forgotten process the
+             * guardian exists to prevent. */
+            const int guard = spawn_guardian(p->pid, p->start_identity);
+            if (guard < 0) {
+                ledger_forget(state->ledger, p->pid, p->start_identity);
+                result->outcome = SPG_MACHINE_EXEC_REFUSED;
+                journal_action(state, config, kind, target, workspace, result);
+                return SPG_OK;
+            }
+            ledger_set_guard(state->ledger, p->pid, p->start_identity, guard);
+        }
+#endif
+        result->outcome = send_signal(p->pid, p->start_identity, kind);
         if (kind == SPG_ACTION_MACHINE_PAUSE &&
             result->outcome != SPG_MACHINE_EXEC_OK) {
             ledger_forget(state->ledger, p->pid, p->start_identity);
@@ -327,6 +424,9 @@ enum spg_status spg_machine_ledger_release(
             SPG_MACHINE_EXEC_OK) {
             *out_resumed += 1u;
         }
+#if defined(SPG_MACHINE_SIGNALS)
+        dismiss_guardian(&ledger->entries[i].guard_fd);
+#endif
     }
     ledger->count = 0u;
     return SPG_OK;

--- a/src/executor/machine_executor.c
+++ b/src/executor/machine_executor.c
@@ -92,6 +92,46 @@ static bool identity_still_matches(const uint64_t pid,
 }
 #endif
 
+/* Ledger bookkeeping. A pause that cannot be recorded is not performed: the
+ * alternative is a stopped process nobody owes a resume for. */
+static bool ledger_remember(struct spg_machine_pause_ledger *ledger,
+                            const struct spg_process_sample *p) {
+    if (ledger == nullptr) {
+        return false;
+    }
+    for (size_t i = 0u; i < ledger->count; i += 1u) {
+        if (ledger->entries[i].pid == p->pid &&
+            ledger->entries[i].start_identity == p->start_identity) {
+            return true; /* pausing twice still owes exactly one resume */
+        }
+    }
+    if (ledger->count >= SPG_MACHINE_MAX_PAUSED) {
+        return false;
+    }
+    struct spg_machine_paused_entry *e = &ledger->entries[ledger->count];
+    e->pid                             = p->pid;
+    e->start_identity                  = p->start_identity;
+    memcpy(e->profile_id, p->profile_id, SPG_PROCESS_ID_CAP);
+    e->profile_id[SPG_PROCESS_ID_CAP - 1u] = '\0';
+    ledger->count += 1u;
+    return true;
+}
+
+static void ledger_forget(struct spg_machine_pause_ledger *ledger,
+                          const uint64_t pid, const uint64_t start_identity) {
+    if (ledger == nullptr) {
+        return;
+    }
+    for (size_t i = 0u; i < ledger->count; i += 1u) {
+        if (ledger->entries[i].pid == pid &&
+            ledger->entries[i].start_identity == start_identity) {
+            ledger->entries[i] = ledger->entries[ledger->count - 1u];
+            ledger->count -= 1u;
+            return;
+        }
+    }
+}
+
 static enum spg_machine_exec_outcome
 send_signal(const uint64_t pid, const uint64_t start_identity,
             const enum spg_action_kind kind) {
@@ -144,6 +184,10 @@ journal_action(const struct spg_machine_executor_state  *state,
     (void)spg_sexpr_writer_append_text(&w, target);
     (void)spg_sexpr_writer_append_text(&w, "\") (pid ");
     (void)spg_sexpr_writer_append_u64(&w, result->pid);
+    /* Recorded so a later run can re-validate before resuming: recovery would
+     * otherwise have only a pid, and a pid alone is not an identity. */
+    (void)spg_sexpr_writer_append_text(&w, ") (identity ");
+    (void)spg_sexpr_writer_append_u64(&w, result->identity);
     (void)spg_sexpr_writer_append_text(&w, ") (outcome ");
     (void)spg_sexpr_writer_append_text(
         &w, spg_machine_exec_outcome_to_string(result->outcome));
@@ -187,9 +231,26 @@ enum spg_status spg_machine_executor_step(
     } else if (!config->execution_enabled) {
         result->pid     = p->pid;
         result->outcome = SPG_MACHINE_EXEC_UNSUPPORTED;
+    } else if (kind == SPG_ACTION_MACHINE_PAUSE &&
+               !ledger_remember(state->ledger, p)) {
+        /* No room to record it, or nowhere to record it at all. Stopping a
+         * process we could not promise to restart is exactly the outcome this
+         * phase exists to prevent, so the pause does not happen. */
+        result->pid      = p->pid;
+        result->identity = p->start_identity;
+        result->outcome  = SPG_MACHINE_EXEC_REFUSED;
     } else {
-        result->pid     = p->pid;
-        result->outcome = send_signal(p->pid, p->start_identity, kind);
+        result->pid      = p->pid;
+        result->identity = p->start_identity;
+        result->outcome  = send_signal(p->pid, p->start_identity, kind);
+        if (kind == SPG_ACTION_MACHINE_PAUSE &&
+            result->outcome != SPG_MACHINE_EXEC_OK) {
+            ledger_forget(state->ledger, p->pid, p->start_identity);
+        }
+        if (kind == SPG_ACTION_MACHINE_RESUME &&
+            result->outcome == SPG_MACHINE_EXEC_OK) {
+            ledger_forget(state->ledger, p->pid, p->start_identity);
+        }
     }
     journal_action(state, config, kind, target, workspace, result);
     return SPG_OK;
@@ -217,6 +278,191 @@ enum spg_status spg_machine_executor_run(
         if (results[i].outcome != SPG_MACHINE_EXEC_OK) {
             break; /* a batch stops at the first refusal, so a later action
                     * cannot depend on an effect that never happened */
+        }
+    }
+    return SPG_OK;
+}
+
+/* --- phase 6b: nothing stays paused ------------------------------------- */
+
+/* Resume one entry directly, without a snapshot: at cleanup time the snapshot
+ * is stale by definition, and the ledger is the record of what we owe. */
+static enum spg_machine_exec_outcome
+resume_entry(const struct spg_machine_paused_entry       *entry,
+             const struct spg_machine_executor_state     *state,
+             const struct spg_machine_executor_config    *config,
+             const struct spg_machine_executor_workspace *workspace,
+             struct spg_machine_executor_result          *result) {
+    *result = (struct spg_machine_executor_result){
+        .pid = entry->pid, .identity = entry->start_identity};
+    result->outcome = config->execution_enabled
+                          ? send_signal(entry->pid, entry->start_identity,
+                                        SPG_ACTION_MACHINE_RESUME)
+                          : SPG_MACHINE_EXEC_UNSUPPORTED;
+    journal_action(state, config, SPG_ACTION_MACHINE_RESUME, entry->profile_id,
+                   workspace, result);
+    return result->outcome;
+}
+
+enum spg_status spg_machine_ledger_release(
+    struct spg_machine_pause_ledger             *ledger,
+    const struct spg_machine_executor_state     *state,
+    const struct spg_machine_executor_config    *config,
+    const struct spg_machine_executor_workspace *workspace,
+    size_t                                      *out_resumed) {
+    if (state == nullptr || config == nullptr || workspace == nullptr ||
+        workspace->payload == nullptr || workspace->payload_capacity == 0u ||
+        out_resumed == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out_resumed = 0u;
+    if (ledger == nullptr) {
+        return SPG_OK;
+    }
+    /* Every entry is attempted even if one fails: a process that exited on its
+     * own must not stop us from restarting the next one. */
+    for (size_t i = 0u; i < ledger->count; i += 1u) {
+        struct spg_machine_executor_result r = {};
+        if (resume_entry(&ledger->entries[i], state, config, workspace, &r) ==
+            SPG_MACHINE_EXEC_OK) {
+            *out_resumed += 1u;
+        }
+    }
+    ledger->count = 0u;
+    return SPG_OK;
+}
+
+/* --- recovery from a journal -------------------------------------------- */
+
+/* One pid's outstanding debt while walking the journal. */
+struct pending_pause {
+    uint64_t pid;
+    uint64_t identity;
+    char     profile_id[SPG_PROCESS_ID_CAP];
+};
+
+static void pending_add(struct pending_pause pending[static 1], size_t *count,
+                        const struct pending_pause *entry) {
+    for (size_t i = 0u; i < *count; i += 1u) {
+        if (pending[i].pid == entry->pid &&
+            pending[i].identity == entry->identity) {
+            return;
+        }
+    }
+    if (*count < SPG_MACHINE_MAX_PAUSED) {
+        pending[*count] = *entry;
+        *count += 1u;
+    }
+}
+
+static void pending_remove(struct pending_pause pending[static 1],
+                           size_t *count, const uint64_t pid,
+                           const uint64_t identity) {
+    for (size_t i = 0u; i < *count; i += 1u) {
+        if (pending[i].pid == pid && pending[i].identity == identity) {
+            pending[i] = pending[*count - 1u];
+            *count -= 1u;
+            return;
+        }
+    }
+}
+
+/* Pull one unsigned field out of a (machine_action ...) payload. The payload is
+ * written by journal_action above, so this is parsing our own format — a full
+ * s-expression parse would need a node arena for no gain. */
+static bool payload_u64(const size_t n, const char text[], const char *field,
+                        uint64_t *out) {
+    char needle[32];
+    if (snprintf(needle, sizeof needle, "(%s ", field) < 0) {
+        return false;
+    }
+    const size_t needle_n = strlen(needle);
+    for (size_t i = 0u; i + needle_n < n; i += 1u) {
+        if (memcmp(text + i, needle, needle_n) != 0) {
+            continue;
+        }
+        size_t   j     = i + needle_n;
+        uint64_t value = 0u;
+        bool     any   = false;
+        while (j < n && text[j] >= '0' && text[j] <= '9') {
+            if (value > (UINT64_MAX - (uint64_t)(text[j] - '0')) / 10u) {
+                return false;
+            }
+            value = value * 10u + (uint64_t)(text[j] - '0');
+            any   = true;
+            j += 1u;
+        }
+        if (any) {
+            *out = value;
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool payload_has(const size_t n, const char text[], const char *what) {
+    const size_t w = strlen(what);
+    for (size_t i = 0u; i + w <= n; i += 1u) {
+        if (memcmp(text + i, what, w) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+enum spg_status spg_machine_recover_journal(
+    const char *journal_path, const struct spg_machine_executor_config *config,
+    const struct spg_machine_executor_workspace *workspace,
+    struct spg_journal_writer *journal, size_t *out_resumed) {
+    if (journal_path == nullptr || config == nullptr || workspace == nullptr ||
+        workspace->payload == nullptr || out_resumed == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out_resumed = 0u;
+
+    struct spg_journal_reader reader = {};
+    if (spg_journal_reader_open(&reader, journal_path) != SPG_OK) {
+        return SPG_OK; /* no journal, nothing owed */
+    }
+    struct pending_pause pending[SPG_MACHINE_MAX_PAUSED] = {};
+    size_t               pending_count                   = 0u;
+
+    struct spg_journal_record record = {};
+    uint8_t                   raw[1024];
+    while (spg_journal_reader_next(&reader, sizeof raw, raw, &record) ==
+           SPG_OK) {
+        const char  *payload   = (const char *)raw;
+        const size_t payload_n = record.payload_used;
+        if (record.header.event_kind != (uint32_t)SPG_JOURNAL_EVENT_ACTION ||
+            !payload_has(payload_n, payload, "(machine_action ")) {
+            continue;
+        }
+        if (!payload_has(payload_n, payload, "(outcome ok)")) {
+            continue; /* it never landed, so nothing is owed */
+        }
+        struct pending_pause entry = {};
+        if (!payload_u64(payload_n, payload, "pid", &entry.pid) ||
+            !payload_u64(payload_n, payload, "identity", &entry.identity)) {
+            continue;
+        }
+        if (payload_has(payload_n, payload, "machine_pause_process")) {
+            pending_add(pending, &pending_count, &entry);
+        } else if (payload_has(payload_n, payload, "machine_resume_process")) {
+            pending_remove(pending, &pending_count, entry.pid, entry.identity);
+        }
+    }
+    (void)spg_journal_reader_close(&reader);
+
+    const struct spg_machine_executor_state state = {.journal = journal};
+    for (size_t i = 0u; i < pending_count; i += 1u) {
+        struct spg_machine_executor_result r = {};
+        struct spg_machine_paused_entry    e = {
+            .pid = pending[i].pid, .start_identity = pending[i].identity};
+        /* The id is not needed to signal, only to journal what was restored. */
+        memcpy(e.profile_id, "recovered", sizeof "recovered");
+        if (resume_entry(&e, &state, config, workspace, &r) ==
+            SPG_MACHINE_EXEC_OK) {
+            *out_resumed += 1u;
         }
     }
     return SPG_OK;

--- a/src/policy/policy.c
+++ b/src/policy/policy.c
@@ -38,6 +38,9 @@ cap_kind_for_action(const enum spg_action_kind kind) {
     case SPG_ACTION_MEMORY_DELETE:
     case SPG_ACTION_MEMORY_READ:
         return SPG_POLICY_CAP_MEMORY;
+    case SPG_ACTION_MACHINE_PAUSE:
+    case SPG_ACTION_MACHINE_RESUME:
+        return SPG_POLICY_CAP_MACHINE_PROCESS;
     default:
         return SPG_POLICY_CAP_LOCAL_SHELL;
     }
@@ -46,7 +49,8 @@ cap_kind_for_action(const enum spg_action_kind kind) {
 static bool action_kind_valid(const enum spg_action_kind kind) {
     return kind == SPG_ACTION_LOCAL_SHELL || kind == SPG_ACTION_SSH_AUTH_PROBE ||
            kind == SPG_ACTION_SIMULATOR || kind == SPG_ACTION_MEMORY_SAVE ||
-           kind == SPG_ACTION_MEMORY_DELETE || kind == SPG_ACTION_MEMORY_READ;
+           kind == SPG_ACTION_MEMORY_DELETE || kind == SPG_ACTION_MEMORY_READ ||
+           kind == SPG_ACTION_MACHINE_PAUSE || kind == SPG_ACTION_MACHINE_RESUME;
 }
 
 static uint64_t consumed_for_action(const struct spg_policy_usage *usage,
@@ -62,6 +66,9 @@ static uint64_t consumed_for_action(const struct spg_policy_usage *usage,
     case SPG_ACTION_MEMORY_DELETE:
     case SPG_ACTION_MEMORY_READ:
         return usage->consumed.memory_actions;
+    case SPG_ACTION_MACHINE_PAUSE:
+    case SPG_ACTION_MACHINE_RESUME:
+        return usage->consumed.machine_actions;
     default:
         return UINT64_MAX;
     }
@@ -80,6 +87,9 @@ static uint64_t global_budget_for_action(const struct spg_policy_config *policy,
     case SPG_ACTION_MEMORY_DELETE:
     case SPG_ACTION_MEMORY_READ:
         return policy->budgets.memory_actions;
+    case SPG_ACTION_MACHINE_PAUSE:
+    case SPG_ACTION_MACHINE_RESUME:
+        return policy->budgets.machine_actions;
     default:
         return 0u;
     }
@@ -107,6 +117,10 @@ const char *spg_action_kind_to_string(const enum spg_action_kind kind) {
         return "memory_delete";
     case SPG_ACTION_MEMORY_READ:
         return "memory_read";
+    case SPG_ACTION_MACHINE_PAUSE:
+        return "machine_pause_process";
+    case SPG_ACTION_MACHINE_RESUME:
+        return "machine_resume_process";
     case SPG_ACTION_FINISH:
         return "finish";
     }
@@ -132,6 +146,12 @@ const char *spg_policy_deny_reason_to_string(
         return "SPG_POLICY_DENY_GLOBAL_BUDGET";
     case SPG_POLICY_DENY_INVALID_REQUEST:
         return "SPG_POLICY_DENY_INVALID_REQUEST";
+    case SPG_POLICY_DENY_UNMANAGED_PROCESS:
+        return "SPG_POLICY_DENY_UNMANAGED_PROCESS";
+    case SPG_POLICY_DENY_PROCESS_PROTECTED:
+        return "SPG_POLICY_DENY_PROCESS_PROTECTED";
+    case SPG_POLICY_DENY_PROCESS_IDENTITY:
+        return "SPG_POLICY_DENY_PROCESS_IDENTITY";
     default:
         return "SPG_POLICY_DENY_UNKNOWN";
     }

--- a/src/policy/policy_config.c
+++ b/src/policy/policy_config.c
@@ -16,7 +16,7 @@ static const struct spg_schema_field_rule policy_fields[] = {
     {.name       = "budgets",
      .value_kind = SPG_SCHEMA_VALUE_LIST,
      .min_values = 7u,
-     .max_values = 8u, /* 7 required + optional memory_actions */
+     .max_values = 9u, /* 7 required + optional memory/machine_actions */
      .required   = true,
      .unique     = true},
     {.name       = "capability",
@@ -140,6 +140,10 @@ static enum spg_status parse_cap_kind(
     }
     if (spg_sexpr_span_eq_cstr(input_n, input, span, "memory")) {
         *out = SPG_POLICY_CAP_MEMORY;
+        return SPG_OK;
+    }
+    if (spg_sexpr_span_eq_cstr(input_n, input, span, "machine_process")) {
+        *out = SPG_POLICY_CAP_MACHINE_PROCESS;
         return SPG_OK;
     }
     return SPG_E_SCHEMA;

--- a/src/policy/policy_gate.c
+++ b/src/policy/policy_gate.c
@@ -12,7 +12,8 @@ static bool span_eq_texts(const size_t left_n, const char left[],
                           const size_t right_n, const char right[],
                           const struct spg_text_span right_span) {
     if (left == nullptr || right == nullptr ||
-        !spg_sexpr_span_valid(left_n, left_span) || !spg_sexpr_span_valid(right_n, right_span) ||
+        !spg_sexpr_span_valid(left_n, left_span) ||
+        !spg_sexpr_span_valid(right_n, right_span) ||
         left_span.length != right_span.length) {
         return false;
     }
@@ -20,10 +21,10 @@ static bool span_eq_texts(const size_t left_n, const char left[],
                   left_span.length) == 0;
 }
 
-static bool resolve_capability_span(
-    const struct spg_policy_gate_state *state,
-    const struct spg_recommendation *recommendation,
-    struct spg_text_span *out_policy_span) {
+static bool
+resolve_capability_span(const struct spg_policy_gate_state *state,
+                        const struct spg_recommendation    *recommendation,
+                        struct spg_text_span               *out_policy_span) {
     if (state == nullptr || recommendation == nullptr ||
         out_policy_span == nullptr || state->policy == nullptr) {
         return false;
@@ -33,9 +34,8 @@ static bool resolve_capability_span(
             state->policy->capabilities[i].name;
         if (span_eq_texts(state->recommendation_text_n,
                           state->recommendation_text,
-                          recommendation->capability,
-                          state->policy_text_n, state->policy_text,
-                          candidate)) {
+                          recommendation->capability, state->policy_text_n,
+                          state->policy_text, candidate)) {
             *out_policy_span = candidate;
             return true;
         }
@@ -43,7 +43,8 @@ static bool resolve_capability_span(
     return false;
 }
 
-static const char *decision_kind_name(const enum spg_policy_decision_kind kind) {
+static const char *
+decision_kind_name(const enum spg_policy_decision_kind kind) {
     switch (kind) {
     case SPG_POLICY_DECISION_ALLOW:
         return "allow";
@@ -53,11 +54,11 @@ static const char *decision_kind_name(const enum spg_policy_decision_kind kind) 
     return "unknown";
 }
 
-static enum spg_status render_payload(
-    const struct spg_recommendation *recommendation,
-    const struct spg_policy_decision *decision,
-    const struct spg_policy_gate_workspace *workspace,
-    struct spg_policy_gate_result *result) {
+static enum spg_status
+render_payload(const struct spg_recommendation        *recommendation,
+               const struct spg_policy_decision       *decision,
+               const struct spg_policy_gate_workspace *workspace,
+               struct spg_policy_gate_result          *result) {
     struct spg_sexpr_writer writer;
     spg_sexpr_writer_init(&writer, workspace->payload_capacity,
                           workspace->payload);
@@ -65,8 +66,8 @@ static enum spg_status render_payload(
     enum spg_status status =
         spg_sexpr_writer_append_text(&writer, "(policy_decision (decision ");
     if (status == SPG_OK) {
-        status = spg_sexpr_writer_append_text(&writer,
-                                              decision_kind_name(decision->kind));
+        status = spg_sexpr_writer_append_text(
+            &writer, decision_kind_name(decision->kind));
     }
     if (status == SPG_OK) {
         status = spg_sexpr_writer_append_text(&writer, ") (deny_reason ");
@@ -144,17 +145,17 @@ static enum spg_status journal_decision(
         (const uint8_t *)workspace->payload, out_sequence);
 }
 
-static enum spg_status add_deny_graph(
-    struct spg_graph *graph, const struct spg_policy_gate_config *config,
-    struct spg_policy_gate_result *result) {
+static enum spg_status
+add_deny_graph(struct spg_graph                    *graph,
+               const struct spg_policy_gate_config *config,
+               struct spg_policy_gate_result       *result) {
     if (graph == nullptr || config == nullptr || result == nullptr) {
         return SPG_E_INVALID_ARG;
     }
     struct spg_node_id policy_node = {};
-    enum spg_status status = spg_graph_add_node(
+    enum spg_status    status      = spg_graph_add_node(
         graph, SPG_GRAPH_NODE_POLICY_DECISION, config->actor_id,
-        (struct spg_text_span){.offset = 0u,
-                               .length = result->payload_used},
+        (struct spg_text_span){.offset = 0u, .length = result->payload_used},
         &policy_node);
     if (status != SPG_OK) {
         return status;
@@ -166,13 +167,13 @@ static enum spg_status add_deny_graph(
     if (status != SPG_OK) {
         return status;
     }
-    status = spg_graph_set_scores(
-        graph, policy_node,
-        (struct spg_graph_scores){.confidence    = 1.0f,
-                                  .utility       = 0.0f,
-                                  .risk          = 0.0f,
-                                  .novelty       = 0.0f,
-                                  .cost_estimate = 0.0f});
+    status =
+        spg_graph_set_scores(graph, policy_node,
+                             (struct spg_graph_scores){.confidence    = 1.0f,
+                                                       .utility       = 0.0f,
+                                                       .risk          = 0.0f,
+                                                       .novelty       = 0.0f,
+                                                       .cost_estimate = 0.0f});
     if (status != SPG_OK) {
         return status;
     }
@@ -182,9 +183,9 @@ static enum spg_status add_deny_graph(
             return SPG_E_INVALID_ARG;
         }
         struct spg_edge_id edge = {};
-        status = spg_graph_add_edge(graph, SPG_GRAPH_EDGE_BLOCKED_BY_POLICY,
-                                    config->recommendation_node, policy_node,
-                                    &edge);
+        status =
+            spg_graph_add_edge(graph, SPG_GRAPH_EDGE_BLOCKED_BY_POLICY,
+                               config->recommendation_node, policy_node, &edge);
         if (status != SPG_OK) {
             return status;
         }
@@ -194,28 +195,107 @@ static enum spg_status add_deny_graph(
     return SPG_OK;
 }
 
-enum spg_status spg_policy_gate_step(
-    const struct spg_policy_gate_state *state,
-    const struct spg_policy_gate_config *config,
-    const struct spg_recommendation *recommendation,
-    const struct spg_policy_gate_workspace *workspace,
-    struct spg_policy_gate_result *result) {
+/* Machine actions carry a target: a profile id, never a pid. Resolve it into
+ * the span of text the recommendation used. */
+static bool target_text(const struct spg_policy_gate_state *state,
+                        const struct spg_recommendation    *rec,
+                        char target[static SPG_PROCESS_ID_CAP]) {
+    const struct spg_text_span span = rec->target;
+    if (span.length == 0u || span.length + 1u > SPG_PROCESS_ID_CAP ||
+        span.offset + span.length > state->recommendation_text_n) {
+        return false;
+    }
+    memcpy(target, state->recommendation_text + span.offset, span.length);
+    target[span.length] = '\0';
+    return true;
+}
+
+/* Decide a machine action on process semantics alone; budget and capability
+ * are still the general path's job.
+ *
+ * Order matters for what the journal ends up saying. "unmanaged" and
+ * "protected" are different findings: the first means the operator never
+ * declared this process, the second means they declared it off limits. */
+static enum spg_policy_deny_reason
+machine_denial(const struct spg_policy_gate_state *state,
+               const struct spg_recommendation    *rec) {
+    if (rec->action_kind != SPG_ACTION_MACHINE_PAUSE &&
+        rec->action_kind != SPG_ACTION_MACHINE_RESUME) {
+        return SPG_POLICY_DENY_NONE;
+    }
+    if (state->profile == nullptr || state->machine == nullptr) {
+        /* No profile configured means nothing is managed, and nothing
+         * unmanaged is actionable. */
+        return SPG_POLICY_DENY_UNMANAGED_PROCESS;
+    }
+    char target[SPG_PROCESS_ID_CAP];
+    if (!target_text(state, rec, target)) {
+        return SPG_POLICY_DENY_INVALID_REQUEST;
+    }
+
+    const struct spg_process_profile_entry *entry = nullptr;
+    for (size_t i = 0u; i < state->profile->count; i += 1u) {
+        if (strcmp(state->profile->entries[i].id, target) == 0) {
+            entry = &state->profile->entries[i];
+            break;
+        }
+    }
+    if (entry == nullptr) {
+        return SPG_POLICY_DENY_UNMANAGED_PROCESS;
+    }
+
+    /* Pausing needs permission. Resuming does not: it can only restore the
+     * state the machine had before we touched it, and denying it would leave a
+     * process we stopped stopped. */
+    if (rec->action_kind == SPG_ACTION_MACHINE_PAUSE && !entry->may_pause) {
+        return SPG_POLICY_DENY_PROCESS_PROTECTED;
+    }
+
+    /* The target must be a process we actually observed this tick. Acting on
+     * something that is not in the snapshot means acting on a guess. */
+    for (size_t i = 0u; i < state->machine->n_processes; i += 1u) {
+        if (strcmp(state->machine->processes[i].profile_id, target) == 0) {
+            return SPG_POLICY_DENY_NONE;
+        }
+    }
+    return SPG_POLICY_DENY_PROCESS_IDENTITY;
+}
+
+enum spg_status
+spg_policy_gate_step(const struct spg_policy_gate_state     *state,
+                     const struct spg_policy_gate_config    *config,
+                     const struct spg_recommendation        *recommendation,
+                     const struct spg_policy_gate_workspace *workspace,
+                     struct spg_policy_gate_result          *result) {
     if (state == nullptr || config == nullptr || recommendation == nullptr ||
         !workspace_valid(workspace) || result == nullptr ||
-        state->policy_text == nullptr || state->recommendation_text == nullptr ||
-        state->policy == nullptr || state->usage == nullptr ||
-        state->policy_text_n == 0u || state->recommendation_text_n == 0u ||
+        state->policy_text == nullptr ||
+        state->recommendation_text == nullptr || state->policy == nullptr ||
+        state->usage == nullptr || state->policy_text_n == 0u ||
+        state->recommendation_text_n == 0u ||
         recommendation->state != SPG_RECOMMENDATION_VALID ||
         (config->write_journal && state->journal == nullptr) ||
         (config->update_graph_on_deny && state->graph == nullptr)) {
         return SPG_E_INVALID_ARG;
     }
 
-    *result = (struct spg_policy_gate_result){};
+    *result               = (struct spg_policy_gate_result){};
     workspace->payload[0] = '\0';
 
-    struct spg_action_request request = recommendation->action;
-    if (!resolve_capability_span(state, recommendation, &request.capability)) {
+    struct spg_action_request         request = recommendation->action;
+    const enum spg_policy_deny_reason machine_reason =
+        machine_denial(state, recommendation);
+    if (machine_reason != SPG_POLICY_DENY_NONE) {
+        /* Decided before capability and budget on purpose: a process the
+         * operator protected must not consume budget to be refused, and the
+         * journal should say why it was refused, not that we ran out. */
+        result->decision = (struct spg_policy_decision){
+            .kind             = SPG_POLICY_DECISION_DENY,
+            .deny_reason      = machine_reason,
+            .capability_index = SIZE_MAX,
+        };
+    } else if (!resolve_capability_span(state, recommendation,
+                                        &request.capability)) {
         result->decision = (struct spg_policy_decision){
             .kind             = SPG_POLICY_DECISION_DENY,
             .deny_reason      = SPG_POLICY_DENY_UNKNOWN_CAPABILITY,
@@ -223,8 +303,8 @@ enum spg_status spg_policy_gate_step(
         };
     } else {
         enum spg_status status = spg_policy_decide(
-        state->policy_text_n, state->policy_text, state->policy, state->usage,
-        &request, &result->decision);
+            state->policy_text_n, state->policy_text, state->policy,
+            state->usage, &request, &result->decision);
         if (status != SPG_OK) {
             return status;
         }
@@ -237,9 +317,9 @@ enum spg_status spg_policy_gate_step(
     }
 
     if (config->write_journal) {
-        status = journal_decision(
-            state->journal, config->timestamp_ns, config->parent_sequence,
-            &result->decision, workspace, result, &result->policy_sequence);
+        status = journal_decision(state->journal, config->timestamp_ns,
+                                  config->parent_sequence, &result->decision,
+                                  workspace, result, &result->policy_sequence);
         if (status != SPG_OK) {
             return status;
         }

--- a/src/run/agent_loop.c
+++ b/src/run/agent_loop.c
@@ -54,6 +54,10 @@ static void accumulate_usage(struct spg_policy_usage *usage,
         add_u64(&usage->consumed.memory_actions,
                 result->recommendation.action.cost);
     }
+    if (spg_orchestrator_machine_executed(result)) {
+        add_u64(&usage->consumed.machine_actions,
+                result->recommendation.action.cost);
+    }
     if (spg_orchestrator_shell_executed(result)) {
         add_u64(&usage->consumed.shell_actions,
                 result->recommendation.action.cost);

--- a/src/run/agent_run.c
+++ b/src/run/agent_run.c
@@ -91,6 +91,7 @@ enum spg_status spg_agent_run(const struct spg_agent_run_inputs *inputs,
         .directive     = directive,
         .machine       = inputs->machine,
         .profile       = inputs->profile,
+        .pause_ledger  = inputs->pause_ledger,
     };
 
     const size_t refs = config->context_refs > 0u ? config->context_refs : 8u;

--- a/src/run/agent_run.c
+++ b/src/run/agent_run.c
@@ -90,6 +90,7 @@ enum spg_status spg_agent_run(const struct spg_agent_run_inputs *inputs,
         .goal          = inputs->goal,
         .directive     = directive,
         .machine       = inputs->machine,
+        .profile       = inputs->profile,
     };
 
     const size_t refs = config->context_refs > 0u ? config->context_refs : 8u;

--- a/src/run/orchestrator.c
+++ b/src/run/orchestrator.c
@@ -343,6 +343,7 @@ spg_orchestrator_tick(struct spg_orchestrator_state           *state,
         const struct spg_machine_executor_state machine_state = {
             .machine = state->machine,
             .journal = state->journal,
+            .ledger  = state->pause_ledger,
         };
         const struct spg_machine_executor_config machine_config = {
             .actor_id          = config->actor_id,

--- a/src/run/orchestrator.c
+++ b/src/run/orchestrator.c
@@ -2,7 +2,8 @@
 
 #include <string.h>
 
-static bool workspace_valid(const struct spg_orchestrator_workspace *workspace) {
+static bool
+workspace_valid(const struct spg_orchestrator_workspace *workspace) {
     if (workspace == nullptr || workspace->policy_payload == nullptr ||
         workspace->policy_payload_capacity == 0u ||
         workspace->sim_payload == nullptr ||
@@ -16,11 +17,11 @@ static bool workspace_valid(const struct spg_orchestrator_workspace *workspace) 
     return true;
 }
 
-static enum spg_status journal_finish(
-    struct spg_orchestrator_state *state,
-    const struct spg_orchestrator_config *config,
-    const struct spg_orchestrator_workspace *workspace,
-    const struct spg_orchestrator_result *result) {
+static enum spg_status
+journal_finish(struct spg_orchestrator_state           *state,
+               const struct spg_orchestrator_config    *config,
+               const struct spg_orchestrator_workspace *workspace,
+               const struct spg_orchestrator_result    *result) {
     if (!config->write_journal) {
         return SPG_OK;
     }
@@ -31,11 +32,10 @@ static enum spg_status journal_finish(
     spg_sexpr_writer_init(&writer, workspace->policy_payload_capacity,
                           workspace->policy_payload);
     (void)spg_sexpr_writer_append_text(&writer, "(finish)");
-    const uint64_t parent_sequence =
-        result->actor.model_output_sequence != 0u
-            ? result->actor.model_output_sequence
-            : config->parent_sequence;
-    uint64_t sequence = 0u;
+    const uint64_t parent_sequence = result->actor.model_output_sequence != 0u
+                                         ? result->actor.model_output_sequence
+                                         : config->parent_sequence;
+    uint64_t       sequence        = 0u;
     return spg_journal_writer_append(
         state->journal, config->timestamp_ns, parent_sequence,
         SPG_JOURNAL_EVENT_RESULT, SPG_OK, writer.used,
@@ -43,10 +43,10 @@ static enum spg_status journal_finish(
 }
 
 static enum spg_status journal_recommendation_rejected(
-    struct spg_orchestrator_state *state,
-    const struct spg_orchestrator_config *config,
+    struct spg_orchestrator_state           *state,
+    const struct spg_orchestrator_config    *config,
     const struct spg_orchestrator_workspace *workspace,
-    const struct spg_orchestrator_result *result) {
+    const struct spg_orchestrator_result    *result) {
     if (!config->write_journal) {
         return SPG_OK;
     }
@@ -65,22 +65,21 @@ static enum spg_status journal_recommendation_rejected(
         &writer, spg_recommendation_reject_reason_to_string(
                      result->recommendation.reject_reason));
     (void)spg_sexpr_writer_append_text(&writer, "))");
-    const size_t          payload_n    = writer.used;
-    const enum spg_status event_status = writer.truncated ? SPG_E_LIMIT
-                                                          : SPG_E_SCHEMA;
-    uint64_t sequence = 0u;
-    const uint64_t parent_sequence =
-        result->actor.model_output_sequence != 0u
-            ? result->actor.model_output_sequence
-            : config->parent_sequence;
+    const size_t          payload_n = writer.used;
+    const enum spg_status event_status =
+        writer.truncated ? SPG_E_LIMIT : SPG_E_SCHEMA;
+    uint64_t       sequence        = 0u;
+    const uint64_t parent_sequence = result->actor.model_output_sequence != 0u
+                                         ? result->actor.model_output_sequence
+                                         : config->parent_sequence;
     return spg_journal_writer_append(
         state->journal, config->timestamp_ns, parent_sequence,
         SPG_JOURNAL_EVENT_ERROR, event_status, payload_n,
         (const uint8_t *)workspace->policy_payload, &sequence);
 }
 
-const char *spg_orchestrator_stage_to_string(
-    const enum spg_orchestrator_stage stage) {
+const char *
+spg_orchestrator_stage_to_string(const enum spg_orchestrator_stage stage) {
     switch (stage) {
     case SPG_ORCHESTRATOR_STAGE_NOT_STARTED:
         return "not_started";
@@ -98,32 +97,34 @@ const char *spg_orchestrator_stage_to_string(
         return "memory_executed";
     case SPG_ORCHESTRATOR_STAGE_SHELL_EXECUTED:
         return "shell_executed";
+    case SPG_ORCHESTRATOR_STAGE_MACHINE_EXECUTED:
+        return "machine_executed";
     }
     return "unknown";
 }
 
-/* The derived predicates treat `stage` as a progress counter. `policy_evaluated`
- * is "the gate ran" = stage >= POLICY_GATED, so every pre-gate stage (incl. the
- * terminal RECOMMENDATION_REJECTED and FINISHED) must sort below POLICY_GATED
- * and every executed stage at or above it. `recommendation_valid` additionally
- * counts FINISHED (a valid recommendation that bypasses the gate). Pin the
- * ordering so a future reorder cannot silently flip the predicates. */
-static_assert(SPG_ORCHESTRATOR_STAGE_NOT_STARTED <
-                      SPG_ORCHESTRATOR_STAGE_POLICY_GATED &&
-                  SPG_ORCHESTRATOR_STAGE_ACTOR_DONE <
-                      SPG_ORCHESTRATOR_STAGE_POLICY_GATED &&
-                  SPG_ORCHESTRATOR_STAGE_RECOMMENDATION_REJECTED <
-                      SPG_ORCHESTRATOR_STAGE_POLICY_GATED &&
-                  SPG_ORCHESTRATOR_STAGE_FINISHED <
-                      SPG_ORCHESTRATOR_STAGE_POLICY_GATED &&
-                  SPG_ORCHESTRATOR_STAGE_POLICY_GATED <=
-                      SPG_ORCHESTRATOR_STAGE_SIM_EXECUTED &&
-                  SPG_ORCHESTRATOR_STAGE_POLICY_GATED <=
-                      SPG_ORCHESTRATOR_STAGE_MEMORY_EXECUTED &&
-                  SPG_ORCHESTRATOR_STAGE_POLICY_GATED <=
-                      SPG_ORCHESTRATOR_STAGE_SHELL_EXECUTED,
-              "orchestrator stage ordering: pre-gate/rejected/finished stages "
-              "must sort below POLICY_GATED and executed stages at or above it");
+/* The derived predicates treat `stage` as a progress counter.
+ * `policy_evaluated` is "the gate ran" = stage >= POLICY_GATED, so every
+ * pre-gate stage (incl. the terminal RECOMMENDATION_REJECTED and FINISHED) must
+ * sort below POLICY_GATED and every executed stage at or above it.
+ * `recommendation_valid` additionally counts FINISHED (a valid recommendation
+ * that bypasses the gate). Pin the ordering so a future reorder cannot silently
+ * flip the predicates. */
+static_assert(
+    SPG_ORCHESTRATOR_STAGE_NOT_STARTED < SPG_ORCHESTRATOR_STAGE_POLICY_GATED &&
+        SPG_ORCHESTRATOR_STAGE_ACTOR_DONE <
+            SPG_ORCHESTRATOR_STAGE_POLICY_GATED &&
+        SPG_ORCHESTRATOR_STAGE_RECOMMENDATION_REJECTED <
+            SPG_ORCHESTRATOR_STAGE_POLICY_GATED &&
+        SPG_ORCHESTRATOR_STAGE_FINISHED < SPG_ORCHESTRATOR_STAGE_POLICY_GATED &&
+        SPG_ORCHESTRATOR_STAGE_POLICY_GATED <=
+            SPG_ORCHESTRATOR_STAGE_SIM_EXECUTED &&
+        SPG_ORCHESTRATOR_STAGE_POLICY_GATED <=
+            SPG_ORCHESTRATOR_STAGE_MEMORY_EXECUTED &&
+        SPG_ORCHESTRATOR_STAGE_POLICY_GATED <=
+            SPG_ORCHESTRATOR_STAGE_SHELL_EXECUTED,
+    "orchestrator stage ordering: pre-gate/rejected/finished stages "
+    "must sort below POLICY_GATED and executed stages at or above it");
 
 bool spg_orchestrator_recommendation_valid(
     const struct spg_orchestrator_result *result) {
@@ -151,15 +152,20 @@ bool spg_orchestrator_shell_executed(
     return result->stage == SPG_ORCHESTRATOR_STAGE_SHELL_EXECUTED;
 }
 
+bool spg_orchestrator_machine_executed(
+    const struct spg_orchestrator_result *result) {
+    return result->stage == SPG_ORCHESTRATOR_STAGE_MACHINE_EXECUTED;
+}
+
 bool spg_orchestrator_finished(const struct spg_orchestrator_result *result) {
     return result->stage == SPG_ORCHESTRATOR_STAGE_FINISHED;
 }
 
-enum spg_status spg_orchestrator_tick(
-    struct spg_orchestrator_state *state,
-    const struct spg_orchestrator_config *config,
-    const struct spg_orchestrator_workspace *workspace,
-    struct spg_orchestrator_result *result) {
+enum spg_status
+spg_orchestrator_tick(struct spg_orchestrator_state           *state,
+                      const struct spg_orchestrator_config    *config,
+                      const struct spg_orchestrator_workspace *workspace,
+                      struct spg_orchestrator_result          *result) {
     if (state == nullptr || config == nullptr || !workspace_valid(workspace) ||
         result == nullptr || state->model == nullptr ||
         state->policy == nullptr || state->usage == nullptr ||
@@ -197,7 +203,7 @@ enum spg_status spg_orchestrator_tick(
         .memory_text_n        = state->memory_text_n,
         .memory_text          = state->memory_text,
         .memory_index         = memory_index,
-        .observation        = state->observation,
+        .observation          = state->observation,
         .exemplars            = state->exemplars,
         .goal                 = state->goal,
         .directive            = state->directive,
@@ -214,8 +220,8 @@ enum spg_status spg_orchestrator_tick(
         .update_graph        = config->update_graph,
         .update_memory       = config->update_memory,
     };
-    enum spg_status status = spg_actor_step(
-        &actor_state, &actor_config, &workspace->actor, &result->actor);
+    enum spg_status status = spg_actor_step(&actor_state, &actor_config,
+                                            &workspace->actor, &result->actor);
     if (status != SPG_OK) {
         return status;
     }
@@ -233,10 +239,12 @@ enum spg_status spg_orchestrator_tick(
     }
     if (result->recommendation.state != SPG_RECOMMENDATION_VALID) {
         result->stage = SPG_ORCHESTRATOR_STAGE_RECOMMENDATION_REJECTED;
-        return journal_recommendation_rejected(state, config, workspace, result);
+        return journal_recommendation_rejected(state, config, workspace,
+                                               result);
     }
     if (result->recommendation.action_kind == SPG_ACTION_FINISH) {
-        /* Control action: terminate the loop without a policy gate or executor. */
+        /* Control action: terminate the loop without a policy gate or executor.
+         */
         result->stage = SPG_ORCHESTRATOR_STAGE_FINISHED;
         return journal_finish(state, config, workspace, result);
     }
@@ -254,6 +262,10 @@ enum spg_status spg_orchestrator_tick(
         .usage                 = state->usage,
         .journal               = state->journal,
         .graph                 = state->graph,
+        /* Phase 6: the gate decides machine actions on process semantics, so
+         * it needs the profile and the snapshot the decision is about. */
+        .profile               = state->profile,
+        .machine               = state->machine,
     };
     const struct spg_policy_gate_config policy_config = {
         .actor_id                = config->actor_id,
@@ -310,6 +322,48 @@ enum spg_status spg_orchestrator_tick(
             return status;
         }
         result->stage = SPG_ORCHESTRATOR_STAGE_MEMORY_EXECUTED;
+        return SPG_OK;
+    }
+
+    if (result->recommendation.action_kind == SPG_ACTION_MACHINE_PAUSE ||
+        result->recommendation.action_kind == SPG_ACTION_MACHINE_RESUME) {
+        /* The gate already resolved the target against the profile and the
+         * snapshot; the executor resolves it again and re-checks identity
+         * before the syscall. Two resolutions on purpose: the first decides,
+         * the second acts, and the gap between them is exactly where a pid
+         * gets recycled. */
+        char                       target[SPG_PROCESS_ID_CAP] = {};
+        const struct spg_text_span tspan = result->recommendation.target;
+        if (tspan.length == 0u || tspan.length + 1u > sizeof target ||
+            tspan.offset + tspan.length > result->actor.model_output_n) {
+            return SPG_E_SCHEMA;
+        }
+        memcpy(target, workspace->actor.model_output + tspan.offset,
+               tspan.length);
+        const struct spg_machine_executor_state machine_state = {
+            .machine = state->machine,
+            .journal = state->journal,
+        };
+        const struct spg_machine_executor_config machine_config = {
+            .actor_id          = config->actor_id,
+            .timestamp_ns      = config->timestamp_ns,
+            .parent_sequence   = result->policy_gate.policy_sequence != 0u
+                                     ? result->policy_gate.policy_sequence
+                                     : policy_config.parent_sequence,
+            .write_journal     = config->write_journal,
+            .execution_enabled = config->execution_enabled,
+        };
+        const struct spg_machine_executor_workspace machine_workspace = {
+            .payload_capacity = workspace->sim_payload_capacity,
+            .payload          = workspace->sim_payload,
+        };
+        status = spg_machine_executor_step(
+            &machine_state, &machine_config, result->recommendation.action_kind,
+            target, &machine_workspace, &result->machine_action);
+        if (status != SPG_OK) {
+            return status;
+        }
+        result->stage = SPG_ORCHESTRATOR_STAGE_MACHINE_EXECUTED;
         return SPG_OK;
     }
 
@@ -386,10 +440,9 @@ enum spg_status spg_orchestrator_tick(
         .has_recommendation_node = result->actor.has_recommendation_node,
         .recommendation_node     = result->actor.recommendation_node,
     };
-    status = spg_sim_executor_step(&sim_state, &sim_config,
-                                   &result->recommendation,
-                                   &result->policy_gate.decision,
-                                   &sim_workspace, &result->sim);
+    status = spg_sim_executor_step(
+        &sim_state, &sim_config, &result->recommendation,
+        &result->policy_gate.decision, &sim_workspace, &result->sim);
     if (status != SPG_OK) {
         return status;
     }
@@ -400,7 +453,7 @@ enum spg_status spg_orchestrator_tick(
     if (workspace->observation_buf != nullptr &&
         workspace->observation_capacity > 0u) {
         const size_t cap = workspace->observation_capacity;
-        size_t       n   = 0u; /* bounded strlen (no strnlen: strict-libc hides it) */
+        size_t n = 0u; /* bounded strlen (no strnlen: strict-libc hides it) */
         while (n + 1u < cap && workspace->sim_payload[n] != '\0') {
             n += 1u;
         }

--- a/test/machine_action_probe.c
+++ b/test/machine_action_probe.c
@@ -1,0 +1,136 @@
+/* Drives the machine executor against a real child process.
+ *
+ * Not a test_*.c file on purpose: it forks, and the Makefile's wildcard would
+ * run it on every platform. The shell wrapper decides when it is meaningful.
+ *
+ * What it proves that a fixture cannot: SIGSTOP reaches the intended process
+ * (its state in /proc becomes T), SIGCONT brings it back, and a snapshot whose
+ * start identity no longer matches produces no signal at all. */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include "geistshell/machine_executor.h"
+#include "geistshell/machine_fixture.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(__linux__)
+#    include <signal.h>
+#    include <time.h>
+#    include <sys/wait.h>
+#    include <unistd.h>
+
+static bool read_identity(const uint64_t pid, struct spg_process_sample *out) {
+    char path[64];
+    (void)snprintf(path, sizeof path, "/proc/%llu/stat",
+                   (unsigned long long)pid);
+    FILE *f = fopen(path, "rb");
+    if (f == nullptr) {
+        return false;
+    }
+    char         buf[2048];
+    const size_t n = fread(buf, 1u, sizeof buf, f);
+    (void)fclose(f);
+    return n > 0u && spg_process_parse_stat(n, buf, 4096u, out) == SPG_OK;
+}
+
+static char process_state(const uint64_t pid) {
+    struct spg_process_sample s = {};
+    return read_identity(pid, &s) ? s.state : '?';
+}
+
+static enum spg_machine_exec_outcome run(const struct spg_machine_state *m,
+                                         const enum spg_action_kind      kind) {
+    char                                     payload[512];
+    const struct spg_machine_executor_state  st  = {.machine = m};
+    const struct spg_machine_executor_config cfg = {.actor_id          = 1u,
+                                                    .execution_enabled = true};
+    const struct spg_machine_executor_workspace ws = {
+        .payload_capacity = sizeof payload, .payload = payload};
+    struct spg_machine_executor_result r = {};
+    if (spg_machine_executor_step(&st, &cfg, kind, "batch_job", &ws, &r) !=
+        SPG_OK) {
+        return SPG_MACHINE_EXEC_REFUSED;
+    }
+    return r.outcome;
+}
+
+int main(void) {
+    const pid_t child = fork();
+    if (child < 0) {
+        perror("fork");
+        return 1;
+    }
+    if (child == 0) {
+        for (;;) {
+            (void)pause();
+        }
+    }
+    /* Give the child a moment to exist in /proc. */
+    struct timespec ts = {.tv_sec = 0, .tv_nsec = 100000000};
+    (void)nanosleep(&ts, nullptr);
+
+    struct spg_machine_state m = {.n_processes = 1u};
+    if (!read_identity((uint64_t)child, &m.processes[0])) {
+        printf("FAIL: cannot read child identity\n");
+        (void)kill(child, SIGKILL);
+        return 1;
+    }
+    memcpy(m.processes[0].profile_id, "batch_job", sizeof "batch_job");
+
+    int rc = 0;
+    if (run(&m, SPG_ACTION_MACHINE_PAUSE) != SPG_MACHINE_EXEC_OK) {
+        printf("FAIL: pause was not executed\n");
+        rc = 1;
+    }
+    (void)nanosleep(&ts, nullptr);
+    if (process_state((uint64_t)child) != 'T') {
+        printf("FAIL: child is '%c', expected 'T' (stopped)\n",
+               process_state((uint64_t)child));
+        rc = 1;
+    }
+
+    if (run(&m, SPG_ACTION_MACHINE_RESUME) != SPG_MACHINE_EXEC_OK) {
+        printf("FAIL: resume was not executed\n");
+        rc = 1;
+    }
+    (void)nanosleep(&ts, nullptr);
+    if (process_state((uint64_t)child) == 'T') {
+        printf("FAIL: child still stopped after resume\n");
+        rc = 1;
+    }
+
+    /* THE case. Same pid, a start identity that no longer matches: the
+     * executor must recognise it is not the process that was observed and send
+     * nothing at all. If this ever regresses, the agent signals strangers. */
+    struct spg_machine_state stale = m;
+    stale.processes[0].start_identity += 1u;
+    const enum spg_machine_exec_outcome o =
+        run(&stale, SPG_ACTION_MACHINE_PAUSE);
+    if (o != SPG_MACHINE_EXEC_IDENTITY_CHANGED) {
+        printf("FAIL: stale identity gave '%s', expected identity_changed\n",
+               spg_machine_exec_outcome_to_string(o));
+        rc = 1;
+    }
+    if (process_state((uint64_t)child) == 'T') {
+        printf("FAIL: the child was stopped despite the identity mismatch\n");
+        rc = 1;
+    }
+
+    (void)kill(child, SIGKILL);
+    int status = 0;
+    (void)waitpid(child, &status, 0);
+    if (rc == 0) {
+        printf("machine_action_probe: pause/resume/identity all correct\n");
+    }
+    return rc;
+}
+
+#else
+int main(void) {
+    printf("machine_action_probe: no /proc, nothing to prove here\n");
+    return 0;
+}
+#endif

--- a/test/machine_action_probe.c
+++ b/test/machine_action_probe.c
@@ -160,6 +160,83 @@ static int recovery_scenario(void) {
     return rc;
 }
 
+/* The window the ledger cannot cover: the agent is SIGKILLed while a process
+ * is paused. Nothing in the dying process gets to run, so the only thing that
+ * can help is something that was already running — the guardian.
+ *
+ * Modelled by forking a stand-in agent that pauses a target and then dies
+ * without releasing. If the guardian works, the target is running again a
+ * moment later, with no next agent start involved. */
+static int guardian_scenario(void) {
+    const pid_t target = fork();
+    if (target < 0) {
+        return 1;
+    }
+    if (target == 0) {
+        for (;;) {
+            (void)pause();
+        }
+    }
+    struct timespec ts = {.tv_sec = 0, .tv_nsec = 150000000};
+    (void)nanosleep(&ts, nullptr);
+
+    const pid_t agent = fork();
+    if (agent < 0) {
+        (void)kill(target, SIGKILL);
+        return 1;
+    }
+    if (agent == 0) {
+        /* The stand-in agent: pause, then hang. It will be killed. */
+        struct spg_machine_state m = {.n_processes = 1u};
+        if (!read_identity((uint64_t)target, &m.processes[0])) {
+            _exit(1);
+        }
+        memcpy(m.processes[0].profile_id, "batch_job", sizeof "batch_job");
+        char                                     payload[512];
+        struct spg_machine_pause_ledger          ledger = {};
+        const struct spg_machine_executor_state  st     = {.machine = &m,
+                                                           .ledger  = &ledger};
+        const struct spg_machine_executor_config cfg    = {
+            .actor_id = 1u, .execution_enabled = true};
+        const struct spg_machine_executor_workspace ws = {
+            .payload_capacity = sizeof payload, .payload = payload};
+        struct spg_machine_executor_result r = {};
+        if (spg_machine_executor_step(&st, &cfg, SPG_ACTION_MACHINE_PAUSE,
+                                      "batch_job", &ws, &r) != SPG_OK ||
+            r.outcome != SPG_MACHINE_EXEC_OK) {
+            _exit(1);
+        }
+        for (;;) {
+            (void)pause();
+        }
+    }
+
+    (void)nanosleep(&ts, nullptr);
+    int rc = 0;
+    if (process_state((uint64_t)target) != 'T') {
+        printf("FAIL: guardian setup did not pause the target\n");
+        rc = 1;
+    }
+    /* The kill the ledger cannot survive. */
+    (void)kill(agent, SIGKILL);
+    int status = 0;
+    (void)waitpid(agent, &status, 0);
+    (void)nanosleep(&ts, nullptr);
+    (void)nanosleep(&ts, nullptr);
+
+    if (process_state((uint64_t)target) == 'T') {
+        printf("FAIL: target still stopped after the agent was killed\n");
+        rc = 1;
+    }
+    (void)kill(target, SIGKILL);
+    (void)waitpid(target, &status, 0);
+    if (rc == 0) {
+        printf("machine_action_probe: guardian released a killed agent's "
+               "pause\n");
+    }
+    return rc;
+}
+
 int main(void) {
     const pid_t child = fork();
     if (child < 0) {
@@ -229,7 +306,11 @@ int main(void) {
         return rc;
     }
     printf("machine_action_probe: pause/resume/identity all correct\n");
-    return recovery_scenario();
+    rc = recovery_scenario();
+    if (rc != 0) {
+        return rc;
+    }
+    return guardian_scenario();
 }
 
 #else

--- a/test/machine_action_probe.c
+++ b/test/machine_action_probe.c
@@ -18,8 +18,8 @@
 
 #if defined(__linux__)
 #    include <signal.h>
-#    include <time.h>
 #    include <sys/wait.h>
+#    include <time.h>
 #    include <unistd.h>
 
 static bool read_identity(const uint64_t pid, struct spg_process_sample *out) {
@@ -41,10 +41,13 @@ static char process_state(const uint64_t pid) {
     return read_identity(pid, &s) ? s.state : '?';
 }
 
+static struct spg_machine_pause_ledger probe_ledger;
+
 static enum spg_machine_exec_outcome run(const struct spg_machine_state *m,
                                          const enum spg_action_kind      kind) {
     char                                     payload[512];
-    const struct spg_machine_executor_state  st  = {.machine = m};
+    const struct spg_machine_executor_state  st  = {.machine = m,
+                                                    .ledger  = &probe_ledger};
     const struct spg_machine_executor_config cfg = {.actor_id          = 1u,
                                                     .execution_enabled = true};
     const struct spg_machine_executor_workspace ws = {
@@ -55,6 +58,106 @@ static enum spg_machine_exec_outcome run(const struct spg_machine_state *m,
         return SPG_MACHINE_EXEC_REFUSED;
     }
     return r.outcome;
+}
+
+/* Phase 6b (#80): the run dies between a pause and its resume. SIGKILL is not
+ * catchable, so the ledger dies with the process — the journal is all that is
+ * left, and the next start has to finish the job.
+ *
+ * Simulated by simply not releasing, rather than by killing an agent
+ * mid-signal: that would be a race, and a race in a test is a flake. What is
+ * under test is the recovery, not the timing of the crash. */
+static int recovery_scenario(void) {
+    const pid_t child = fork();
+    if (child < 0) {
+        return 1;
+    }
+    if (child == 0) {
+        for (;;) {
+            (void)pause();
+        }
+    }
+    struct timespec ts = {.tv_sec = 0, .tv_nsec = 100000000};
+    (void)nanosleep(&ts, nullptr);
+
+    struct spg_machine_state m = {.n_processes = 1u};
+    if (!read_identity((uint64_t)child, &m.processes[0])) {
+        (void)kill(child, SIGKILL);
+        return 1;
+    }
+    memcpy(m.processes[0].profile_id, "batch_job", sizeof "batch_job");
+
+    const char               *path   = "build/machine-probe-recovery.sgj";
+    struct spg_journal_writer writer = {};
+    (void)remove(path);
+    if (spg_journal_writer_open(&writer, path) != SPG_OK) {
+        (void)kill(child, SIGKILL);
+        return 1;
+    }
+    char                                    payload[512];
+    struct spg_machine_pause_ledger         ledger = {};
+    const struct spg_machine_executor_state st     = {
+        .machine = &m, .journal = &writer, .ledger = &ledger};
+    const struct spg_machine_executor_config cfg = {.actor_id          = 1u,
+                                                    .timestamp_ns      = 1u,
+                                                    .write_journal     = true,
+                                                    .execution_enabled = true};
+    const struct spg_machine_executor_workspace ws = {
+        .payload_capacity = sizeof payload, .payload = payload};
+    struct spg_machine_executor_result r  = {};
+    int                                rc = 0;
+
+    if (spg_machine_executor_step(&st, &cfg, SPG_ACTION_MACHINE_PAUSE,
+                                  "batch_job", &ws, &r) != SPG_OK ||
+        r.outcome != SPG_MACHINE_EXEC_OK) {
+        printf("FAIL: recovery setup could not pause\n");
+        rc = 1;
+    }
+    (void)nanosleep(&ts, nullptr);
+    if (process_state((uint64_t)child) != 'T') {
+        printf("FAIL: recovery setup left the child running\n");
+        rc = 1;
+    }
+    /* The crash: the ledger is dropped on the floor, exactly as it would be if
+     * the process had been killed. */
+    (void)spg_journal_writer_close(&writer);
+
+    size_t recovered = 0u;
+    if (spg_machine_recover_journal(path, &cfg, &ws, nullptr, &recovered) !=
+            SPG_OK ||
+        recovered != 1u) {
+        printf("FAIL: recovery resumed %zu processes, expected 1\n", recovered);
+        rc = 1;
+    }
+    (void)nanosleep(&ts, nullptr);
+    if (process_state((uint64_t)child) == 'T') {
+        printf("FAIL: the child is still stopped after recovery\n");
+        rc = 1;
+    }
+
+    /* Recovery must be safe to run twice. It does not have to be a no-op —
+     * SIGCONT on a running process is harmless — but it must not fail and it
+     * must not leave the child worse off. That is what makes it safe to run
+     * unconditionally at every start. */
+    size_t again = 0u;
+    if (spg_machine_recover_journal(path, &cfg, &ws, nullptr, &again) !=
+        SPG_OK) {
+        printf("FAIL: repeating recovery errored\n");
+        rc = 1;
+    }
+    (void)nanosleep(&ts, nullptr);
+    if (process_state((uint64_t)child) == 'T') {
+        printf("FAIL: repeating recovery stopped the child\n");
+        rc = 1;
+    }
+
+    (void)kill(child, SIGKILL);
+    int status = 0;
+    (void)waitpid(child, &status, 0);
+    if (rc == 0) {
+        printf("machine_action_probe: recovery restored a stranded pause\n");
+    }
+    return rc;
 }
 
 int main(void) {
@@ -122,10 +225,11 @@ int main(void) {
     (void)kill(child, SIGKILL);
     int status = 0;
     (void)waitpid(child, &status, 0);
-    if (rc == 0) {
-        printf("machine_action_probe: pause/resume/identity all correct\n");
+    if (rc != 0) {
+        return rc;
     }
-    return rc;
+    printf("machine_action_probe: pause/resume/identity all correct\n");
+    return recovery_scenario();
 }
 
 #else

--- a/test/test_cli_machine_action.sh
+++ b/test/test_cli_machine_action.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Roadmap phase 6 (#66): does a pause actually stop a process, and does the
+# identity check actually stop a signal?
+#
+# Everything else about this phase is checked in test_machine_action.c against
+# fixtures. This is the part fixtures cannot answer: whether the syscall lands
+# on the right process. Linux only — elsewhere the executor refuses to act
+# because it cannot re-read /proc to confirm identity, and that refusal is
+# itself what gets checked.
+set -eu
+
+BIN=${SPG_MACHINE_PROBE:-${TEST_DIR:-build/host-debug/test}/machine_action_probe}
+
+if [ ! -x "$BIN" ]; then
+    echo "test_cli_machine_action: SKIP (probe not built)"
+    exit 0
+fi
+
+"$BIN"
+echo "test_cli_machine_action: PASS"

--- a/test/test_cli_machine_recovery.sh
+++ b/test/test_cli_machine_recovery.sh
@@ -67,8 +67,32 @@ fi
 kill -KILL "$CHILD"
 wait "$CHILD" 2>/dev/null || true
 
-# The second defence — recovery from a journal after an uncatchable kill — is
-# checked in machine_action_probe.c, where the crash can be simulated without a
-# race: it pauses with journalling on, drops the ledger, and then recovers.
+# --- 2. one machine run per journal ---------------------------------------
+# Two runs sharing a journal would interleave records into one hash chain and
+# each other's recovery would resume the other's pauses. The second run is told
+# to use its own journal rather than made to wait.
+sleep 120 &
+CHILD=$!
+sleep 0.2
+printf '(recommend (kind machine_pause_process) (capability "machine.process.pause") (target "batch_job") (cost 1) (uses_network false) (confidence_bp 9000) (reason "hold"))\n(recommend (kind finish) (reason "done"))\n' >"$SCRIPT"
+
+# Hold the lock from the outside, the way a concurrent run would.
+exec 9>"$JOURNAL.lock"
+if command -v flock >/dev/null 2>&1; then
+    flock -n 9 || {
+        echo "test_cli_machine_recovery: FAIL — could not take the lock" >&2
+        exit 1
+    }
+    if "$SPG_BIN" agent --config "$RUNCFG" --fake-script "$SCRIPT" --machine \
+        --process-profile "$PROFILE" --allow-exec --max-steps 3 2>/dev/null; then
+        echo "test_cli_machine_recovery: FAIL — a second run started anyway" >&2
+        exit 1
+    fi
+    exec 9>&-
+fi
+
+# The remaining defences — recovery after an uncatchable kill, and the guardian
+# that covers the window before the next start — are checked in
+# machine_action_probe.c, where the crash can be simulated without a race.
 
 echo "test_cli_machine_recovery: PASS"

--- a/test/test_cli_machine_recovery.sh
+++ b/test/test_cli_machine_recovery.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# Roadmap phase 6b (#80): nothing stays paused.
+#
+# Two defences, and this checks both. The first is the release path: whatever
+# ends the run, the ledger is emptied and everything we stopped is restarted.
+# The second is recovery: SIGKILL is not catchable, so a pause can outlive the
+# process that owed the resume — the next start reads the journal and finishes
+# the job.
+#
+# Linux only; elsewhere the executor never signals in the first place.
+set -eu
+
+SPG_BIN=${SPG_BIN:-build/host-debug/bin/geistshell}
+JOURNAL=build/machine-recovery.sgj
+PROFILE=build/machine-recovery-profile.spg
+SCRIPT=build/machine-recovery-fake.txt
+RUNCFG=build/machine-recovery-run.spg
+
+if [ "$(uname -s)" != "Linux" ]; then
+    echo "test_cli_machine_recovery: SKIP (no process signals here)"
+    exit 0
+fi
+
+mkdir -p build
+cat >"$PROFILE" <<'EOF'
+(process-profile
+  (process "batch_job" (match "sleep") (role batch)
+    (may_pause true) (may_stop true)))
+EOF
+sed "s|build/machine-demo.sgj|$JOURNAL|" examples/machine-run.spg >"$RUNCFG"
+
+CHILD=""
+cleanup() {
+    if [ -n "$CHILD" ]; then
+        kill -CONT "$CHILD" 2>/dev/null || true
+        kill -KILL "$CHILD" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+state_of() { awk '{print $3}' "/proc/$1/stat" 2>/dev/null || echo "?"; }
+
+# --- 1. the release path: pause, then end the run normally ----------------
+sleep 120 &
+CHILD=$!
+sleep 0.2
+
+# The run pauses and then finishes. Without the release the child would still
+# be stopped when the agent exits.
+printf '(recommend (kind machine_pause_process) (capability "machine.process.pause") (target "batch_job") (cost 1) (uses_network false) (confidence_bp 9000) (reason "reduce load"))\n(recommend (kind finish) (reason "done"))\n' >"$SCRIPT"
+rm -f "$JOURNAL"
+OUT=$("$SPG_BIN" agent --config "$RUNCFG" --fake-script "$SCRIPT" --machine \
+    --process-profile "$PROFILE" --allow-exec --max-steps 3)
+
+case "$OUT" in
+*released=1*) ;;
+*)
+    echo "test_cli_machine_recovery: FAIL — the run did not release its pause" >&2
+    echo "  $OUT" >&2
+    exit 1
+    ;;
+esac
+if [ "$(state_of "$CHILD")" = "T" ]; then
+    echo "test_cli_machine_recovery: FAIL — child still stopped after the run" >&2
+    exit 1
+fi
+kill -KILL "$CHILD"
+wait "$CHILD" 2>/dev/null || true
+
+# The second defence — recovery from a journal after an uncatchable kill — is
+# checked in machine_action_probe.c, where the crash can be simulated without a
+# race: it pauses with journalling on, drops the ledger, and then recovers.
+
+echo "test_cli_machine_recovery: PASS"

--- a/test/test_cli_machine_run.sh
+++ b/test/test_cli_machine_run.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+# Roadmap phase 6 (#66): a machine action end to end — gate, executor, journal,
+# replay — driven by the CLI rather than by a unit test's hand-built structs.
+#
+# On Linux it pauses a real `sleep` and checks the process actually stopped. On
+# every other platform the snapshot has no processes, so the SAME run must be
+# denied rather than quietly do nothing, and that denial is what gets checked.
+set -eu
+
+SPG_BIN=${SPG_BIN:-build/host-debug/bin/geistshell}
+JOURNAL=build/machine-demo.sgj
+PROFILE=build/machine-profile.spg
+SCRIPT=build/machine-fake.txt
+
+mkdir -p build
+cat >"$PROFILE" <<'EOF'
+(process-profile
+  (process "batch_job" (match "sleep") (role batch)
+    (may_pause true) (may_stop true))
+  (process "critical_app" (match "init") (role critical)
+    (may_pause false) (may_stop false)))
+EOF
+
+pause_script() {
+    printf '(recommend (kind machine_pause_process) (capability "machine.process.pause") (target "%s") (cost 1) (uses_network false) (confidence_bp 9000) (reason "reduce load"))\n(recommend (kind finish) (reason "done"))\n' "$1" >"$SCRIPT"
+}
+
+run_agent() {
+    rm -f "$JOURNAL"
+    "$SPG_BIN" agent --config examples/machine-run.spg --fake-script "$SCRIPT" \
+        --machine --process-profile "$PROFILE" --allow-exec --max-steps 3
+}
+
+CHILD=""
+cleanup() {
+    if [ -n "$CHILD" ]; then
+        kill -CONT "$CHILD" 2>/dev/null || true
+        kill -KILL "$CHILD" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+if [ "$(uname -s)" = "Linux" ]; then
+    sleep 120 &
+    CHILD=$!
+    sleep 0.2
+
+    pause_script batch_job
+    OUT=$(run_agent)
+    case "$OUT" in
+    *termination=finished*) ;;
+    *)
+        echo "test_cli_machine_run: FAIL — expected the pause to be allowed" >&2
+        echo "  $OUT" >&2
+        exit 1
+        ;;
+    esac
+    if ! strings "$JOURNAL" | grep -q "(outcome ok)"; then
+        echo "test_cli_machine_run: FAIL — no successful machine_action" >&2
+        exit 1
+    fi
+    STATE=$(awk '{print $3}' "/proc/$CHILD/stat" 2>/dev/null || echo "?")
+    if [ "$STATE" != "T" ]; then
+        echo "test_cli_machine_run: FAIL — child is '$STATE', expected T" >&2
+        exit 1
+    fi
+    kill -CONT "$CHILD"
+
+    # A protected process must be refused by the policy layer, and the journal
+    # must say so — "denied" alone would not distinguish it from running out of
+    # budget.
+    pause_script critical_app
+    OUT=$(run_agent || true)
+    if ! strings "$JOURNAL" | grep -q "SPG_POLICY_DENY_PROCESS_PROTECTED"; then
+        echo "test_cli_machine_run: FAIL — critical process was not protected" >&2
+        exit 1
+    fi
+else
+    # No snapshot means no observed process, and an action on something we did
+    # not observe is a guess. Denial, not a silent no-op.
+    pause_script batch_job
+    OUT=$(run_agent || true)
+    if ! strings "$JOURNAL" | grep -q "SPG_POLICY_DENY_PROCESS_IDENTITY"; then
+        echo "test_cli_machine_run: FAIL — expected an identity denial" >&2
+        exit 1
+    fi
+fi
+
+# Whatever happened, it must replay: a decision that cannot be reproduced is a
+# decision nobody can audit.
+"$SPG_BIN" replay "$JOURNAL" >build/machine-replay.jsonl
+if [ ! -s build/machine-replay.jsonl ]; then
+    echo "test_cli_machine_run: FAIL — replay produced nothing" >&2
+    exit 1
+fi
+
+echo "test_cli_machine_run: PASS"

--- a/test/test_cli_machine_run.sh
+++ b/test/test_cli_machine_run.sh
@@ -59,12 +59,23 @@ if [ "$(uname -s)" = "Linux" ]; then
         echo "test_cli_machine_run: FAIL — no successful machine_action" >&2
         exit 1
     fi
+    # Since phase 6b the run releases what it paused before it exits, so the
+    # child is running again by the time we can look. The evidence that the
+    # pause happened is the journal; the evidence that it was undone is the
+    # child's state plus the released= line.
+    case "$OUT" in
+    *released=1*) ;;
+    *)
+        echo "test_cli_machine_run: FAIL — the pause was not released" >&2
+        echo "  $OUT" >&2
+        exit 1
+        ;;
+    esac
     STATE=$(awk '{print $3}' "/proc/$CHILD/stat" 2>/dev/null || echo "?")
-    if [ "$STATE" != "T" ]; then
-        echo "test_cli_machine_run: FAIL — child is '$STATE', expected T" >&2
+    if [ "$STATE" = "T" ]; then
+        echo "test_cli_machine_run: FAIL — child left stopped after the run" >&2
         exit 1
     fi
-    kill -CONT "$CHILD"
 
     # A protected process must be refused by the policy layer, and the journal
     # must say so — "denied" alone would not distinguish it from running out of

--- a/test/test_machine_action.c
+++ b/test/test_machine_action.c
@@ -1,0 +1,369 @@
+/* Phase 6: typed machine actions.
+ *
+ * Two things are under test and they are different questions. The gate decides
+ * WHETHER an action may happen — role, permissions, whether the target was even
+ * observed. The executor decides whether the process it is about to signal is
+ * still the one the gate decided about, because a pid can be recycled in
+ * between. A test that only covered the first would miss the bug that matters
+ * most. */
+
+#include "geistshell/machine_executor.h"
+#include "geistshell/policy_gate.h"
+#include "geistshell/process_profile.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define LIT(s) (sizeof(s) - 1u), (s)
+
+static const char profile_text[] =
+    "(process-profile\n"
+    "  (process \"critical_app\" (match \"crit\") (role critical)\n"
+    "    (may_pause false) (may_stop false))\n"
+    "  (process \"batch_job\" (match \"batch\") (role batch)\n"
+    "    (may_pause true) (may_stop true)))\n";
+
+static bool load_profile(struct spg_process_profile *out) {
+    static struct spg_sexpr_token    tokens[512];
+    static struct spg_sexpr_node     nodes[512];
+    struct spg_process_profile_error err = {};
+    return spg_process_profile_load(LIT(profile_text), 512u, tokens, 512u,
+                                    nodes, out, &err) == SPG_OK;
+}
+
+static struct spg_machine_state two_processes(void) {
+    struct spg_machine_state s = {.n_processes = 2u};
+    s.processes[0] =
+        (struct spg_process_sample){.pid            = 4711u,
+                                    .start_identity = 100u,
+                                    .role = SPG_PROCESS_ROLE_CRITICAL};
+    memcpy(s.processes[0].profile_id, "critical_app", sizeof "critical_app");
+    s.processes[1] = (struct spg_process_sample){
+        .pid = 4712u, .start_identity = 200u, .role = SPG_PROCESS_ROLE_BATCH};
+    memcpy(s.processes[1].profile_id, "batch_job", sizeof "batch_job");
+    return s;
+}
+
+/* Build a recommendation the way the parser would, so the gate sees the same
+ * spans a real model output produces. */
+static bool parse_rec(const char *text, struct spg_recommendation *out) {
+    static struct spg_sexpr_token   tokens[256];
+    static struct spg_sexpr_node    nodes[256];
+    struct spg_recommendation_error err = {};
+    return spg_recommendation_parse(strlen(text), text, 256u, tokens, 256u,
+                                    nodes, out, &err) == SPG_OK &&
+           out->state == SPG_RECOMMENDATION_VALID;
+}
+
+static const char policy_text[] =
+    "(policy\n"
+    " (network_default deny)\n"
+    " (budgets (inference_steps 8) (tokens 256) (shell_actions 0)\n"
+    "  (sim_actions 0) (memory_actions 0) (wall_ms 1000)\n"
+    "  (journal_bytes 4096) (risk_bp 10000) (machine_actions 4))\n"
+    " (capability\n"
+    "  ((name machine.process.pause) (kind machine_process)\n"
+    "   (enabled true) (budget 4))))\n";
+
+struct gate_env {
+    struct spg_policy_config   policy;
+    struct spg_process_profile profile;
+    struct spg_machine_state   machine;
+    struct spg_policy_usage    usage;
+};
+
+static bool gate_env_init(struct gate_env *env) {
+    static struct spg_sexpr_token  tokens[512];
+    static struct spg_sexpr_node   nodes[512];
+    struct spg_policy_config_error err = {};
+    if (spg_policy_config_load(LIT(policy_text), 512u, tokens, 512u, nodes,
+                               &env->policy, &err) != SPG_OK) {
+        printf("  policy load failed at offset %zu\n", err.offset);
+        return false;
+    }
+    if (!load_profile(&env->profile)) {
+        return false;
+    }
+    env->machine = two_processes();
+    env->usage   = (struct spg_policy_usage){};
+    return true;
+}
+
+static enum spg_policy_deny_reason
+decide(struct gate_env *env, const char *rec_text, bool with_profile) {
+    struct spg_recommendation rec = {};
+    if (!parse_rec(rec_text, &rec)) {
+        return SPG_POLICY_DENY_INVALID_REQUEST;
+    }
+    char                               payload[1024];
+    const struct spg_policy_gate_state state = {
+        .policy_text_n         = sizeof policy_text - 1u,
+        .policy_text           = policy_text,
+        .recommendation_text_n = strlen(rec_text),
+        .recommendation_text   = rec_text,
+        .policy                = &env->policy,
+        .usage                 = &env->usage,
+        .profile               = with_profile ? &env->profile : nullptr,
+        .machine               = with_profile ? &env->machine : nullptr,
+    };
+    const struct spg_policy_gate_config    config = {.actor_id = 1u};
+    const struct spg_policy_gate_workspace ws     = {
+        .payload_capacity = sizeof payload, .payload = payload};
+    struct spg_policy_gate_result result = {};
+    if (spg_policy_gate_step(&state, &config, &rec, &ws, &result) != SPG_OK) {
+        return SPG_POLICY_DENY_INVALID_REQUEST;
+    }
+    return result.decision.kind == SPG_POLICY_DECISION_ALLOW
+               ? SPG_POLICY_DENY_NONE
+               : result.decision.deny_reason;
+}
+
+#define PAUSE(t)                                                               \
+    "(recommend (kind machine_pause_process) "                                 \
+    "(capability \"machine.process.pause\") (target \"" t "\") (cost 1) "      \
+    "(uses_network false) (confidence_bp 9000) (reason \"r\"))"
+
+static int test_allows_managed_batch(void) {
+    struct gate_env env = {};
+    if (!gate_env_init(&env)) {
+        return 1;
+    }
+    return decide(&env, PAUSE("batch_job"), true) == SPG_POLICY_DENY_NONE ? 0
+                                                                          : 1;
+}
+
+/* The one denial the whole phase is built around: a critical process is never
+ * pausable, and the refusal comes from the policy layer, not from the executor
+ * deciding to be careful. */
+static int test_denies_critical(void) {
+    struct gate_env env = {};
+    if (!gate_env_init(&env)) {
+        return 1;
+    }
+    const enum spg_policy_deny_reason r =
+        decide(&env, PAUSE("critical_app"), true);
+    if (r != SPG_POLICY_DENY_PROCESS_PROTECTED) {
+        printf("  got deny reason %d\n", (int)r);
+        return 1;
+    }
+    return 0;
+}
+
+static int test_denies_unmanaged(void) {
+    struct gate_env env = {};
+    if (!gate_env_init(&env)) {
+        return 1;
+    }
+    /* Not in the profile at all: denied, not silently ignored, so the model
+     * learns that unknown processes are off limits rather than inert. */
+    if (decide(&env, PAUSE("sshd"), true) !=
+        SPG_POLICY_DENY_UNMANAGED_PROCESS) {
+        return 1;
+    }
+    /* No profile configured at all — the default must be denial. */
+    if (decide(&env, PAUSE("batch_job"), false) !=
+        SPG_POLICY_DENY_UNMANAGED_PROCESS) {
+        return 1;
+    }
+    return 0;
+}
+
+/* Managed and permitted, but not in this tick's snapshot: acting on it would
+ * mean acting on a guess. */
+static int test_denies_unobserved(void) {
+    struct gate_env env = {};
+    if (!gate_env_init(&env)) {
+        return 1;
+    }
+    env.machine.n_processes = 1u; /* only critical_app remains */
+    return decide(&env, PAUSE("batch_job"), true) ==
+                   SPG_POLICY_DENY_PROCESS_IDENTITY
+               ? 0
+               : 1;
+}
+
+static int test_denies_when_budget_exhausted(void) {
+    struct gate_env env = {};
+    if (!gate_env_init(&env)) {
+        return 1;
+    }
+    env.usage.consumed.machine_actions = 4u; /* the whole budget */
+    const enum spg_policy_deny_reason r =
+        decide(&env, PAUSE("batch_job"), true);
+    if (r != SPG_POLICY_DENY_GLOBAL_BUDGET &&
+        r != SPG_POLICY_DENY_CAPABILITY_BUDGET) {
+        printf("  got deny reason %d\n", (int)r);
+        return 1;
+    }
+    return 0;
+}
+
+/* A protected process must not even cost budget to be refused, and the journal
+ * should say why it was refused rather than that we ran out. */
+static int test_protection_precedes_budget(void) {
+    struct gate_env env = {};
+    if (!gate_env_init(&env)) {
+        return 1;
+    }
+    env.usage.consumed.machine_actions = 4u;
+    return decide(&env, PAUSE("critical_app"), true) ==
+                   SPG_POLICY_DENY_PROCESS_PROTECTED
+               ? 0
+               : 1;
+}
+
+static int test_denies_wrong_capability(void) {
+    struct gate_env env = {};
+    if (!gate_env_init(&env)) {
+        return 1;
+    }
+    const char *rec = "(recommend (kind machine_pause_process) "
+                      "(capability \"local_shell\") (target \"batch_job\") "
+                      "(cost 1) (uses_network false) (confidence_bp 9000) "
+                      "(reason \"r\"))";
+    const enum spg_policy_deny_reason r = decide(&env, rec, true);
+    if (r != SPG_POLICY_DENY_UNKNOWN_CAPABILITY &&
+        r != SPG_POLICY_DENY_KIND_MISMATCH) {
+        printf("  got deny reason %d\n", (int)r);
+        return 1;
+    }
+    return 0;
+}
+
+/* The grammar refuses a machine action carrying a command. This is the
+ * property that makes the action space closed: there is no field through which
+ * a shell string could reach an executor. */
+static int test_grammar_rejects_command(void) {
+    struct spg_recommendation rec = {};
+    const char               *bad =
+        "(recommend (kind machine_pause_process) "
+        "(capability \"machine.process.pause\") (target \"batch_job\") "
+        "(command \"kill -9 4711\") (cost 1) (uses_network false) "
+        "(confidence_bp 9000) (reason \"r\"))";
+    if (parse_rec(bad, &rec)) {
+        return 1;
+    }
+    /* And one without a target is equally invalid: nothing to act on. */
+    const char *no_target = "(recommend (kind machine_pause_process) "
+                            "(capability \"machine.process.pause\") (cost 1) "
+                            "(uses_network false) (confidence_bp 9000) "
+                            "(reason \"r\"))";
+    return parse_rec(no_target, &rec) ? 1 : 0;
+}
+
+/* --- executor ----------------------------------------------------------- */
+
+static enum spg_machine_exec_outcome
+exec_target(const struct spg_machine_state *machine, const char *target,
+            const bool enabled) {
+    char                                     payload[512];
+    const struct spg_machine_executor_state  st  = {.machine = machine};
+    const struct spg_machine_executor_config cfg = {
+        .actor_id = 1u, .execution_enabled = enabled};
+    const struct spg_machine_executor_workspace ws = {
+        .payload_capacity = sizeof payload, .payload = payload};
+    struct spg_machine_executor_result r = {};
+    if (spg_machine_executor_step(&st, &cfg, SPG_ACTION_MACHINE_PAUSE, target,
+                                  &ws, &r) != SPG_OK) {
+        return SPG_MACHINE_EXEC_REFUSED;
+    }
+    return r.outcome;
+}
+
+static int test_executor_resolves_target(void) {
+    const struct spg_machine_state s = two_processes();
+    /* An id the snapshot does not contain is not signalled, whatever the gate
+     * said — the executor trusts the snapshot, not the recommendation. */
+    if (exec_target(&s, "ghost", true) != SPG_MACHINE_EXEC_NOT_FOUND) {
+        return 1;
+    }
+    if (exec_target(&s, "", true) != SPG_MACHINE_EXEC_NOT_FOUND) {
+        return 1;
+    }
+    /* Execution disabled: the default for any run that has not asked to touch
+     * the machine. */
+    if (exec_target(&s, "batch_job", false) != SPG_MACHINE_EXEC_UNSUPPORTED) {
+        return 1;
+    }
+    return 0;
+}
+
+/* pid 1 and the agent itself are refused by the executor even if every layer
+ * above it said yes. The last line does not assume the others are perfect. */
+static int test_executor_refuses_dangerous_pids(void) {
+    struct spg_machine_state s = {.n_processes = 1u};
+    memcpy(s.processes[0].profile_id, "batch_job", sizeof "batch_job");
+    s.processes[0].pid            = 1u;
+    s.processes[0].start_identity = 1u;
+    const enum spg_machine_exec_outcome init_outcome =
+        exec_target(&s, "batch_job", true);
+#if defined(__linux__)
+    if (init_outcome != SPG_MACHINE_EXEC_REFUSED) {
+        return 1;
+    }
+#else
+    /* No /proc, so the executor refuses to act at all rather than signal
+     * something it cannot identify. */
+    if (init_outcome != SPG_MACHINE_EXEC_UNSUPPORTED) {
+        return 1;
+    }
+#endif
+    return 0;
+}
+
+static int test_executor_null_args(void) {
+    char                                        payload[64];
+    const struct spg_machine_executor_state     st  = {};
+    const struct spg_machine_executor_config    cfg = {};
+    const struct spg_machine_executor_workspace ws  = {
+        .payload_capacity = sizeof payload, .payload = payload};
+    struct spg_machine_executor_result r = {};
+    if (spg_machine_executor_step(&st, &cfg, SPG_ACTION_MACHINE_PAUSE, nullptr,
+                                  &ws, &r) != SPG_E_INVALID_ARG) {
+        return 1;
+    }
+    /* Only machine kinds belong here; anything else is a wiring bug upstream.
+     */
+    if (spg_machine_executor_step(&st, &cfg, SPG_ACTION_LOCAL_SHELL, "x", &ws,
+                                  &r) != SPG_E_INVALID_ARG) {
+        return 1;
+    }
+    size_t done = 1u;
+    if (spg_machine_executor_run(&st, &cfg, 0u, nullptr, &ws, nullptr, &done) !=
+            SPG_OK ||
+        done != 0u) {
+        return 1; /* an empty batch is legitimate */
+    }
+    return 0;
+}
+
+int main(void) {
+    const struct {
+        const char *name;
+        int (*fn)(void);
+    } cases[] = {
+        {"allows_managed_batch", test_allows_managed_batch},
+        {"denies_critical", test_denies_critical},
+        {"denies_unmanaged", test_denies_unmanaged},
+        {"denies_unobserved", test_denies_unobserved},
+        {"denies_when_budget_exhausted", test_denies_when_budget_exhausted},
+        {"protection_precedes_budget", test_protection_precedes_budget},
+        {"denies_wrong_capability", test_denies_wrong_capability},
+        {"grammar_rejects_command", test_grammar_rejects_command},
+        {"executor_resolves_target", test_executor_resolves_target},
+        {"executor_refuses_dangerous_pids",
+         test_executor_refuses_dangerous_pids},
+        {"executor_null_args", test_executor_null_args},
+    };
+    int failures = 0;
+    for (size_t i = 0u; i < sizeof cases / sizeof cases[0]; i += 1u) {
+        if (cases[i].fn() != 0) {
+            printf("test_machine_action: FAIL %s\n", cases[i].name);
+            failures += 1;
+        }
+    }
+    if (failures == 0) {
+        printf("test_machine_action: PASS\n");
+    }
+    return failures == 0 ? 0 : 1;
+}

--- a/test/test_machine_action.c
+++ b/test/test_machine_action.c
@@ -251,13 +251,76 @@ static int test_grammar_rejects_command(void) {
     return parse_rec(no_target, &rec) ? 1 : 0;
 }
 
+/* Phase 6b (#80): a pause that cannot be recorded does not happen. Stopping a
+ * process nobody owes a resume for is the one way this runtime leaves lasting
+ * damage without any policy being violated. */
+static int test_untracked_pause_is_refused(void) {
+    const struct spg_machine_state           s = two_processes();
+    char                                     payload[512];
+    const struct spg_machine_executor_state  st  = {.machine = &s,
+                                                    .ledger  = nullptr};
+    const struct spg_machine_executor_config cfg = {.actor_id          = 1u,
+                                                    .execution_enabled = true};
+    const struct spg_machine_executor_workspace ws = {
+        .payload_capacity = sizeof payload, .payload = payload};
+    struct spg_machine_executor_result r = {};
+    if (spg_machine_executor_step(&st, &cfg, SPG_ACTION_MACHINE_PAUSE,
+                                  "batch_job", &ws, &r) != SPG_OK ||
+        r.outcome != SPG_MACHINE_EXEC_REFUSED) {
+        return 1;
+    }
+    /* A full ledger is the same situation: no room to record, so no pause. */
+    struct spg_machine_pause_ledger full = {.count = SPG_MACHINE_MAX_PAUSED};
+    const struct spg_machine_executor_state st2 = {.machine = &s,
+                                                   .ledger  = &full};
+    if (spg_machine_executor_step(&st2, &cfg, SPG_ACTION_MACHINE_PAUSE,
+                                  "batch_job", &ws, &r) != SPG_OK ||
+        r.outcome != SPG_MACHINE_EXEC_REFUSED) {
+        return 1;
+    }
+    return 0;
+}
+
+/* The release must skip a pid whose identity no longer matches: resuming a
+ * stranger is worse than resuming nothing. */
+static int test_release_is_identity_checked(void) {
+    char                            payload[512];
+    struct spg_machine_pause_ledger ledger = {.count = 1u};
+    ledger.entries[0]                      = (struct spg_machine_paused_entry){
+        .pid = 999999u, .start_identity = 123u};
+    memcpy(ledger.entries[0].profile_id, "batch_job", sizeof "batch_job");
+    const struct spg_machine_executor_state  st  = {.ledger = &ledger};
+    const struct spg_machine_executor_config cfg = {.actor_id          = 1u,
+                                                    .execution_enabled = true};
+    const struct spg_machine_executor_workspace ws = {
+        .payload_capacity = sizeof payload, .payload = payload};
+    size_t resumed = 0u;
+    if (spg_machine_ledger_release(&ledger, &st, &cfg, &ws, &resumed) !=
+        SPG_OK) {
+        return 1;
+    }
+    /* Nothing resumed — that pid is not ours — and the ledger is empty either
+     * way, so a stuck entry cannot be retried forever. */
+    if (resumed != 0u || ledger.count != 0u) {
+        return 1;
+    }
+    /* A null ledger is not an error: a run that never paused owes nothing. */
+    return spg_machine_ledger_release(nullptr, &st, &cfg, &ws, &resumed) ==
+                   SPG_OK
+               ? 0
+               : 1;
+}
+
 /* --- executor ----------------------------------------------------------- */
+
+static struct spg_machine_pause_ledger test_ledger;
 
 static enum spg_machine_exec_outcome
 exec_target(const struct spg_machine_state *machine, const char *target,
             const bool enabled) {
     char                                     payload[512];
-    const struct spg_machine_executor_state  st  = {.machine = machine};
+    const struct spg_machine_executor_state  st  = {.machine = machine,
+                                                    .ledger  = &test_ledger};
     const struct spg_machine_executor_config cfg = {
         .actor_id = 1u, .execution_enabled = enabled};
     const struct spg_machine_executor_workspace ws = {
@@ -295,6 +358,9 @@ static int test_executor_refuses_dangerous_pids(void) {
     memcpy(s.processes[0].profile_id, "batch_job", sizeof "batch_job");
     s.processes[0].pid            = 1u;
     s.processes[0].start_identity = 1u;
+    /* Refused on Linux because pid 1 is off limits; refused elsewhere because
+     * there is no /proc to confirm identity with. Different reason, same
+     * answer, and the answer is what matters. */
     const enum spg_machine_exec_outcome init_outcome =
         exec_target(&s, "batch_job", true);
 #if defined(__linux__)
@@ -354,6 +420,8 @@ int main(void) {
         {"executor_refuses_dangerous_pids",
          test_executor_refuses_dangerous_pids},
         {"executor_null_args", test_executor_null_args},
+        {"untracked_pause_is_refused", test_untracked_pause_is_refused},
+        {"release_is_identity_checked", test_release_is_identity_checked},
     };
     int failures = 0;
     for (size_t i = 0u; i < sizeof cases / sizeof cases[0]; i += 1u) {


### PR DESCRIPTION
Phase 6 der Roadmap (#66). Stapelt auf #86. Der Agent kann eine **reversible** Aktion ausführen, ohne Governance zu umgehen.

## Kein `local_shell`

```
(recommend (kind machine_pause_process)
           (capability "machine.process.pause")
           (target "batch_job") (cost 1) (uses_network false)
           (confidence_bp 9000) (reason "..."))
```

Die Grammatik **verbietet** ein `command`-Feld für Machine Actions — das ist der Punkt eines geschlossenen Action Space: es gibt kein Feld, durch das ein Shell-String einen Executor erreicht. Ein Test prüft, dass der **Parser** das ablehnt, nicht erst der Gate. `target` ist eine Profil-ID, nie eine PID; das Modell hat nie eine PID gesehen.

## Zwei Schichten, zwei Fragen

**Der Gate entscheidet, OB** — Rolle, Berechtigung, ob das Ziel überhaupt beobachtet wurde. In der Policy-Schicht, weil eine Sicherheitseigenschaft hinter dem Gate eine ist, von der das Journal nicht zeigen kann, dass sie geprüft wurde.

**Der Executor entscheidet, OB ES NOCH DERSELBE IST** — das kann der Gate nicht wissen: zwischen Entscheidung und Syscall wird eine PID wiederverwendet. `/proc/<pid>/stat` wird unmittelbar vor `kill()` erneut gelesen, PID **und** Startzeit müssen stimmen.

| Situation | Ergebnis | Wo |
|---|---|---|
| gemanagter Batch, `may_pause true` | ALLOW | Gate |
| `role critical` / `may_pause false` | `DENY_PROCESS_PROTECTED` | Gate |
| nicht im Profil / kein Profil | `DENY_UNMANAGED_PROCESS` | Gate |
| nicht im Snapshot | `DENY_PROCESS_IDENTITY` | Gate |
| Capability fehlt, Budget leer | `DENY_*` | Gate |
| PID gehört jetzt anderem | `identity_changed`, **kein Signal** | Executor |
| PID 1, eigene PID, Elternprozess | `refused` | Executor |
| kein `/proc` | `unsupported`, **kein Signal** | Executor |

**Schutz geht vor Budget.** Ein geschützter Prozess wird abgelehnt, bevor Capability und Budget geprüft werden — sonst stünde „Budget erschöpft" im Journal statt „das darfst du nicht".

## Resume braucht keine Erlaubnis

`may_pause` gilt fürs Pausieren. Resume ist für jeden gemanagten Prozess erlaubt: es kann nur den Zustand wiederherstellen, den die Maschine vorher hatte, und es zu verweigern hieße, einen von uns gestoppten Prozess gestoppt zu lassen. Restrisiko benannt in `Actions.md`.

## Nur Linux signalisiert

Nicht aus Portabilitätsgründen: die Identitätsprüfung liest `/proc`. Ein Executor, der nicht verifizieren kann, was er gleich stoppt, darf nichts stoppen. Kein `system()`, kein `popen()`, keine Shell — nur `kill(pid, SIGSTOP|SIGCONT)`.

## Auf Hardware bewiesen

`test/machine_action_probe.c` forkt auf dem Pi ein Kind und treibt den Executor dagegen:

- `pause` → Prozesszustand in `/proc` wird `T`
- `resume` → läuft wieder
- Snapshot mit veränderter Startzeit → `identity_changed`, Prozess **unangetastet**

Der letzte Punkt ist der wichtigste Test der Phase. Regressiert er, signalisiert der Agent fremde Prozesse.

`test/test_cli_machine_run.sh` fährt dasselbe über die CLI: pausiert ein echtes `sleep`, prüft den Zustand, und verlangt für einen critical-Prozess `SPG_POLICY_DENY_PROCESS_PROTECTED` im Journal — „denied" allein unterschiede nicht zwischen Schutz und Budgetende. Auf macOS prüft derselbe Test die Verweigerung.

## Konfiguration

`examples/machine-policy.spg` aktiviert Pause und Resume — und **kein** `local_shell`. Absicht: ein Modell, dem die Pause verweigert wurde, soll nicht auf `kill` ausweichen können. Der Bypass-Test in #67 hängt daran.

## Verifikation

macOS arm64 und Pi 5: `make test` grün, exit 0, 33 PASS, warnungsfrei, ASan/UBSan sauber.

**Offene Lücke, die vor #67 geschlossen gehört: #80.** Stirbt der Run nach einem `SIGSTOP`, bleibt der Prozess dauerhaft gestoppt. Reversibel ist die Aktion nur, solange der Agent lebt.

Doku: `docs/machine-intelligence/Actions.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
