### PR TITLE
Phase 9: Ziele, die die Maschine bewertet — nicht das Modell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ SPG_SOURCES := \
     src/memory/memory.c \
     src/machine/diagnose.c \
     src/machine/machine_fixture.c \
+    src/machine/machine_goal.c \
     src/machine/process.c \
     src/machine/process_profile.c \
     src/machine/telemetry.c \

--- a/docs/machine-intelligence/Goals.md
+++ b/docs/machine-intelligence/Goals.md
@@ -1,0 +1,124 @@
+# Ziele und Constraints — Phase 9
+
+Ein Lauf ist nicht erfolgreich, weil das Modell `finish` sagt.
+
+Ticket: geisten/geistshell#69. Voraussetzung: [Closed-Loop.md](Closed-Loop.md).
+
+## Vier Schichten, bewusst getrennt
+
+```
+(machine-goal
+  (max-temperature-mc 70000)
+  (min-critical-service-health-bp 9500)
+  (prefer-min-energy true)
+  (max-actions 3))
+```
+
+| Schicht | Wo | Wer prüft |
+|---|---|---|
+| **Harte Constraints** | `(machine-goal ...)` | der Harness, gegen den beobachteten Endzustand |
+| **Optimierungspräferenz** | `prefer-min-energy` | niemand — sie wird protokolliert, nicht bewertet |
+| **Semantische Prozessrestriktionen** | Process Profile (#62) | der Policy Gate |
+| **Policy und Safety** | Policy Config | der Policy Gate |
+
+Diese Trennung ist der Punkt. Ein Ziel kann die Schichten 2–4 **nie**
+erweitern: Etwas zu verlangen, das die Policy verbietet, macht es nicht
+erlaubt, sondern das Ziel unerreichbar. Die Richtung geht nur in eine Seite —
+ein Ziel darf weniger verlangen als die Policy zulässt, nie mehr.
+
+`prefer-min-energy` wird bewusst nicht bewertet: hier misst nichts Energie
+(#75). Eine Präferenz, die als Kriterium durchginge, ohne dass jemand sie
+messen kann, wäre schlimmer als keine.
+
+## Was „erreicht" heißt
+
+`spg_machine_goal_evaluate()` liest den **beobachteten** Endzustand und die
+**tatsächlich ausgeführte** Aktionszahl. Das Modell kommt in dieser Rechnung
+nicht vor.
+
+| Verdikt | Bedeutung |
+|---|---|
+| `satisfied` | alle harten Constraints erfüllt |
+| `temperature_too_high` | Grenzwert überschritten |
+| `critical_unhealthy` | ein kritischer Prozess ist gestoppt oder verschwunden |
+| `too_many_actions` | mehr Aktionen ausgeführt als erlaubt |
+| `unmeasurable` | ein Constraint existiert, sein Wert war nicht lesbar |
+| `no_goal` | kein Ziel konfiguriert |
+
+Das Verdikt trägt die gemessenen Werte mit sich. Ein Harness, der nur
+„gescheitert" erfährt, kann eine heiße Maschine nicht von einer verschwendeten
+unterscheiden.
+
+### Unmessbar ist kein Erfolg
+
+Ein Constraint, dessen Wert nicht gelesen werden konnte, gilt als **nicht
+erfüllt**. Ein defekter Sensor ist kein Beleg dafür, dass ein Grenzwert
+eingehalten wurde — er wurde nur nicht widerlegt.
+
+Dasselbe gilt für `min-critical-service-health-bp` auf einer Maschine, in deren
+Snapshot kein kritischer Prozess vorkommt: 100 % zu melden hieße, ein Ziel zu
+bestehen, dessen Gegenstand nie identifiziert wurde.
+
+### `no_goal` ist nicht `satisfied`
+
+Ein Lauf ohne Ziel hat kein Ziel erreicht. Ihn als bestanden zu zählen würde
+jede Zusammenfassung aufblähen, in der er vorkommt.
+
+### Health, erste Fassung
+
+10000 bp, wenn jeder als kritisch markierte Prozess vorhanden und nicht
+gestoppt ist; 0, wenn einer gestoppt (`T`) oder ein Zombie (`Z`) ist. Das ist
+Verfügbarkeit, nicht Dienstgüte — eine feinere Definition braucht etwas, das
+den Dienst selbst misst, und das ist Machine-B-Gebiet (#75).
+
+## Der Nachweis
+
+Drei Szenarien in `examples/eval/machine/closed_loop_goal.spg`. **Alle drei
+enden damit, dass das Modell dasselbe `finish` ausgibt.** Was sie unterscheidet,
+ist die Maschine, die sie hinterlassen:
+
+| Fall | Termination | Verdikt | Ergebnis |
+|---|---|---|---|
+| `false_finish_while_hot` | `finished` | `temperature_too_high` | **fail** |
+| `goal_met` | `finished` | `satisfied` | pass |
+| `acted_when_forbidden` | `finished` | `too_many_actions` | **fail** |
+
+Der erste Fall ist der, für den die Phase existiert: sauber terminiert, korrekt
+geparst, vom Gate zugelassen — und trotzdem gescheitert, weil die Maschine bei
+82 °C steht. Kann die objektive Prüfung ein `pass` nicht **überstimmen**, ist
+sie Dekoration.
+
+Der dritte trennt Policy von Ziel: die Aktion war von der Policy erlaubt, das
+**Ziel** verbietet sie. Zwei Schichten, zwei Antworten.
+
+## Aktionen, nicht Schritte
+
+`max-actions` wird gegen `actions_executed` geprüft — was der Lauf **getan**
+hat, nicht wie oft das Modell gefragt wurde. Ein Modell, das dreimal
+nachdenkt und einmal handelt, hat eine Aktion verbraucht.
+
+`(max-actions 0)` wird **nicht** als Widerspruch abgelehnt. „Prüfen, ohne etwas
+anzufassen" ist ein legitimer Lauf; eine Maschine, die ihre Constraints bereits
+erfüllt, besteht ihn. Jede Aktion lässt ihn scheitern.
+
+## Im Context
+
+Das Ziel wird **vor** dem Zustand gerendert: erst wofür der Lauf da ist, dann
+was er sieht. Ein Modell, das die Constraints nach den Zahlen liest, muss die
+Zahlen erneut lesen.
+
+Ein Roundtrip-Test verlangt, dass der gerenderte Block wieder als dasselbe Ziel
+gelesen wird — sonst beschreiben Context und Verdikt verschiedene Läufe.
+
+## Grenzen
+
+- **Kein Optimierungsframework.** Constraints sind Schwellwerte, keine
+  Zielfunktion. Die erste Fassung braucht das laut Ticket nicht, und ohne
+  Energiemessung wäre eine Zielfunktion ohnehin unvollständig.
+- **Ein Endzustand, keine Trajektorie.** Ob die Temperatur *zwischendurch* über
+  dem Grenzwert lag, sieht diese Prüfung nicht. Für ein Ziel der Form „nie
+  überschreiten" bräuchte es das History-Fenster aus #79.
+- **`impossible` ist kein eigenes Verdikt.** Ein unerreichbares Ziel endet als
+  `temperature_too_high` oder `unmeasurable` — korrekt, aber es sagt nicht
+  „das war nie zu schaffen". Das zu unterscheiden braucht eine Vorstellung
+  davon, was die Maschine überhaupt könnte, und die hat der Harness nicht.

--- a/examples/eval/machine/closed_loop_goal.spg
+++ b/examples/eval/machine/closed_loop_goal.spg
@@ -1,0 +1,39 @@
+; Phase 9 (#69): the goal decides, not the model.
+;
+; Every case here ends with the model saying `finish`. What separates them is
+; the machine it left behind — which is the entire point.
+(eval_suite
+ (config "examples/machine-run.spg")
+
+ ; THE case. The model declares completion on a machine still at 82 C. The run
+ ; terminates cleanly and must still be scored as a failure.
+ (case (name "false_finish_while_hot")
+       (machine "examples/eval/machine/states/loop_before.spg")
+       (machine_after "examples/eval/machine/states/goal_hot.spg")
+       (process_profile "examples/eval/machine/loop-profile.spg")
+       (goal_file "examples/eval/machine/goals/keep_cool.spg")
+       (script "examples/eval/machine/scripts/goal_finish.txt")
+       (max_steps 3)
+       (expect (termination finished)))
+
+ ; Same script, same words from the model, cool machine: this one passes.
+ (case (name "goal_met")
+       (machine "examples/eval/machine/states/loop_before.spg")
+       (machine_after "examples/eval/machine/states/goal_cool.spg")
+       (process_profile "examples/eval/machine/loop-profile.spg")
+       (goal_file "examples/eval/machine/goals/keep_cool.spg")
+       (script "examples/eval/machine/scripts/goal_finish.txt")
+       (max_steps 3)
+       (expect (termination finished)))
+
+ ; A goal that forbids acting, and a run that acts anyway. The action was
+ ; permitted by the policy — the goal is what it violates, and the two are
+ ; different layers on purpose.
+ (case (name "acted_when_forbidden")
+       (machine "examples/eval/machine/states/loop_before.spg")
+       (machine_after "examples/eval/machine/states/goal_cool.spg")
+       (process_profile "examples/eval/machine/loop-profile.spg")
+       (goal_file "examples/eval/machine/goals/no_actions.spg")
+       (script "examples/eval/machine/scripts/loop_ok.txt")
+       (max_steps 3)
+       (expect (termination finished))))

--- a/examples/eval/machine/goals/keep_cool.spg
+++ b/examples/eval/machine/goals/keep_cool.spg
@@ -1,0 +1,8 @@
+; Keep the machine below 70 C, keep the critical service alive, and do it in at
+; most three actions. Every number here is checked against the OBSERVED final
+; state — the model reading this cannot argue with it.
+(machine-goal
+  (max-temperature-mc 70000)
+  (min-critical-service-health-bp 9500)
+  (prefer-min-energy true)
+  (max-actions 3))

--- a/examples/eval/machine/goals/no_actions.spg
+++ b/examples/eval/machine/goals/no_actions.spg
@@ -1,0 +1,3 @@
+; Verify without touching anything. Not a contradiction: a machine that already
+; meets its constraints satisfies this. Any action at all fails it.
+(machine-goal (max-temperature-mc 70000) (max-actions 0))

--- a/examples/eval/machine/scripts/goal_finish.txt
+++ b/examples/eval/machine/scripts/goal_finish.txt
@@ -1,0 +1,1 @@
+(recommend (kind finish) (reason "healthy"))

--- a/examples/eval/machine/states/goal_cool.spg
+++ b/examples/eval/machine/states/goal_cool.spg
@@ -1,0 +1,5 @@
+; Cool, and the critical service is running: the goal is met.
+(machine-state (cpu-load-bp 1500) (temperature-mc 58000)
+ (memory-total-bytes 4245815296) (memory-used-bytes 1000000000)
+ (process (id "critical_app") (role critical) (cpu-bp 1200) (rss-bytes 52428800))
+ (process (id "batch_job") (role batch) (cpu-bp 0) (rss-bytes 104857600)))

--- a/examples/eval/machine/states/goal_hot.spg
+++ b/examples/eval/machine/states/goal_hot.spg
@@ -1,0 +1,5 @@
+; Still too hot after the run: whatever the model says, this goal is not met.
+(machine-state (cpu-load-bp 2000) (temperature-mc 82000)
+ (memory-total-bytes 4245815296) (memory-used-bytes 1000000000)
+ (process (id "critical_app") (role critical) (cpu-bp 1200) (rss-bytes 52428800))
+ (process (id "batch_job") (role batch) (cpu-bp 0) (rss-bytes 104857600)))

--- a/include/geistshell/actor.h
+++ b/include/geistshell/actor.h
@@ -42,6 +42,7 @@ struct spg_actor_state {
     const char *directive;
     /* Optional machine snapshot for the context (roadmap phase 3). */
     const struct spg_machine_state *machine;
+    const struct spg_machine_goal  *machine_goal;
 };
 
 struct spg_actor_step_config {

--- a/include/geistshell/agent_loop.h
+++ b/include/geistshell/agent_loop.h
@@ -93,6 +93,10 @@ struct spg_agent_loop_config {
 struct spg_agent_loop_result {
     size_t                          steps_taken;
     size_t                          repairs_used; /* self-repair retries spent */
+    /* Actions the run actually executed — not steps. A goal that bounds
+     * actions must be checked against what happened, not against how many
+     * times the model was asked. */
+    size_t                          actions_executed;
     enum spg_agent_loop_termination termination;
     enum spg_status                 last_status; /* last tick status */
     struct spg_orchestrator_result  last;        /* final step's result */

--- a/include/geistshell/agent_run.h
+++ b/include/geistshell/agent_run.h
@@ -62,6 +62,9 @@ struct spg_agent_run_inputs {
      * spg_agent_loop_config.machine_settle_ms — without it a live run measures
      * the load from before its own action. */
     uint64_t                        machine_settle_ms;
+    /* Optional goal for the context (phase 9). The harness, not the loop,
+     * decides whether it was met. */
+    const struct spg_machine_goal  *machine_goal;
 };
 
 struct spg_agent_run_config {

--- a/include/geistshell/context.h
+++ b/include/geistshell/context.h
@@ -3,6 +3,7 @@
 
 #include "geistshell/graph.h"
 #include "geistshell/journal.h"
+#include "geistshell/machine_goal.h"
 #include "geistshell/machine_state.h"
 #include "geistshell/memory.h"
 #include "geistshell/policy.h"
@@ -50,6 +51,10 @@ struct spg_context_sources {
      * Null = none, which is the default and keeps the context byte-identical
      * to before this existed — the phase-0 journal freeze depends on that. */
     const struct spg_machine_state *machine;
+    /* Optional goal, rendered as (machine-goal ...) right before the state so
+     * the model reads what the run is FOR before what it is looking at. Null =
+     * no goal, the default, and the context is unchanged. */
+    const struct spg_machine_goal *machine_goal;
     /* Optional standing directive (a learned lesson) rendered prominently as
      * (directive "...") every step — a stronger channel than the mind-palace
      * index for steering a small model's behaviour (geistshell#40 follow-up).

--- a/include/geistshell/eval.h
+++ b/include/geistshell/eval.h
@@ -41,6 +41,8 @@ struct spg_eval_case_result {
     enum spg_eval_outcome           outcome;
     enum spg_agent_loop_termination termination; /* actual */
     size_t                          steps_taken;
+    /* Actions the run executed, for a goal that bounds them (phase 9). */
+    size_t                          actions_executed;
     size_t                          repairs_used;
     enum spg_status                 status; /* run status (SPG_OK unless error) */
     /* Concrete failure signal from the final tick, so reflection can distil a

--- a/include/geistshell/machine_goal.h
+++ b/include/geistshell/machine_goal.h
@@ -1,0 +1,125 @@
+#ifndef GEISTSHELL_MACHINE_GOAL_H
+#define GEISTSHELL_MACHINE_GOAL_H
+
+#include "geistshell/machine_state.h"
+#include "geistshell/sexpr.h"
+#include "geistshell/status.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* What a machine run is for, and how to tell whether it worked (roadmap phase
+ * 9, #69).
+ *
+ *   (machine-goal
+ *     (max-temperature-mc 70000)
+ *     (min-critical-service-health-bp 9500)
+ *     (prefer-min-energy true)
+ *     (max-actions 3))
+ *
+ * Four things are kept apart on purpose, because collapsing them is how a
+ * safety property quietly becomes a suggestion:
+ *
+ *   1. HARD CONSTRAINTS — the numbers above. Measurable against the final
+ *      snapshot, and the only thing that decides whether a run succeeded.
+ *   2. OPTIMISATION PREFERENCES — prefer-min-energy. A tie-breaker, never a
+ *      pass/fail criterion; nothing here measures energy yet (#75).
+ *   3. SEMANTIC PROCESS RESTRICTIONS — what may be paused or stopped. Those
+ *      live in the process profile (#62) and are enforced by the policy gate.
+ *   4. POLICY AND SAFETY — capabilities and budgets, in the policy config.
+ *
+ * A goal can never widen 2, 3 or 4. Asking for something the policy forbids
+ * does not make it allowed; it makes the goal IMPOSSIBLE, which is a terminal
+ * state and not an error. The direction only goes one way: a goal can ask for
+ * less than the policy permits, never for more. */
+
+/* Absent constraint. Distinct from 0, which is a real and very strict bound. */
+#define SPG_GOAL_UNSET UINT64_MAX
+#define SPG_GOAL_UNSET_S INT64_MIN
+
+struct spg_machine_goal {
+    /* Hard constraints. */
+    int64_t  max_temperature_mc;
+    uint64_t min_critical_health_bp;
+    uint64_t max_actions;
+
+    /* Optimisation preference; recorded, not judged. */
+    bool prefer_min_energy;
+
+    bool present; /* false = no goal was configured */
+};
+
+/* Why a run did or did not satisfy its goal. A bare pass/fail cannot tell a
+ * harness which knob to turn, and "it said finish" is not a reason. */
+enum spg_goal_verdict {
+    SPG_GOAL_SATISFIED = 0,
+    SPG_GOAL_TEMPERATURE_TOO_HIGH,
+    SPG_GOAL_CRITICAL_UNHEALTHY,
+    SPG_GOAL_TOO_MANY_ACTIONS,
+    /* A constraint exists but the value it names could not be measured.
+     * Deliberately a failure, never a pass: an unreadable sensor is not
+     * evidence that a limit was respected. */
+    SPG_GOAL_UNMEASURABLE,
+    /* No goal was configured, so there is nothing to satisfy. Reported rather
+     * than silently passing. */
+    SPG_GOAL_NO_GOAL,
+};
+
+struct spg_goal_evaluation {
+    enum spg_goal_verdict verdict;
+    /* The measured value that decided it, for the record. */
+    int64_t  temperature_mc;
+    uint64_t critical_health_bp;
+    uint64_t actions_used;
+};
+
+[[nodiscard]] enum spg_status
+spg_machine_goal_load(size_t input_n, const char input[], size_t token_capacity,
+                      struct spg_sexpr_token   tokens[static token_capacity],
+                      size_t                   node_capacity,
+                      struct spg_sexpr_node    nodes[static node_capacity],
+                      struct spg_machine_goal *out);
+
+/* Health of the critical services in a snapshot, in basis points.
+ *
+ * First definition, and a deliberately blunt one: 10000 when every process the
+ * profile marks critical is present and running, 0 when any of them is stopped
+ * or has vanished, and UNKNOWN when the snapshot names no critical process at
+ * all. It is a availability measure, not a quality-of-service one — a finer
+ * definition needs something that measures the service itself, which is
+ * machine B's territory (#75). */
+[[nodiscard]] uint64_t
+spg_critical_health_bp(const struct spg_machine_state *state);
+
+/* Judge a finished run against its goal, from the OBSERVED state.
+ *
+ * This is the whole point of the phase: a run is not successful because the
+ * model emitted `finish`. actions_used is what the run actually executed, so a
+ * goal that bounds actions is checked against the journal's truth rather than
+ * the model's account of it. */
+[[nodiscard]] enum spg_status
+spg_machine_goal_evaluate(const struct spg_machine_goal  *goal,
+                          const struct spg_machine_state *final_state,
+                          uint64_t                        actions_used,
+                          struct spg_goal_evaluation     *out);
+
+/* Deterministic (machine-goal ...) block for the model context. Same shape as
+ * the file, so what the model reads is what the harness checks. */
+[[nodiscard]] enum spg_status
+spg_machine_goal_render(const struct spg_machine_goal *goal,
+                        size_t dst_capacity, char dst[static dst_capacity],
+                        size_t *out_required);
+
+[[nodiscard]] const char *
+spg_goal_verdict_to_string(enum spg_goal_verdict verdict);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/geistshell/orchestrator.h
+++ b/include/geistshell/orchestrator.h
@@ -50,6 +50,8 @@ struct spg_orchestrator_state {
      * a live run refreshes from the host instead. Null = the snapshot stays
      * as it was, which is phase 6's behaviour. */
     const struct spg_machine_state *machine_after;
+    /* What the run is for (phase 9). Read-only here; the harness judges it. */
+    const struct spg_machine_goal *machine_goal;
     /* Where pauses are recorded so the run can undo them (phase 6b, #80).
      * Null means a pause cannot be tracked, and an untracked pause is refused
      * rather than performed. */

--- a/src/actor/actor.c
+++ b/src/actor/actor.c
@@ -152,6 +152,7 @@ enum spg_status spg_actor_step(struct spg_actor_state                *state,
         .goal                 = state->goal,
         .directive            = state->directive,
         .machine              = state->machine,
+        .machine_goal         = state->machine_goal,
     };
 
     enum spg_status status = spg_context_build(

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -1886,7 +1886,7 @@ static int agent_command(int argc, char **argv) {
     bool     with_machine  = false; /* roadmap phase 3: (machine-state ...) */
     /* Declared up here because every early `goto done` must find it defined —
      * the cleanup path releases it. */
-    int         machine_lock = -1;
+    int machine_lock = -1;
     /* Milliseconds to let the machine settle before re-observing. Default 0
      * keeps a scripted run synchronous; a live experiment needs enough for the
      * counters to reflect its own action. */
@@ -2526,8 +2526,11 @@ struct eval_run_report {
      * action", and those want opposite fixes. */
     size_t case_parsed[EVAL_MAX_CASES];
     size_t case_gated[EVAL_MAX_CASES];
-    size_t parsed; /* runs whose form was accepted        */
-    size_t gated;  /* ... and the policy gate allowed it  */
+    /* Phase 9: the objective verdict per case, reported alongside the outcome
+     * so a reader can see WHY a run that finished cleanly still failed. */
+    enum spg_goal_verdict goal_verdicts[EVAL_MAX_CASES];
+    size_t                parsed; /* runs whose form was accepted        */
+    size_t                gated;  /* ... and the policy gate allowed it  */
 
     /* #64 diagnosis metrics. A diagnosis case asks one question — what is
      * wrong — so a bare pass rate hides the two failures that matter: naming
@@ -3061,6 +3064,35 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
                 goto done;
             }
         }
+        /* Phase 9 (#69): what the run is for. The model reads it, and the
+         * harness checks it against the machine afterwards — those are two
+         * different things and only the second decides the verdict. */
+        static struct spg_machine_goal case_machine_goal;
+        char                           goal_path[CLI_PATH_MAX];
+        const bool                     has_goal_file =
+            eval_str(nod, c, suite_text.n, suite_text.data, "goal_file",
+                     goal_path, sizeof goal_path);
+        if (has_goal_file) {
+            struct file_buffer gtext = {};
+            if (read_file(goal_path, &gtext) != SPG_OK) {
+                fprintf(stderr, "eval: cannot read goal_file %s\n", goal_path);
+                rc = SPG_E_IO;
+                goto done;
+            }
+            const enum spg_status gs = spg_machine_goal_load(
+                gtext.n, gtext.data, ws.token_capacity, ws.tokens,
+                ws.node_capacity, ws.nodes, &case_machine_goal);
+            free_file_buffer(&gtext);
+            if (gs != SPG_OK) {
+                fprintf(stderr, "eval: invalid goal_file %s: %s\n", goal_path,
+                        spg_status_to_string(gs));
+                rc = gs;
+                goto done;
+            }
+        } else {
+            case_machine_goal = (struct spg_machine_goal){};
+        }
+
         /* Without a profile nothing is managed and every machine action is
          * denied — correct as a default, useless as a scenario. */
         static struct spg_process_profile case_profile;
@@ -3221,6 +3253,9 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
                         gin.profile      = &case_profile;
                         gin.pause_ledger = &case_pause_ledger;
                     }
+                    if (has_goal_file) {
+                        gin.machine_goal = &case_machine_goal;
+                    }
                     if (has_fixture) {
                         if (!eval_sandbox_prepare(&sandbox_state, name, s,
                                                   fixture, store)) {
@@ -3302,6 +3337,9 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
                     cin.profile      = &case_profile;
                     cin.pause_ledger = &case_pause_ledger;
                 }
+                if (has_goal_file) {
+                    cin.machine_goal = &case_machine_goal;
+                }
                 if (has_fixture) {
                     if (!eval_sandbox_prepare(&sandbox_state, name, s, fixture,
                                               store)) {
@@ -3337,6 +3375,28 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
                         last.outcome = SPG_EVAL_FAIL_OBSERVATION;
                     }
                 }
+                /* Phase 9: the goal decides, not the model. A run that
+                 * emitted `finish` on a machine that still violates its
+                 * constraints has not succeeded — and the objective check has
+                 * to be able to OVERRULE a pass, or it is decoration. */
+                if (has_goal_file) {
+                    const struct spg_machine_state *observed =
+                        has_machine_after ? &case_machine_after
+                        : has_machine     ? &case_machine
+                                          : nullptr;
+                    struct spg_goal_evaluation ge = {};
+                    if (observed != nullptr &&
+                        spg_machine_goal_evaluate(&case_machine_goal, observed,
+                                                  r.actions_executed,
+                                                  &ge) == SPG_OK) {
+                        report->goal_verdicts[case_idx] = ge.verdict;
+                        if (ge.verdict != SPG_GOAL_SATISFIED &&
+                            r.outcome == SPG_EVAL_PASS) {
+                            r.outcome    = SPG_EVAL_FAIL_OBSERVATION;
+                            last.outcome = SPG_EVAL_FAIL_OBSERVATION;
+                        }
+                    }
+                }
                 if (r.outcome == SPG_EVAL_PASS) {
                     passed_in_case += 1u;
                     report->passed += 1u;
@@ -3369,10 +3429,12 @@ static void eval_print_report(const char                   *suite_path,
     for (size_t i = 0u; i < report->ncases; i += 1u) {
         const struct spg_eval_case_result *r = &report->results[i];
         printf("{\"name\":\"%s\",\"outcome\":\"%s\",\"termination\":\"%s\","
-               "\"steps\":%zu,\"repairs\":%zu",
+               "\"steps\":%zu,\"actions\":%zu,\"goal\":\"%s\",\"repairs\":%zu",
                report->names[i], spg_eval_outcome_to_string(r->outcome),
                spg_agent_loop_termination_to_string(r->termination),
-               r->steps_taken, r->repairs_used);
+               r->steps_taken, r->actions_executed,
+               spg_goal_verdict_to_string(report->goal_verdicts[i]),
+               r->repairs_used);
         /* With --samples N>1, aggregate k-of-N; N==1 stays byte-identical. */
         if (report->runs[i] > 1u) {
             printf(",\"runs\":%zu,\"passed\":%zu", report->runs[i],

--- a/src/context/context.c
+++ b/src/context/context.c
@@ -697,6 +697,18 @@ static void render_observation(const struct spg_context_sources *sources,
  * buffer can never truncate. */
 static void render_machine(const struct spg_context_sources *sources,
                            struct render_state              *state) {
+    /* Goal first: what the run is for, then what it is looking at. A model
+     * that reads the constraints after the numbers has to re-read the
+     * numbers. */
+    if (sources->machine_goal != nullptr && sources->machine_goal->present) {
+        char   goal_block[512];
+        size_t goal_n = 0u;
+        if (spg_machine_goal_render(sources->machine_goal, sizeof goal_block,
+                                    goal_block, &goal_n) == SPG_OK) {
+            append_cstr(state, goal_block);
+            append_cstr(state, "\n");
+        }
+    }
     if (sources->machine == nullptr) {
         return;
     }

--- a/src/eval/eval.c
+++ b/src/eval/eval.c
@@ -84,6 +84,7 @@ spg_eval_run_case(const struct spg_fake_response *script, const size_t script_n,
     result->status       = status;
     result->termination  = loop.termination;
     result->steps_taken  = loop.steps_taken;
+    result->actions_executed = loop.actions_executed;
     result->repairs_used = loop.repairs_used;
     /* Concrete signal from the final tick for reflection to learn from. */
     result->reject_reason = loop.last.recommendation.reject_reason;

--- a/src/machine/machine_goal.c
+++ b/src/machine/machine_goal.c
@@ -1,0 +1,301 @@
+/* Goals, and the only honest way to tell whether one was met: measure the
+ * machine, not the model's account of it. */
+
+#include "geistshell/machine_goal.h"
+
+#include <string.h>
+
+static uint32_t field_value(const size_t input_n, const char input[],
+                            const struct spg_sexpr_node nodes[static 1],
+                            const uint32_t parent, const char *name) {
+    uint32_t field = spg_sexpr_first_child(nodes, parent);
+    while (field != SPG_SEXPR_INVALID_INDEX) {
+        if (nodes[field].kind == SPG_SEXPR_NODE_LIST) {
+            const uint32_t head = spg_sexpr_first_child(nodes, field);
+            if (head != SPG_SEXPR_INVALID_INDEX &&
+                spg_sexpr_span_eq_cstr(input_n, input, nodes[head].span,
+                                       name)) {
+                return spg_sexpr_second_child(nodes, field);
+            }
+        }
+        field = nodes[field].next_sibling;
+    }
+    return SPG_SEXPR_INVALID_INDEX;
+}
+
+enum spg_status
+spg_machine_goal_load(const size_t input_n, const char input[],
+                      const size_t             token_capacity,
+                      struct spg_sexpr_token   tokens[static token_capacity],
+                      const size_t             node_capacity,
+                      struct spg_sexpr_node    nodes[static node_capacity],
+                      struct spg_machine_goal *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = (struct spg_machine_goal){
+        .max_temperature_mc     = SPG_GOAL_UNSET_S,
+        .min_critical_health_bp = SPG_GOAL_UNSET,
+        .max_actions            = SPG_GOAL_UNSET,
+    };
+
+    size_t                 token_count = 0u;
+    size_t                 node_count  = 0u;
+    struct spg_sexpr_error error       = {};
+    const enum spg_status  status      = spg_sexpr_parse_text(
+        input_n, input, token_capacity, tokens, node_capacity, nodes,
+        &token_count, &node_count, &error);
+    if (status != SPG_OK) {
+        return status;
+    }
+    if (node_count == 0u) {
+        return SPG_E_FORMAT;
+    }
+    const uint32_t root = 0u;
+    const uint32_t head = spg_sexpr_first_child(nodes, root);
+    if (nodes[root].kind != SPG_SEXPR_NODE_LIST ||
+        head == SPG_SEXPR_INVALID_INDEX ||
+        !spg_sexpr_span_eq_cstr(input_n, input, nodes[head].span,
+                                "machine-goal")) {
+        return SPG_E_SCHEMA;
+    }
+
+    uint32_t node =
+        field_value(input_n, input, nodes, root, "max-temperature-mc");
+    if (node != SPG_SEXPR_INVALID_INDEX) {
+        struct spg_text_span span   = nodes[node].span;
+        bool                 negate = false;
+        if (span.length > 0u && input[span.offset] == '-') {
+            negate = true;
+            span.offset += 1u;
+            span.length -= 1u;
+        }
+        uint64_t magnitude = 0u;
+        if (spg_sexpr_parse_uint64_span(input_n, input, span, &magnitude) !=
+                SPG_OK ||
+            magnitude > (uint64_t)INT64_MAX) {
+            return SPG_E_SCHEMA;
+        }
+        out->max_temperature_mc =
+            negate ? -(int64_t)magnitude : (int64_t)magnitude;
+    }
+
+    node = field_value(input_n, input, nodes, root,
+                       "min-critical-service-health-bp");
+    if (node != SPG_SEXPR_INVALID_INDEX) {
+        if (spg_sexpr_parse_uint64_span(input_n, input, nodes[node].span,
+                                        &out->min_critical_health_bp) !=
+            SPG_OK) {
+            return SPG_E_SCHEMA;
+        }
+        /* A share above 100% cannot be met by anything, which makes it a typo
+         * rather than a very strict goal. */
+        if (out->min_critical_health_bp > 10000u) {
+            return SPG_E_SCHEMA;
+        }
+    }
+
+    node = field_value(input_n, input, nodes, root, "max-actions");
+    if (node != SPG_SEXPR_INVALID_INDEX &&
+        spg_sexpr_parse_uint64_span(input_n, input, nodes[node].span,
+                                    &out->max_actions) != SPG_OK) {
+        return SPG_E_SCHEMA;
+    }
+
+    node = field_value(input_n, input, nodes, root, "prefer-min-energy");
+    if (node != SPG_SEXPR_INVALID_INDEX) {
+        if (spg_sexpr_span_eq_cstr(input_n, input, nodes[node].span, "true")) {
+            out->prefer_min_energy = true;
+        } else if (!spg_sexpr_span_eq_cstr(input_n, input, nodes[node].span,
+                                           "false")) {
+            return SPG_E_SCHEMA;
+        }
+    }
+
+    /* Note on (max-actions 0): it is NOT rejected as contradictory. A machine
+     * that already meets its constraints satisfies the goal without acting,
+     * and "verify without touching anything" is a legitimate run. What it does
+     * mean is that any action at all fails the goal — which the evaluation
+     * below reports as too_many_actions rather than as a parse error. */
+    out->present = true;
+    return SPG_OK;
+}
+
+uint64_t spg_critical_health_bp(const struct spg_machine_state *state) {
+    if (state == nullptr) {
+        return SPG_MACHINE_UNKNOWN;
+    }
+    size_t critical  = 0u;
+    size_t unhealthy = 0u;
+    for (size_t i = 0u; i < state->n_processes; i += 1u) {
+        const struct spg_process_sample *p = &state->processes[i];
+        if (p->role != SPG_PROCESS_ROLE_CRITICAL) {
+            continue;
+        }
+        critical += 1u;
+        /* T is stopped, Z is a zombie. Either means the service is not serving,
+         * whatever its CPU numbers say. */
+        if (p->state == 'T' || p->state == 'Z') {
+            unhealthy += 1u;
+        }
+    }
+    if (critical == 0u) {
+        /* Nothing declared critical: not perfect health, simply unmeasured.
+         * Reporting 100% here would let a goal pass on a machine where the
+         * service was never even identified. */
+        return SPG_MACHINE_UNKNOWN;
+    }
+    return unhealthy == 0u ? 10000u : 0u;
+}
+
+enum spg_status
+spg_machine_goal_evaluate(const struct spg_machine_goal  *goal,
+                          const struct spg_machine_state *final_state,
+                          const uint64_t                  actions_used,
+                          struct spg_goal_evaluation     *out) {
+    if (goal == nullptr || final_state == nullptr || out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = (struct spg_goal_evaluation){
+        .verdict            = SPG_GOAL_SATISFIED,
+        .temperature_mc     = final_state->temperature_mc,
+        .critical_health_bp = spg_critical_health_bp(final_state),
+        .actions_used       = actions_used,
+    };
+    if (!goal->present) {
+        out->verdict = SPG_GOAL_NO_GOAL;
+        return SPG_OK;
+    }
+
+    /* Actions first: it is the only constraint that cannot be unmeasurable,
+     * and a run that overspent has already failed regardless of the outcome. */
+    if (goal->max_actions != SPG_GOAL_UNSET &&
+        actions_used > goal->max_actions) {
+        out->verdict = SPG_GOAL_TOO_MANY_ACTIONS;
+        return SPG_OK;
+    }
+
+    if (goal->max_temperature_mc != SPG_GOAL_UNSET_S) {
+        if (final_state->temperature_mc == SPG_MACHINE_UNKNOWN_S) {
+            /* The constraint exists and the sensor does not. Conservative by
+             * design: a limit nobody could measure was not respected, it was
+             * merely not contradicted. */
+            out->verdict = SPG_GOAL_UNMEASURABLE;
+            return SPG_OK;
+        }
+        if (final_state->temperature_mc > goal->max_temperature_mc) {
+            out->verdict = SPG_GOAL_TEMPERATURE_TOO_HIGH;
+            return SPG_OK;
+        }
+    }
+
+    if (goal->min_critical_health_bp != SPG_GOAL_UNSET) {
+        if (out->critical_health_bp == SPG_MACHINE_UNKNOWN) {
+            out->verdict = SPG_GOAL_UNMEASURABLE;
+            return SPG_OK;
+        }
+        if (out->critical_health_bp < goal->min_critical_health_bp) {
+            out->verdict = SPG_GOAL_CRITICAL_UNHEALTHY;
+            return SPG_OK;
+        }
+    }
+    return SPG_OK;
+}
+
+/* --- rendering ---------------------------------------------------------- */
+
+struct writer {
+    size_t capacity;
+    char  *dst;
+    size_t used;
+    bool   overflowed;
+};
+
+static void put(struct writer *w, const char *text) {
+    for (size_t i = 0u; text[i] != '\0'; i += 1u) {
+        if (w->used + 1u < w->capacity) {
+            w->dst[w->used] = text[i];
+        } else {
+            w->overflowed = true;
+        }
+        w->used += 1u;
+    }
+}
+
+static void put_i64(struct writer *w, const int64_t value) {
+    char     tmp[21];
+    size_t   len = 0u;
+    uint64_t mag = value < 0 ? (uint64_t)(-(value + 1)) + 1u : (uint64_t)value;
+    do {
+        tmp[len] = (char)('0' + (mag % 10u));
+        len += 1u;
+        mag /= 10u;
+    } while (mag > 0u && len < sizeof tmp);
+    if (value < 0) {
+        put(w, "-");
+    }
+    char out[22];
+    for (size_t i = 0u; i < len; i += 1u) {
+        out[i] = tmp[len - 1u - i];
+    }
+    out[len] = '\0';
+    put(w, out);
+}
+
+enum spg_status spg_machine_goal_render(const struct spg_machine_goal *goal,
+                                        const size_t dst_capacity,
+                                        char         dst[static dst_capacity],
+                                        size_t      *out_required) {
+    if (goal == nullptr || out_required == nullptr || dst_capacity == 0u) {
+        return SPG_E_INVALID_ARG;
+    }
+    struct writer w = {.capacity = dst_capacity, .dst = dst};
+    put(&w, "(machine-goal");
+    if (goal->max_temperature_mc != SPG_GOAL_UNSET_S) {
+        put(&w, " (max-temperature-mc ");
+        put_i64(&w, goal->max_temperature_mc);
+        put(&w, ")");
+    }
+    if (goal->min_critical_health_bp != SPG_GOAL_UNSET) {
+        put(&w, " (min-critical-service-health-bp ");
+        put_i64(&w, (int64_t)goal->min_critical_health_bp);
+        put(&w, ")");
+    }
+    if (goal->max_actions != SPG_GOAL_UNSET) {
+        put(&w, " (max-actions ");
+        put_i64(&w, (int64_t)goal->max_actions);
+        put(&w, ")");
+    }
+    /* Rendered only when set: a preference the run does not hold is noise in a
+     * small model's window. */
+    if (goal->prefer_min_energy) {
+        put(&w, " (prefer-min-energy true)");
+    }
+    put(&w, ")");
+
+    *out_required = w.used + 1u;
+    if (w.overflowed) {
+        dst[0] = '\0';
+        return SPG_E_LIMIT;
+    }
+    dst[w.used] = '\0';
+    return SPG_OK;
+}
+
+const char *spg_goal_verdict_to_string(const enum spg_goal_verdict verdict) {
+    switch (verdict) {
+    case SPG_GOAL_SATISFIED:
+        return "satisfied";
+    case SPG_GOAL_TEMPERATURE_TOO_HIGH:
+        return "temperature_too_high";
+    case SPG_GOAL_CRITICAL_UNHEALTHY:
+        return "critical_unhealthy";
+    case SPG_GOAL_TOO_MANY_ACTIONS:
+        return "too_many_actions";
+    case SPG_GOAL_UNMEASURABLE:
+        return "unmeasurable";
+    case SPG_GOAL_NO_GOAL:
+        return "no_goal";
+    }
+    return "unmeasurable";
+}

--- a/src/run/agent_loop.c
+++ b/src/run/agent_loop.c
@@ -222,6 +222,7 @@ spg_agent_loop_run(struct spg_orchestrator_state           *state,
             return SPG_OK;
         }
         made_progress = true; /* reached only on an allowed, executed step */
+        result->actions_executed += 1u;
 
         /* Phase 7: observe again, so the next tick reasons about the world the
          * action left behind rather than the one it decided on. This is the

--- a/src/run/agent_run.c
+++ b/src/run/agent_run.c
@@ -91,6 +91,7 @@ enum spg_status spg_agent_run(const struct spg_agent_run_inputs *inputs,
         .directive     = directive,
         .machine       = inputs->machine,
         .machine_after = inputs->machine_after,
+        .machine_goal  = inputs->machine_goal,
         .profile       = inputs->profile,
         .pause_ledger  = inputs->pause_ledger,
     };

--- a/src/run/orchestrator.c
+++ b/src/run/orchestrator.c
@@ -208,6 +208,7 @@ spg_orchestrator_tick(struct spg_orchestrator_state           *state,
         .goal                 = state->goal,
         .directive            = state->directive,
         .machine              = state->machine,
+        .machine_goal         = state->machine_goal,
     };
     const struct spg_actor_step_config actor_config = {
         .actor_id            = config->actor_id,

--- a/test/test_cli_goal.sh
+++ b/test/test_cli_goal.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Roadmap phase 9 (#69): the goal decides, not the model.
+#
+# All three cases end with the model emitting the same `finish`. What separates
+# them is the machine each one leaves behind. If the objective check cannot
+# overrule a clean termination, it is decoration.
+set -eu
+
+SPG_BIN=${SPG_BIN:-build/host-debug/bin/geistshell}
+OUT=build/goal-eval.jsonl
+
+# Two of the three cases are SUPPOSED to fail, so the suite exits non-zero.
+# That is the result under test, not a problem running it.
+"$SPG_BIN" eval examples/eval/machine/closed_loop_goal.spg >"$OUT" || true
+
+python3 - "$OUT" <<'PY'
+import json, sys
+
+rows = [json.loads(l) for l in open(sys.argv[1])]
+by = {r["name"]: r for r in rows[:-1]}
+summary = rows[-1]
+
+hot = by["false_finish_while_hot"]
+# The run ended cleanly. That is exactly what makes this the case worth having.
+assert hot["termination"] == "finished", hot
+assert hot["outcome"] != "pass", hot
+assert hot["goal"] == "temperature_too_high", hot
+
+met = by["goal_met"]
+assert met["outcome"] == "pass", met
+assert met["goal"] == "satisfied", met
+
+# The same script and the same words from the model — only the machine differs.
+assert hot["steps"] == met["steps"], (hot, met)
+
+acted = by["acted_when_forbidden"]
+assert acted["termination"] == "finished", acted
+assert acted["goal"] == "too_many_actions", acted
+assert acted["outcome"] != "pass", acted
+# Actions, not steps: the bound is on what the run DID.
+assert acted["actions"] == 1, acted
+
+assert summary["passed"] == 1, summary
+PY
+
+echo "test_cli_goal: PASS"

--- a/test/test_machine_goal.c
+++ b/test/test_machine_goal.c
@@ -1,0 +1,292 @@
+/* Phase 9: a run is not successful because the model said so.
+ *
+ * Every case here is the same question from a different side: does the verdict
+ * come from the machine, or from the model's account of it? */
+
+#include "geistshell/machine_fixture.h"
+#include "geistshell/machine_goal.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define LIT(s) (sizeof(s) - 1u), (s)
+
+static enum spg_status load_goal(const size_t n, const char text[],
+                                 struct spg_machine_goal *out) {
+    struct spg_sexpr_token tokens[256];
+    struct spg_sexpr_node  nodes[256];
+    return spg_machine_goal_load(n, text, 256u, tokens, 256u, nodes, out);
+}
+
+static bool load_state(const size_t n, const char text[],
+                       struct spg_machine_state *out) {
+    struct spg_sexpr_token tokens[512];
+    struct spg_sexpr_node  nodes[512];
+    return spg_machine_state_parse(n, text, 512u, tokens, 512u, nodes, out) ==
+           SPG_OK;
+}
+
+static const char goal_text[] =
+    "(machine-goal (max-temperature-mc 70000)\n"
+    " (min-critical-service-health-bp 9500) (prefer-min-energy true)\n"
+    " (max-actions 3))\n";
+
+static int test_parse(void) {
+    struct spg_machine_goal g = {};
+    if (load_goal(LIT(goal_text), &g) != SPG_OK) {
+        return 1;
+    }
+    if (g.max_temperature_mc != 70000 || g.min_critical_health_bp != 9500u ||
+        g.max_actions != 3u || !g.prefer_min_energy || !g.present) {
+        return 1;
+    }
+    /* An absent constraint is unset, not zero — zero is a real and very strict
+     * bound and must not appear by omission. */
+    struct spg_machine_goal partial = {};
+    if (load_goal(LIT("(machine-goal (max-actions 1))"), &partial) != SPG_OK) {
+        return 1;
+    }
+    if (partial.max_temperature_mc != SPG_GOAL_UNSET_S ||
+        partial.min_critical_health_bp != SPG_GOAL_UNSET) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_rejects(void) {
+    struct spg_machine_goal g = {};
+    if (load_goal(LIT("(policy (network_default deny))"), &g) != SPG_E_SCHEMA) {
+        return 1;
+    }
+    if (load_goal(LIT("(machine-goal (max-actions"), &g) == SPG_OK) {
+        return 1;
+    }
+    /* A health share above 100% cannot be met by anything, which makes it a
+     * typo rather than a strict goal. */
+    if (load_goal(LIT("(machine-goal (min-critical-service-health-bp 20000))"),
+                  &g) != SPG_E_SCHEMA) {
+        return 1;
+    }
+    if (load_goal(LIT("(machine-goal (prefer-min-energy maybe))"), &g) !=
+        SPG_E_SCHEMA) {
+        return 1;
+    }
+    if (load_goal(LIT("(machine-goal (max-actions -1))"), &g) == SPG_OK) {
+        return 1;
+    }
+    return 0;
+}
+
+/* THE case this phase exists for: the model says finish, the machine is still
+ * too hot, and the run must not count as a success. */
+static int test_false_finish_fails(void) {
+    struct spg_machine_goal  g = {};
+    struct spg_machine_state s = {};
+    if (load_goal(LIT(goal_text), &g) != SPG_OK) {
+        return 1;
+    }
+    if (!load_state(LIT("(machine-state (temperature-mc 82000)"
+                        " (process (id \"critical_app\") (role critical)"
+                        " (cpu-bp 100) (rss-bytes 1)))"),
+                    &s)) {
+        return 1;
+    }
+    struct spg_goal_evaluation e = {};
+    if (spg_machine_goal_evaluate(&g, &s, 1u, &e) != SPG_OK) {
+        return 1;
+    }
+    if (e.verdict != SPG_GOAL_TEMPERATURE_TOO_HIGH) {
+        printf("  verdict=%s\n", spg_goal_verdict_to_string(e.verdict));
+        return 1;
+    }
+    /* The measured value travels with the verdict: a harness that only learns
+     * "failed" cannot tell a hot machine from an overspent one. */
+    if (e.temperature_mc != 82000) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_satisfied(void) {
+    struct spg_machine_goal  g = {};
+    struct spg_machine_state s = {};
+    if (load_goal(LIT(goal_text), &g) != SPG_OK) {
+        return 1;
+    }
+    if (!load_state(LIT("(machine-state (temperature-mc 58000)"
+                        " (process (id \"critical_app\") (role critical)"
+                        " (cpu-bp 2400) (rss-bytes 1)))"),
+                    &s)) {
+        return 1;
+    }
+    struct spg_goal_evaluation e = {};
+    if (spg_machine_goal_evaluate(&g, &s, 2u, &e) != SPG_OK ||
+        e.verdict != SPG_GOAL_SATISFIED) {
+        return 1;
+    }
+    return 0;
+}
+
+/* A paused critical process is the failure the whole profile exists to
+ * prevent; the goal must see it even if the run terminated cleanly. */
+static int test_paused_critical_fails(void) {
+    struct spg_machine_goal g = {};
+    if (load_goal(LIT("(machine-goal (min-critical-service-health-bp 9500))"),
+                  &g) != SPG_OK) {
+        return 1;
+    }
+    struct spg_machine_state s = {.n_processes = 1u};
+    s.processes[0]             = (struct spg_process_sample){
+        .role = SPG_PROCESS_ROLE_CRITICAL, .state = 'T'};
+    struct spg_goal_evaluation e = {};
+    if (spg_machine_goal_evaluate(&g, &s, 1u, &e) != SPG_OK ||
+        e.verdict != SPG_GOAL_CRITICAL_UNHEALTHY) {
+        return 1;
+    }
+    s.processes[0].state = 'S';
+    if (spg_machine_goal_evaluate(&g, &s, 1u, &e) != SPG_OK ||
+        e.verdict != SPG_GOAL_SATISFIED) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_action_budget(void) {
+    struct spg_machine_goal g = {};
+    if (load_goal(LIT("(machine-goal (max-actions 2))"), &g) != SPG_OK) {
+        return 1;
+    }
+    struct spg_machine_state   s = {};
+    struct spg_goal_evaluation e = {};
+    if (spg_machine_goal_evaluate(&g, &s, 2u, &e) != SPG_OK ||
+        e.verdict != SPG_GOAL_SATISFIED) {
+        return 1;
+    }
+    if (spg_machine_goal_evaluate(&g, &s, 3u, &e) != SPG_OK ||
+        e.verdict != SPG_GOAL_TOO_MANY_ACTIONS) {
+        return 1;
+    }
+    /* max-actions 0 is a legitimate run — verify, touch nothing. It is not a
+     * contradiction, so it parses; any action at all then fails it. */
+    struct spg_machine_goal zero = {};
+    if (load_goal(LIT("(machine-goal (max-actions 0))"), &zero) != SPG_OK) {
+        return 1;
+    }
+    if (spg_machine_goal_evaluate(&zero, &s, 0u, &e) != SPG_OK ||
+        e.verdict != SPG_GOAL_SATISFIED) {
+        return 1;
+    }
+    if (spg_machine_goal_evaluate(&zero, &s, 1u, &e) != SPG_OK ||
+        e.verdict != SPG_GOAL_TOO_MANY_ACTIONS) {
+        return 1;
+    }
+    return 0;
+}
+
+/* An unreadable sensor is not evidence that a limit was respected. */
+static int test_unmeasurable_is_not_success(void) {
+    struct spg_machine_goal g = {};
+    if (load_goal(LIT("(machine-goal (max-temperature-mc 70000))"), &g) !=
+        SPG_OK) {
+        return 1;
+    }
+    struct spg_machine_state   s = {.temperature_mc = SPG_MACHINE_UNKNOWN_S};
+    struct spg_goal_evaluation e = {};
+    if (spg_machine_goal_evaluate(&g, &s, 0u, &e) != SPG_OK ||
+        e.verdict != SPG_GOAL_UNMEASURABLE) {
+        return 1;
+    }
+    /* Same for health: a machine with no critical process declared has not
+     * proven its critical service is fine. */
+    struct spg_machine_goal h = {};
+    if (load_goal(LIT("(machine-goal (min-critical-service-health-bp 9000))"),
+                  &h) != SPG_OK) {
+        return 1;
+    }
+    struct spg_machine_state empty = {};
+    if (spg_machine_goal_evaluate(&h, &empty, 0u, &e) != SPG_OK ||
+        e.verdict != SPG_GOAL_UNMEASURABLE) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_no_goal_is_reported(void) {
+    const struct spg_machine_goal  none = {};
+    const struct spg_machine_state s    = {};
+    struct spg_goal_evaluation     e    = {};
+    if (spg_machine_goal_evaluate(&none, &s, 0u, &e) != SPG_OK) {
+        return 1;
+    }
+    /* Not "satisfied": a run with no goal met no goal, and a harness that
+     * counted it as a pass would inflate every summary it produces. */
+    return e.verdict == SPG_GOAL_NO_GOAL ? 0 : 1;
+}
+
+static int test_render(void) {
+    struct spg_machine_goal g = {};
+    if (load_goal(LIT(goal_text), &g) != SPG_OK) {
+        return 1;
+    }
+    char   buf[512];
+    size_t required = 0u;
+    if (spg_machine_goal_render(&g, sizeof buf, buf, &required) != SPG_OK) {
+        return 1;
+    }
+    const char *expected =
+        "(machine-goal (max-temperature-mc 70000)"
+        " (min-critical-service-health-bp 9500) (max-actions 3)"
+        " (prefer-min-energy true))";
+    if (strcmp(buf, expected) != 0) {
+        printf("  rendered: %s\n", buf);
+        return 1;
+    }
+    /* What the model reads must be re-readable as the same goal, or the
+     * context and the verdict are describing different runs. */
+    struct spg_machine_goal reparsed = {};
+    if (load_goal(required - 1u, buf, &reparsed) != SPG_OK) {
+        return 1;
+    }
+    if (reparsed.max_temperature_mc != g.max_temperature_mc ||
+        reparsed.min_critical_health_bp != g.min_critical_health_bp ||
+        reparsed.max_actions != g.max_actions) {
+        return 1;
+    }
+    /* One byte short: no partial goal escapes into a context. */
+    char   tight[512];
+    size_t needed = 0u;
+    if (spg_machine_goal_render(&g, required - 1u, tight, &needed) !=
+            SPG_E_LIMIT ||
+        tight[0] != '\0') {
+        return 1;
+    }
+    return 0;
+}
+
+int main(void) {
+    const struct {
+        const char *name;
+        int (*fn)(void);
+    } cases[] = {
+        {"parse", test_parse},
+        {"rejects", test_rejects},
+        {"false_finish_fails", test_false_finish_fails},
+        {"satisfied", test_satisfied},
+        {"paused_critical_fails", test_paused_critical_fails},
+        {"action_budget", test_action_budget},
+        {"unmeasurable_is_not_success", test_unmeasurable_is_not_success},
+        {"no_goal_is_reported", test_no_goal_is_reported},
+        {"render", test_render},
+    };
+    int failures = 0;
+    for (size_t i = 0u; i < sizeof cases / sizeof cases[0]; i += 1u) {
+        if (cases[i].fn() != 0) {
+            printf("test_machine_goal: FAIL %s\n", cases[i].name);
+            failures += 1;
+        }
+    }
+    if (failures == 0) {
+        printf("test_machine_goal: PASS\n");
+    }
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Phase 9 der Roadmap (#69). Stapelt auf #89. Ein Lauf ist nicht erfolgreich, weil das Modell `finish` sagt.

## Der Nachweis

Drei Szenarien, **alle enden damit, dass das Modell dasselbe `finish` ausgibt.** Was sie unterscheidet, ist die Maschine, die sie hinterlassen:

| Fall | Termination | Verdikt | Ergebnis |
|---|---|---|---|
| `false_finish_while_hot` | `finished` | `temperature_too_high` | **fail** |
| `goal_met` | `finished` | `satisfied` | pass |
| `acted_when_forbidden` | `finished` | `too_many_actions` | **fail** |

Der erste Fall ist der, für den die Phase existiert: sauber terminiert, korrekt geparst, vom Gate zugelassen — und trotzdem gescheitert, weil die Maschine bei 82 °C steht. **Kann die objektive Prüfung ein `pass` nicht überstimmen, ist sie Dekoration.**

Der dritte trennt Policy von Ziel: die Aktion war von der Policy *erlaubt*, das **Ziel** verbietet sie. Zwei Schichten, zwei Antworten.

## Vier Schichten, bewusst getrennt

| Schicht | Wo | Wer prüft |
|---|---|---|
| harte Constraints | `(machine-goal ...)` | der Harness, gegen den beobachteten Endzustand |
| Optimierungspräferenz | `prefer-min-energy` | niemand — protokolliert, nicht bewertet |
| semantische Prozessrestriktionen | Process Profile (#62) | Policy Gate |
| Policy und Safety | Policy Config | Policy Gate |

Ein Ziel kann die Schichten 2–4 **nie** erweitern. Etwas zu verlangen, das die Policy verbietet, macht es nicht erlaubt, sondern das Ziel unerreichbar.

`prefer-min-energy` wird bewusst nicht bewertet: hier misst nichts Energie (#75). Ein Kriterium, das als solches durchginge, ohne dass jemand es messen kann, wäre schlimmer als keins.

## Unmessbar ist kein Erfolg

Ein Constraint, dessen Wert nicht gelesen werden konnte, gilt als **nicht erfüllt** — ein defekter Sensor ist kein Beleg dafür, dass ein Grenzwert eingehalten wurde, er wurde nur nicht widerlegt. Dasselbe für `min-critical-service-health-bp` auf einer Maschine ohne kritischen Prozess im Snapshot: 100 % zu melden hieße, ein Ziel zu bestehen, dessen Gegenstand nie identifiziert wurde.

Und ein Lauf ohne Ziel meldet `no_goal`, nicht `satisfied` — sonst bläht er jede Zusammenfassung auf, in der er vorkommt.

## Aktionen, nicht Schritte

`max-actions` prüft gegen `actions_executed`, also was der Lauf **getan** hat. Ein Modell, das dreimal nachdenkt und einmal handelt, hat eine Aktion verbraucht.

`(max-actions 0)` wird **nicht** als Widerspruch abgelehnt: „prüfen, ohne etwas anzufassen" ist ein legitimer Lauf, den eine bereits konforme Maschine besteht.

## Grenzen, benannt

- **Kein Optimierungsframework** — Constraints sind Schwellwerte, keine Zielfunktion. Ohne Energiemessung wäre eine ohnehin unvollständig.
- **Ein Endzustand, keine Trajektorie.** Eine Temperatur, die *zwischendurch* über dem Grenzwert lag, sieht diese Prüfung nicht; dafür bräuchte es das History-Fenster (#79).
- **`impossible` ist kein eigenes Verdikt.** Ein unerreichbares Ziel meldet, welcher Constraint scheiterte, nicht „das war nie zu schaffen" — das zu unterscheiden bräuchte ein Modell davon, was die Maschine überhaupt könnte.

## Verifikation

macOS und Pi 5: `make test` grün, 38 bzw. 39 PASS, warnungsfrei, ASan/UBSan sauber.

Doku: `docs/machine-intelligence/Goals.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
