### PR TITLE
Phase 10: Model Tournament — und die Latenz aus Phase 4

### DIFF
--- a/docs/machine-intelligence/Model-Tournament.md
+++ b/docs/machine-intelligence/Model-Tournament.md
@@ -1,0 +1,98 @@
+# Model Tournament — Phase 10
+
+Dieselben Szenarien, verschiedene Modelle, eine Tabelle.
+
+Ticket: geisten/geistshell#70. Voraussetzungen:
+[Diagnosis-Benchmark.md](Diagnosis-Benchmark.md), [Goals.md](Goals.md).
+
+## Kein zweiter Harness
+
+Jeder Teilnehmer läuft durch den **vorhandenen** Modell-Adapter und den
+**vorhandenen** Eval-Harness. Ein eigener Turnier-Pfad würde zwei Harnesses
+vergleichen statt zwei Modelle.
+
+`examples/machine/run_tournament.sh` erzeugt pro Modell eine Run-Config (der
+Modellpfad steht dort, nicht in der Umgebung), fährt die Suite und schreibt
+eine Zeile nach `machine-benchmark.jsonl`. Am Ende entsteht
+`machine-benchmark.md`.
+
+## Latenz, endlich gemessen
+
+Phase 4 ließ die Inferenzzeit offen. Der Harness misst jetzt Wanduhr pro Fall
+und Peak-RSS für den Prozess — **hinter `--timing`, standardmäßig aus.**
+
+Der Grund für den Schalter ist kein Geschmack: zwei identische Eval-Läufe
+müssen bitgleiche Reports liefern. Ein Wanduhr-Wert im Standard-Output bricht
+jeden Diff und den Fixture-Test, der genau darauf beruht. Ein Report ist zum
+Vergleichen da; eine Messung gehört hinter einen Schalter. Der bestehende Test
+hat mich darauf gestoßen, nachdem ich die Felder zuerst unbedingt ausgegeben
+hatte.
+
+Die Runtime selbst liest weiterhin keine Uhr — das ist es, was Replay
+byte-identisch hält. Gemessen wird im Harness, und nichts davon erreicht
+Journal oder Context.
+
+## Was in der Tabelle steht
+
+| Spalte | Woher | Grenze |
+|---|---|---|
+| Size | `stat` der GGUF-Datei | – |
+| Known / Held-out | getrennt, nie gemittelt | – |
+| Unsafe | Aktionsvorschlag in einer reinen Diagnose-Suite | – |
+| Reject | Anteil nicht geparster Empfehlungen | – |
+| Deny | geparst, aber vom Gate abgelehnt | eigene Spalte, nicht mit Reject vermischt |
+| Steps / p95 | pro Fall | p95 über neun Fälle ist eine Beschreibung, keine Statistik |
+| Latency | ganze Suite auf diesem Host | **nicht** pro Inferenz — dafür bräuchte es Instrumentierung im Adapter |
+| Peak RSS | Harness-Prozess | enthält das Modell, aber auch den Harness |
+
+Reject und Deny bleiben getrennt: eine Empfehlung, die nicht parst, und eine,
+die geparst und abgelehnt wurde, sind verschiedene Fehler. Sie zu addieren
+verwischt genau den Unterschied, den die Leiter aus #53 sichtbar macht.
+
+## Wer nicht antritt, steht trotzdem in der Tabelle
+
+Ein Modell, das nicht geladen werden konnte, bekommt eine Zeile mit
+`not run (status N)` — nicht das Weglassen. Eine Tabelle, in der ein Teilnehmer
+fehlt, lädt den Leser ein anzunehmen, es sei schon in Ordnung gewesen.
+
+Ein nicht konfiguriertes Remote-Modell ist genau dieser Fall und wird **nie**
+als bestanden gewertet.
+
+## Kein Best-of-N
+
+Bei `--samples N > 1` berichtet der Harness k/N pro Fall. Es gibt keinen Pfad,
+der den besten Lauf auswählt — nicht weil es niemand tut, sondern weil es ihn
+nicht gibt. Die answer-free Selektion aus #55 ist die Alternative, wo eine
+Auswahl gebraucht wird.
+
+## Gemessen auf dem Pi 5
+
+| Model | Size | Known | Held-out | Unsafe | Reject | Steps | Latency | Peak RSS |
+|---|---|---|---|---|---|---|---|---|
+| fake (scripted) | – | 6/6 | 3/3 | 0 | 0 | 1,0 | 1 ms | 3,7 MB |
+| Gemma4-E2B Q4_K_M | 2963 MB | **2/6** | **1/3** | 0 | 0 | 1,0 | 254 852 ms | 1,82 GB |
+| remote | – | nicht gelaufen (kein `GEISTSHELL_API_URL`) | | | | | | |
+
+Rund 28 Sekunden pro Fall auf vier Kernen. Peak-RSS liegt unter der Dateigröße,
+weil die Gewichte gemappt und nicht kopiert werden.
+
+Das Ergebnis deckt sich exakt mit Phase 4 (2/6 known, 1/3 held-out) — dasselbe
+Modell, dieselbe Suite, dieselbe Zahl. Zwei unabhängige Läufe über
+verschiedene Codepfade, die dasselbe sagen, sind mehr wert als ein Lauf mit
+einer schöneren Zahl.
+
+Die Form sitzt, die Entscheidung nicht: Parse und Gate bleiben vollständig, das
+Modell wählt nur die falsche Ursache.
+
+## Grenzen
+
+- **Latenz ist Suite-Latenz.** Pro-Token- oder Pro-Inferenz-Zeiten bräuchten
+  eine Uhr im Adapter. Das ist eine Änderung an der Inferenzschicht und keine
+  am Harness — sie gehört dorthin, wo jemand sie braucht.
+- **Peak RSS ist Prozess-RSS.** Modell und Harness sind darin nicht getrennt.
+  Für einen Größenvergleich zwischen Modellen ist die Differenz zum
+  Fake-Adapter der ehrlichere Wert.
+- **CPU-Auslastung während der Inferenz wird nicht gemessen.** Das Ticket
+  nennt sie; sie bräuchte einen Sampler neben dem laufenden Modell, und der
+  wäre selbst Last. Nicht gemessen ist besser als falsch gemessen.
+- **Energie: `null`.** Wie überall, bis #75 etwas hat, das sie misst.

--- a/examples/machine/run_tournament.sh
+++ b/examples/machine/run_tournament.sh
@@ -1,0 +1,232 @@
+#!/bin/sh
+# Model tournament (roadmap phase 10, #70).
+#
+# Runs the SAME machine scenarios through every model and writes one row per
+# model. No new model framework: every entrant goes through the existing
+# adapter and the existing eval harness, or the comparison would be between two
+# harnesses rather than two models.
+#
+#   run_tournament.sh [--samples N] [--models "fake geist:/path/to.gguf remote"]
+#                     [--out-dir build]
+#
+# A model that cannot be reached produces an error row. It is never counted as
+# a pass and never silently skipped — a table with a missing entrant invites
+# the reader to assume it was fine.
+set -eu
+
+SPG_BIN=${SPG_BIN:-build/host-debug/bin/geistshell}
+SAMPLES=1
+OUT_DIR=build
+MODELS="fake"
+# Two suites, because a scripted case and a model case are different files:
+# the first pins the ground truth, the second declares (model "geist") per case
+# so a real model actually runs. Pointing every entrant at the scripted suite
+# is how you get a table where a 3 GB model scores 6/6 in 0 ms — which is what
+# the first version of this script did, and the table looked perfectly fine.
+SUITE=examples/eval/machine/diagnosis.spg
+MODEL_SUITE=examples/eval/machine/diagnosis_model.spg
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --samples) SAMPLES=$2; shift 2 ;;
+        --models) MODELS=$2; shift 2 ;;
+        --out-dir) OUT_DIR=$2; shift 2 ;;
+        --suite) SUITE=$2; shift 2 ;;
+        --model-suite) MODEL_SUITE=$2; shift 2 ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+mkdir -p "$OUT_DIR"
+JSONL="$OUT_DIR/machine-benchmark.jsonl"
+MD="$OUT_DIR/machine-benchmark.md"
+: >"$JSONL"
+
+for entry in $MODELS; do
+    kind=${entry%%:*}
+    path=${entry#*:}
+    [ "$path" = "$entry" ] && path=""
+
+    RAW="$OUT_DIR/tournament-$kind.jsonl"
+    STATUS=0
+    SIZE=0
+    [ -n "$path" ] && [ -f "$path" ] && SIZE=$(wc -c <"$path" | tr -d ' ')
+
+    case "$kind" in
+        fake)
+            # The scripted baseline. Not a model: the control that shows the
+            # harness itself scores correctly.
+            "$SPG_BIN" eval "$SUITE" --samples "$SAMPLES" --timing >"$RAW" 2>/dev/null \
+                || STATUS=$?
+            ;;
+        geist)
+            if [ -z "$path" ] || [ ! -f "$path" ]; then
+                echo "tournament: no model file for geist ($path)" >&2
+                STATUS=127
+                : >"$RAW"
+            else
+                # The model path lives in the run config, not the environment,
+                # so an entrant needs its own config and a suite pointing at
+                # it. Generated rather than checked in: the path is per host.
+                RUNCFG="$OUT_DIR/tournament-run-$kind.spg"
+                SUITECFG="$OUT_DIR/tournament-suite-$kind.spg"
+                BASECFG=$(sed -n 's/.*(config "\([^"]*\)").*/\1/p' \
+                          "$MODEL_SUITE" | head -1)
+                # Only the model line is replaced; policy, budgets and journal
+                # stay exactly as configured.
+                sed "s|(model \"[^\"]*\")|(model \"$path\")|" "$BASECFG" \
+                    >"$RUNCFG"
+                sed "s|(config \"[^\"]*\")|(config \"$RUNCFG\")|" \
+                    "$MODEL_SUITE" >"$SUITECFG"
+                # A model entrant whose suite has no model cases would quietly
+                # run the scripted answers and produce a table that looks
+                # right. Refuse instead: a wrong number is worse than none.
+                if ! grep -q '(model "geist")' "$SUITECFG"; then
+                    echo "tournament: $MODEL_SUITE has no (model \"geist\") cases" >&2
+                    STATUS=2
+                    : >"$RAW"
+                else
+                    "$SPG_BIN" eval "$SUITECFG" --samples "$SAMPLES" \
+                        --constrained --timing >"$RAW" 2>/dev/null || STATUS=$?
+                fi
+            fi
+            ;;
+        remote)
+            if [ -z "${GEISTSHELL_API_URL:-}" ]; then
+                echo "tournament: GEISTSHELL_API_URL unset, remote not run" >&2
+                STATUS=127
+                : >"$RAW"
+            else
+                "$SPG_BIN" eval "$SUITE" --samples "$SAMPLES" --timing \
+                    --remote-url "$GEISTSHELL_API_URL" >"$RAW" 2>/dev/null \
+                    || STATUS=$?
+            fi
+            ;;
+        *)
+            echo "tournament: unknown model kind $kind" >&2
+            STATUS=2
+            : >"$RAW"
+            ;;
+    esac
+
+    python3 - "$RAW" "$kind" "$path" "$SIZE" "$STATUS" "$SAMPLES" "$JSONL" <<'PY'
+import json, sys
+
+raw, kind, path, size, status, samples, out = sys.argv[1:8]
+rows = []
+try:
+    with open(raw, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+except (OSError, json.JSONDecodeError):
+    rows = []
+
+cases = [r for r in rows if "name" in r]
+summary = next((r for r in rows if "suite" in r), None)
+
+record = {
+    "model": kind,
+    "model_path": path or None,
+    "model_size_bytes": int(size) or None,
+    "samples": int(samples),
+    "status": int(status),
+}
+
+if summary is None:
+    # No usable output. Reported as an error row rather than omitted: a table
+    # with a missing entrant reads as "it was fine".
+    record.update({"available": False, "known": None, "heldout": None,
+                   "unsafe": None, "reject_rate": None, "deny_rate": None,
+                   "mean_steps": None, "p95_steps": None,
+                   "latency_ms": None, "peak_rss_kb": None})
+else:
+    diag = summary.get("diagnosis", {})
+    total = summary.get("total", 0) or 0
+    parsed = summary.get("parsed", 0) or 0
+    gated = summary.get("gated", 0) or 0
+    steps = sorted(c.get("steps", 0) for c in cases)
+
+    def p95(values):
+        if not values:
+            return None
+        # Nearest-rank. With nine cases this is the second-worst, and saying so
+        # matters more than the number: a p95 over a handful of samples is a
+        # description, not a statistic.
+        import math
+        idx = max(0, math.ceil(0.95 * len(values)) - 1)
+        return values[idx]
+
+    record.update({
+        "available": True,
+        # Known and held-out never averaged: the split is the point.
+        "known": diag.get("known"),
+        "known_runs": diag.get("known_runs"),
+        "heldout": diag.get("heldout"),
+        "heldout_runs": diag.get("heldout_runs"),
+        "unsafe": diag.get("action_proposed"),
+        "hallucinated": diag.get("hallucinated"),
+        # A recommendation that did not parse, and one that parsed but was
+        # denied, are different failures and stay apart.
+        "reject_rate": round((total - parsed) / total, 4) if total else None,
+        "deny_rate": round((parsed - gated) / total, 4) if total else None,
+        "mean_steps": round(sum(steps) / len(steps), 2) if steps else None,
+        "p95_steps": p95(steps),
+        "latency_ms": summary.get("latency_ms"),
+        "peak_rss_kb": summary.get("peak_rss_kb"),
+    })
+
+with open(out, "a", encoding="utf-8") as f:
+    f.write(json.dumps(record) + "\n")
+PY
+done
+
+python3 - "$JSONL" "$MD" "$SUITE" "$MODEL_SUITE" <<'PY'
+import json, sys
+
+jsonl, md, suite, model_suite = sys.argv[1:5]
+rows = [json.loads(l) for l in open(jsonl, encoding="utf-8")]
+
+def cell(value, suffix=""):
+    return "–" if value is None else f"{value}{suffix}"
+
+def size_mb(value):
+    return "–" if not value else f"{value / (1024 * 1024):.0f} MB"
+
+lines = [
+    "# Machine Benchmark",
+    "",
+    f"Scripted control: `{suite}`. Model entrants: `{model_suite}`.",
+    "Generated by `examples/machine/run_tournament.sh`.",
+    "",
+    "Known and held-out are reported apart and never averaged. A model that",
+    "could not be run appears as a row with no numbers rather than not at all.",
+    "",
+    "| Model | Size | Known | Held-out | Unsafe | Reject | Steps | p95 | Latency | Peak RSS |",
+    "|---|---|---|---|---|---|---|---|---|---|",
+]
+for r in rows:
+    if not r.get("available"):
+        lines.append(
+            f"| {r['model']} | {size_mb(r['model_size_bytes'])} | "
+            f"not run (status {r['status']}) | | | | | | | |")
+        continue
+    known = f"{r['known']}/{r['known_runs']}" if r.get("known_runs") else "–"
+    held = f"{r['heldout']}/{r['heldout_runs']}" if r.get("heldout_runs") else "–"
+    lines.append(
+        f"| {r['model']} | {size_mb(r['model_size_bytes'])} | {known} | {held} "
+        f"| {cell(r['unsafe'])} | {cell(r['reject_rate'])} "
+        f"| {cell(r['mean_steps'])} | {cell(r['p95_steps'])} "
+        f"| {cell(r['latency_ms'], ' ms')} | {cell(r['peak_rss_kb'], ' kB')} |")
+
+lines += [
+    "",
+    "Latency is the whole suite on this host, not per inference — the harness",
+    "times cases, and a per-token number would need instrumentation inside the",
+    "adapter. Peak RSS is the harness process, so it includes the model.",
+    "",
+]
+open(md, "w", encoding="utf-8").write("\n".join(lines))
+print(f"wrote {jsonl} and {md}")
+PY

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -31,6 +31,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/resource.h>
+#include <time.h>
 #include <sys/file.h>
 #include <unistd.h> /* mkstemp/write/close/unlink: the guard-gate temp suite */
 
@@ -749,6 +751,29 @@ static int lock_machine_journal(const char *journal_path) {
         return -1;
     }
     return fd;
+}
+
+/* Wall clock for measurement only — never for anything the journal records.
+ * A benchmark has to know how long a thing took; the runtime still must not. */
+static uint64_t bench_now_ms(void) {
+    struct timespec ts = {};
+    (void)clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000u + (uint64_t)(ts.tv_nsec / 1000000);
+}
+
+/* Peak resident set of this process, in kilobytes. Linux reports ru_maxrss in
+ * KB and macOS in bytes — a difference that would otherwise show up as a
+ * thousandfold jump between hosts in the results table. */
+static uint64_t bench_peak_rss_kb(void) {
+    struct rusage usage = {};
+    if (getrusage(RUSAGE_SELF, &usage) != 0) {
+        return 0u;
+    }
+#if defined(__APPLE__)
+    return (uint64_t)usage.ru_maxrss / 1024u;
+#else
+    return (uint64_t)usage.ru_maxrss;
+#endif
 }
 
 static void update_run_usage(struct spg_policy_usage              *usage,
@@ -2526,6 +2551,20 @@ struct eval_run_report {
      * action", and those want opposite fixes. */
     size_t case_parsed[EVAL_MAX_CASES];
     size_t case_gated[EVAL_MAX_CASES];
+    /* Phase 10 (#70): wall time per case and peak RSS for the whole suite.
+     *
+     * Measured here and nowhere else. The runtime reads no clock — that is what
+     * keeps replay byte-identical — but a benchmark that cannot say how long
+     * something took is not a benchmark. This never enters a journal or a
+     * context; it is the harness observing itself. */
+    uint64_t case_latency_ms[EVAL_MAX_CASES];
+    uint64_t suite_latency_ms;
+    uint64_t peak_rss_kb;
+    /* Off by default, and that is not laziness: two identical eval runs must
+     * produce byte-identical reports, and a wall-clock number in the default
+     * output breaks every diff and every fixture test that relies on it.
+     * A measurement belongs behind a switch; a report is for comparing. */
+    bool report_timing;
     /* Phase 9: the objective verdict per case, reported alongside the outcome
      * so a reader can see WHY a run that finished cleanly still failed. */
     enum spg_goal_verdict goal_verdicts[EVAL_MAX_CASES];
@@ -2935,7 +2974,8 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
                                     nod[head].span, "case")) {
             continue;
         }
-        const size_t case_idx = report->ncases;
+        const size_t   case_idx  = report->ncases;
+        const uint64_t case_start = bench_now_ms();
         char        *name     = report->names[case_idx];
         (void)snprintf(name, sizeof report->names[0], "case");
         char script_path[CLI_PATH_MAX];
@@ -3407,7 +3447,8 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
             free_file_buffer(&script_text);
         }
 
-        report->results[case_idx]     = last;
+        report->case_latency_ms[case_idx] = bench_now_ms() - case_start;
+        report->results[case_idx]         = last;
         report->runs[case_idx]        = runs_in_case;
         report->case_passed[case_idx] = passed_in_case;
         report->ncases += 1u;
@@ -3424,6 +3465,7 @@ done:
     return rc;
 }
 
+
 static void eval_print_report(const char                   *suite_path,
                               const struct eval_run_report *report) {
     for (size_t i = 0u; i < report->ncases; i += 1u) {
@@ -3435,6 +3477,10 @@ static void eval_print_report(const char                   *suite_path,
                r->steps_taken, r->actions_executed,
                spg_goal_verdict_to_string(report->goal_verdicts[i]),
                r->repairs_used);
+        if (report->report_timing) {
+            printf(",\"latency_ms\":%llu",
+                   (unsigned long long)report->case_latency_ms[i]);
+        }
         /* With --samples N>1, aggregate k-of-N; N==1 stays byte-identical. */
         if (report->runs[i] > 1u) {
             printf(",\"runs\":%zu,\"passed\":%zu", report->runs[i],
@@ -3461,6 +3507,11 @@ static void eval_print_report(const char                   *suite_path,
            ",\"parsed\":%zu,\"gated\":%zu",
            suite_path, report->total, report->passed, report->parsed,
            report->gated);
+    if (report->report_timing) {
+        printf(",\"latency_ms\":%llu,\"peak_rss_kb\":%llu",
+               (unsigned long long)report->suite_latency_ms,
+               (unsigned long long)report->peak_rss_kb);
+    }
     if (report->diagnosis_suite) {
         size_t known_runs = 0u, known_ok = 0u, held_runs = 0u, held_ok = 0u;
         size_t halluc = 0u, actions = 0u;
@@ -3496,7 +3547,16 @@ static int eval_command(int argc, char **argv) {
     size_t      samples      = 1u;
     bool        constrained  = false;
     float       temperature  = 0.0f;
+    bool report_timing = false;
     for (int i = 2; i < argc; i += 1) {
+        if (strcmp(argv[i], "--timing") == 0) {
+            /* Adds wall-clock and peak RSS to the report. Off by default so
+             * two identical runs stay byte-identical — the property the
+             * fixture test relies on, and the one that makes a report worth
+             * diffing at all. */
+            report_timing = true;
+            continue;
+        }
         if (strcmp(argv[i], "--remote-url") == 0 && i + 1 < argc) {
             remote_url = argv[++i];
             continue;
@@ -3539,6 +3599,7 @@ static int eval_command(int argc, char **argv) {
         return 2;
     }
     static struct eval_run_report report;
+    const uint64_t                suite_start_ms = bench_now_ms();
     const struct eval_run_opts    opts = {.remote_url   = remote_url,
                                           .remote_model = remote_model,
                                           .samples      = samples,
@@ -3551,6 +3612,9 @@ static int eval_command(int argc, char **argv) {
                 spg_status_to_string(status));
         return 1;
     }
+    report.suite_latency_ms = bench_now_ms() - suite_start_ms;
+    report.peak_rss_kb      = bench_peak_rss_kb();
+    report.report_timing    = report_timing;
     eval_print_report(suite_path, &report);
     return (report.total > 0u && report.passed == report.total) ? 0 : 1;
 }

--- a/test/test_cli_tournament.sh
+++ b/test/test_cli_tournament.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# Roadmap phase 10 (#70): the tournament runner.
+#
+# What a smoke test can prove here is not that a model is good — it is that the
+# table cannot lie: a model that did not run must be visible as such, and the
+# split between known and held-out must survive into the output.
+set -eu
+
+SPG_BIN=${SPG_BIN:-build/host-debug/bin/geistshell}
+OUT_DIR=build/tournament-test
+RUNNER=examples/machine/run_tournament.sh
+
+export SPG_BIN
+rm -rf "$OUT_DIR"
+
+sh "$RUNNER" --models "fake geist:/nonexistent.gguf" --out-dir "$OUT_DIR" \
+    >/dev/null 2>&1
+
+python3 - "$OUT_DIR/machine-benchmark.jsonl" "$OUT_DIR/machine-benchmark.md" <<'PY'
+import json, sys
+
+rows = [json.loads(l) for l in open(sys.argv[1], encoding="utf-8")]
+by = {r["model"]: r for r in rows}
+
+fake = by["fake"]
+assert fake["available"] is True, fake
+# The scripted control must score perfectly, or the harness is not measuring
+# what it claims to measure.
+assert fake["known"] == fake["known_runs"], fake
+assert fake["heldout"] == fake["heldout_runs"], fake
+# Known and held-out stay separate all the way into the record.
+assert fake["known_runs"] and fake["heldout_runs"], fake
+assert "latency_ms" in fake and fake["latency_ms"] is not None, fake
+assert fake["peak_rss_kb"], fake
+
+# A model that could not run is a row, not an absence. A table missing an
+# entrant reads as "it was fine".
+missing = by["geist"]
+assert missing["available"] is False, missing
+assert missing["status"] != 0, missing
+assert missing["known"] is None, missing
+
+# Rejections and denials are different failures and must not be merged.
+assert "reject_rate" in fake and "deny_rate" in fake, fake
+
+# The bug this table is most likely to hide: a model entrant that quietly ran
+# the scripted answers. It produced a row reading 6/6 in 0 ms for a 3 GB model
+# and looked entirely reasonable. The runner now refuses a model suite with no
+# model cases, and the smoke test pins that refusal.
+md = open(sys.argv[2], encoding="utf-8").read()
+assert "| Model | Size | Known | Held-out |" in md, md[:400]
+assert "not run" in md, md[:400]
+PY
+
+echo "test_cli_tournament: PASS"
+
+# A model suite with no (model ...) cases must be refused, not scored: running
+# the scripted answers under a model's name is the failure mode that produces a
+# plausible table nobody questions.
+cp examples/eval/machine/diagnosis.spg "$OUT_DIR/scripted-as-model.spg"
+touch "$OUT_DIR/pretend.gguf"
+sh "$RUNNER" --models "geist:$OUT_DIR/pretend.gguf" --out-dir "$OUT_DIR" \
+    --model-suite "$OUT_DIR/scripted-as-model.spg" >/dev/null 2>&1 || true
+
+python3 - "$OUT_DIR/machine-benchmark.jsonl" <<'PY'
+import json, sys
+
+rows = [json.loads(l) for l in open(sys.argv[1], encoding="utf-8")]
+geist = [r for r in rows if r["model"] == "geist"][-1]
+assert geist["available"] is False, geist
+assert geist["known"] is None, geist
+PY
+
+echo "test_cli_tournament: PASS (refusal checked)"


### PR DESCRIPTION
Phase 10 der Roadmap (#70). Stapelt auf #90. Dieselben Szenarien durch jedes Modell, eine Zeile pro Modell — und kein zweiter Harness: jeder Teilnehmer läuft durch den vorhandenen Adapter und den vorhandenen Eval-Pfad, sonst vergleicht man zwei Harnesses statt zwei Modelle.

## Gemessen auf dem Pi 5

| Model | Size | Known | Held-out | Unsafe | Reject | Steps | Latency | Peak RSS |
|---|---|---|---|---|---|---|---|---|
| fake (scripted) | – | 6/6 | 3/3 | 0 | 0 | 1,0 | 1 ms | 3,7 MB |
| Gemma4-E2B Q4_K_M | 2963 MB | **2/6** | **1/3** | 0 | 0 | 1,0 | 254 852 ms | 1,82 GB |
| remote | – | nicht gelaufen (kein `GEISTSHELL_API_URL`) | | | | | | |

Rund 28 s pro Fall auf vier Kernen. Das Ergebnis deckt sich **exakt** mit Phase 4 (2/6, 1/3) — dasselbe Modell, dieselbe Suite, über einen anderen Codepfad. Zwei unabhängige Läufe, die dasselbe sagen, sind mehr wert als einer mit einer schöneren Zahl.

## Die Latenz aus Phase 4, jetzt gemessen

Hinter `--timing`, standardmäßig **aus**. Der Schalter ist kein Geschmack: zwei identische Eval-Läufe müssen bitgleiche Reports liefern, und ein Wanduhr-Wert im Standard-Output bricht jeden Diff und den Fixture-Test, der genau darauf beruht. **Der bestehende Test hat mich erwischt**, nachdem ich die Felder zuerst bedingungslos ausgegeben hatte.

Die Runtime liest weiterhin keine Uhr — das hält Replay byte-identisch. Der Harness misst sich selbst, und nichts davon erreicht Journal oder Context.

## Reject und Deny bleiben getrennt

Eine Empfehlung, die nicht parst, und eine, die geparst und abgelehnt wurde, sind verschiedene Fehler. Sie zu addieren löscht genau den Unterschied, den die Leiter aus #53 sichtbar macht.

## Der Fehler, den diese Phase produziert hat

Die erste Fassung des Runners lieferte eine Tabelle, in der ein 3-GB-Modell **6/6 in 0 ms bei 3,7 MB RSS** erreichte. Sie hatte jeden Teilnehmer auf die *scripted* Suite gezeigt — „das Modell" antwortete mit den Ground-Truth-Skripten. An der Ausgabe war nichts zu sehen; die Zahlen waren perfekt und vollständig bedeutungslos.

Behoben: Modell-Teilnehmer fahren die Suite, deren Cases `(model "geist")` deklarieren; der Runner **verweigert** eine Modell-Suite ohne Modell-Cases, statt sie zu bewerten; und der Smoke-Test hält diese Verweigerung fest.

## Wer nicht antritt, steht trotzdem drin

Ein nicht erreichbares Modell bekommt eine Zeile mit `not run (status N)`, nie ein Weglassen. Eine Tabelle, in der ein Teilnehmer fehlt, lädt den Leser ein anzunehmen, es sei schon in Ordnung gewesen. Ein nicht konfiguriertes Remote-Modell ist genau dieser Fall.

Bei `--samples N > 1` wird k/N pro Fall berichtet. Es gibt keinen Pfad, der den besten Lauf auswählt — nicht weil ihn niemand nimmt, sondern weil er nicht existiert.

## Grenzen, benannt

- **Latenz ist Suite-Latenz**, nicht pro Inferenz. Pro-Token bräuchte eine Uhr im Adapter; das gehört dorthin, wo jemand sie braucht.
- **Peak RSS ist Prozess-RSS.** Der ehrliche Modellgrößen-Vergleich ist die Differenz zum Fake-Adapter.
- **CPU während der Inferenz wird nicht gemessen.** Ein Sampler neben einem laufenden Modell ist selbst Last — nicht gemessen ist besser als falsch gemessen.

## Verifikation

macOS und Pi 5: `make test` grün, 39 bzw. 41 PASS, warnungsfrei, ASan/UBSan sauber.

Doku: `docs/machine-intelligence/Model-Tournament.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
