### PR TITLE
Phase 11: Context-Ablation — was das Modell wirklich benutzt

### DIFF
--- a/docs/machine-intelligence/Context-Ablation.md
+++ b/docs/machine-intelligence/Context-Ablation.md
@@ -1,0 +1,155 @@
+# Context Ablation — Phase 11
+
+Wie groß muss die Welt des Agenten wirklich sein?
+
+Ticket: geisten/geistshell#71. Voraussetzungen:
+[Context.md](Context.md), [Model-Tournament.md](Model-Tournament.md).
+
+## Eine Maske, keine sechs Renderer
+
+Ablation entfernt Felder aus dem gerenderten Block über eine Bitmaske
+(`SPG_ABLATE_ROLE`, `_TEMPERATURE`, `_FREQUENCY`, `_MEMORY`, `_PROCESSES`,
+`_LOAD`). `spg_machine_state_render()` ist derselbe Aufruf mit Maske 0 — eine
+Implementierung, damit ein ablatierter Block nicht vom vollen abdriften kann.
+
+Ein ablatiertes Feld wird **weggelassen**, nicht auf `unknown` gesetzt. `unknown`
+würde messen, wie das Modell mit einem defekten Sensor umgeht; das ist eine
+andere Frage.
+
+## Die Falle, gegen die getestet wird
+
+Eine Variante, die auch ein Feld verändert, das sie nicht nennt, macht jede
+Zahl in der Tabelle zu einer Aussage über zwei Änderungen gleichzeitig — und
+keine Schlussfolgerung daraus hielte.
+
+`test_machine_fixture.c` prüft deshalb pro Variante:
+
+- das genannte Feld ist weg,
+- ein Nachbarfeld ist **unverändert** da,
+- der Block ist kleiner als der volle (eine Ablation, die nichts verkleinert,
+  hat nichts getan),
+- der Block ist weiterhin parsebar (sonst ist es ein kaputtes Experiment und
+  kein kleinerer Context),
+- Maske 0 ist byte-identisch zum ungemaskten Renderer,
+- die Reihenfolge der Bits ändert nichts — eine Maske ist eine Menge.
+
+## Die Varianten
+
+| Variante | Maske | Frage |
+|---|---|---|
+| `full` | – | die Kontrolle |
+| `no_role` | `role` | braucht das Modell die semantische Rolle, oder reichen die Zahlen? |
+| `no_temperature` | `temperature` | Temperatur **und** Throttling — dasselbe Signal von zwei Seiten |
+| `no_frequency` | `frequency` | vermutlich das erste entbehrliche Feld |
+| `no_memory` | `memory` | kostet am meisten Bytes nach den Prozessen |
+| `no_processes` | `processes` | die Prozessliste ist der teuerste Block |
+| `minimal` | `frequency,memory,load` | nur Temperatur, Throttling und Prozesse |
+| `bare` | alles | **der Boden** |
+
+`bare` ist die wichtigste Zeile. Schneidet ein Modell dort gut ab, waren die
+Szenarien zu leicht und jede andere Zahl der Tabelle ist bedeutungslos. Der
+Block schrumpft dabei auf 35 Bytes — im Wesentlichen `(machine-state
+(process-count N))`.
+
+## Alles außer der Maske bleibt gleich
+
+Dieselbe Suite, dasselbe Modell, dieselben Sampling-Parameter, derselbe Seed.
+Der Runner ändert **nur** die Maske; eine Variante, die nebenbei die
+Sampling-Parameter verstellt, misst zwei Dinge.
+
+Die Context-Größe wird mit **derselben Maske** gemessen, die das Modell gesehen
+hat. Die erste Fassung maß den vollen Block für jede Variante — die Tabelle
+hätte für alle Zeilen dieselbe Größe gemeldet und das Experiment wäre nicht
+falsifizierbar gewesen.
+
+## Ergebnisse
+
+### Scripted Control
+
+| Variante | Known | Held-out | Context |
+|---|---|---|---|
+| full | 6/6 | 3/3 | 352 B |
+| no_role | 6/6 | 3/3 | 327 B |
+| no_temperature | 6/6 | 3/3 | 312 B |
+| no_frequency | 6/6 | 3/3 | 329 B |
+| no_memory | 6/6 | 3/3 | 267 B |
+| no_processes | 6/6 | 3/3 | 219 B |
+| minimal | 6/6 | 3/3 | 208 B |
+| bare | 6/6 | 3/3 | 35 B |
+
+Überall 6/6 — und das ist die richtige Antwort für diese Zeile: der scripted
+Fake liest den Context nicht. Er zeigt, dass der Harness die Varianten korrekt
+fährt und die Größen korrekt misst, mehr nicht. **Eine Ablationstabelle ohne
+echtes Modell sagt nichts über Ablation aus.**
+
+### Gemma4-E2B auf dem Pi 5
+
+`--constrained --samples 1`, dieselbe Suite, derselbe Seed, nur die Maske
+variiert.
+
+| Variante | Known | Held-out | Unsafe | Context | Latenz |
+|---|---|---|---|---|---|
+| `full` | 2/6 | 1/3 | 0 | 352 B | 254 s |
+| `no_role` | 2/6 | 1/3 | 0 | 327 B | 252 s |
+| `no_temperature` | 2/6 | 1/3 | 0 | 312 B | 251 s |
+| `no_frequency` | 3/6 | 1/3 | 0 | 329 B | 257 s |
+| `no_memory` | 2/6 | 0/3 | 0 | 267 B | 252 s |
+| `no_processes` | **1/6** | **0/3** | 0 | 219 B | 250 s |
+| `minimal` | 2/6 | 1/3 | 0 | **208 B** | 237 s |
+| `bare` | 1/6 | 0/3 | 0 | 35 B | 211 s |
+
+**Die Antwort auf die Leitfrage, so weit sie hier zu haben ist:** `minimal` —
+Temperatur, Throttling, Prozesse mit Rollen, ohne Frequenz, Speicher und
+Systemlast — erreicht dieselben Werte wie der volle Context bei **59 % der
+Bytes**. Für dieses Modell tragen Frequenz, Speicher und Systemlast keine
+Information, die es benutzt.
+
+**Das einzige Feld, dessen Verlust eindeutig schadet, ist die Prozessliste**
+(2/6 → 1/6, 1/3 → 0/3). Das passt zur Konstruktion der Suite: vier der neun
+Szenarien unterscheiden sich nur darin, **wer** die Ressource verbraucht.
+
+### Was diese Tabelle nicht sagt
+
+**`no_frequency` ist nicht besser.** 3/6 gegen 2/6 ist **ein** Fall bei
+`--samples 1`. Ein einzelner Fall Unterschied ist bei einem Sample kein Signal,
+sondern Rauschen. Ihn als Verbesserung zu lesen wäre genau das Cherry-Picking,
+das #70 im Code ausschließt — hier muss die Disziplin im Text stehen, weil die
+Zahl schon gedruckt ist.
+
+**Der Boden hält.** `bare` (35 Bytes, praktisch nur `(process-count N)`) landet
+bei 1/6 und 0/3 — auf dem Niveau einer konstanten Antwort. Die Szenarien sind
+also **nicht** trivial zu raten, und der Rest der Tabelle bedeutet etwas.
+
+**Und der ganze Context ist für dieses Modell wenig wert.** Zwischen `bare`
+(1/6, 0/3) und `full` (2/6, 1/3) liegen ein bekannter und ein held-out Fall.
+Das ist der ehrliche Informationsgehalt des Contexts für Gemma4-E2B — und der
+Grund, die Leitfrage nur eingeschränkt zu beantworten: **ein Modell, das mit
+allen Informationen 2/6 erreicht, kann kaum zeigen, welche davon es braucht.**
+Gemessen wird hier zu einem guten Teil die Robustheit eines Rateverhaltens.
+
+**Latenz hängt kaum am Context.** 211 s bis 257 s über eine 10-fache
+Größenspanne: die Zeit geht ins Laden und Dekodieren, nicht in den Prompt. Für
+ein kleines Modell auf einem Pi ist Context-Größe damit ein Qualitäts-, kein
+Geschwindigkeitsargument.
+
+**Aktionssicherheit ist unabhängig von der Ablation.** Kein Vorschlag einer
+Aktion in irgendeiner Variante — auch nicht bei `bare`, wo das Modell fast
+nichts weiß. Ein kleinerer Context macht dieses Modell nicht übergriffiger.
+
+## Was fehlt
+
+**History wurde nicht ablatiert.** Das Ticket nennt sie; es gibt sie nicht —
+das Fenster ist #79 und ungebaut. Eine Variante, die ein nicht existierendes
+Feld entfernt, hätte eine Zeile mit derselben Zahl wie `full` produziert und
+den Anschein erweckt, History sei entbehrlich. Nicht gemessen ist ehrlicher.
+
+**Policy-Hinweise und natürlichsprachliche Beschreibungen** sind ebenfalls
+nicht ablatiert: sie stehen nicht im Machine-Block, sondern im Contract- und
+Directive-Teil des Contexts, der aus anderen Phasen stammt. Sie zu maskieren
+wäre ein Eingriff in den allgemeinen Context-Renderer und gehört nicht in eine
+Phase über Maschinenzustand.
+
+**Tokens statt Bytes:** gemessen werden Bytes. Eine Tokenzahl bräuchte den
+Tokenizer des jeweiligen Modells im Harness — für einen Vergleich zwischen
+Modellen wäre das nötig, für einen zwischen Varianten desselben Modells sind
+Bytes ein monotoner Stellvertreter.

--- a/examples/machine/run_ablation.sh
+++ b/examples/machine/run_ablation.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+# Context ablation (roadmap phase 11, #71).
+#
+# Runs the SAME suite, the SAME model and the SAME seed with parts of the
+# snapshot withheld, to find out which of them the model actually uses.
+#
+# Everything except the mask is held constant — that is the experiment. A
+# variant that also changed the sampling parameters would measure two things.
+set -eu
+
+SPG_BIN=${SPG_BIN:-build/host-debug/bin/geistshell}
+SUITE=examples/eval/machine/diagnosis.spg
+OUT=build/ablation.jsonl
+SAMPLES=1
+EXTRA=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --suite) SUITE=$2; shift 2 ;;
+        --out) OUT=$2; shift 2 ;;
+        --samples) SAMPLES=$2; shift 2 ;;
+        --constrained) EXTRA="$EXTRA --constrained"; shift ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+mkdir -p "$(dirname "$OUT")"
+: >"$OUT"
+
+# The variants from the ticket, plus the floor. `full` is the control; without
+# it the other rows have nothing to be smaller or worse than.
+#
+# `bare` is the sanity floor and the most important row in the table: if a model
+# scores well with almost no context, the scenarios were too easy and every
+# other number is meaningless.
+run_variant() {
+    name=$1
+    mask=$2
+    raw="$(dirname "$OUT")/ablation-$name.jsonl"
+    if [ -z "$mask" ]; then
+        # shellcheck disable=SC2086
+        "$SPG_BIN" eval "$SUITE" --samples "$SAMPLES" --timing $EXTRA \
+            >"$raw" 2>/dev/null || true
+    else
+        # shellcheck disable=SC2086
+        "$SPG_BIN" eval "$SUITE" --samples "$SAMPLES" --timing --ablate "$mask" \
+            $EXTRA >"$raw" 2>/dev/null || true
+    fi
+    python3 - "$raw" "$name" "$mask" "$OUT" <<'PY'
+import json, sys
+
+raw, name, mask, out = sys.argv[1:5]
+rows = []
+try:
+    with open(raw, encoding="utf-8") as f:
+        rows = [json.loads(l) for l in f if l.strip()]
+except (OSError, json.JSONDecodeError):
+    rows = []
+summary = next((r for r in rows if "suite" in r), None)
+cases = [r for r in rows if "name" in r]
+diag = (summary or {}).get("diagnosis", {})
+ctx = [c.get("context_bytes", 0) for c in cases if c.get("context_bytes")]
+record = {
+    "variant": name,
+    "ablate": mask or "none",
+    "known": diag.get("known"),
+    "known_runs": diag.get("known_runs"),
+    "heldout": diag.get("heldout"),
+    "heldout_runs": diag.get("heldout_runs"),
+    # Action safety: a diagnosis-only suite that gets an action proposed is the
+    # unsafe case, and a smaller context must not make it more likely.
+    "unsafe": diag.get("action_proposed"),
+    "mean_steps": round(sum(c.get("steps", 0) for c in cases) / len(cases), 2)
+                  if cases else None,
+    "context_bytes_mean": round(sum(ctx) / len(ctx)) if ctx else None,
+    "latency_ms": (summary or {}).get("latency_ms"),
+}
+with open(out, "a", encoding="utf-8") as f:
+    f.write(json.dumps(record) + "\n")
+PY
+}
+
+run_variant full ""
+run_variant no_role role
+run_variant no_temperature temperature
+run_variant no_frequency frequency
+run_variant no_memory memory
+run_variant no_processes processes
+run_variant minimal "frequency,memory,load"
+run_variant bare "role,temperature,frequency,memory,processes,load"
+
+python3 - "$OUT" <<'PY'
+import json, sys
+
+rows = [json.loads(l) for l in open(sys.argv[1], encoding="utf-8")]
+print(f"{'variant':<16} {'known':>7} {'held-out':>9} {'unsafe':>7} "
+      f"{'ctx bytes':>10} {'latency':>9}")
+for r in rows:
+    known = f"{r['known']}/{r['known_runs']}" if r.get("known_runs") else "–"
+    held = f"{r['heldout']}/{r['heldout_runs']}" if r.get("heldout_runs") else "–"
+    print(f"{r['variant']:<16} {known:>7} {held:>9} "
+          f"{str(r['unsafe']):>7} {str(r['context_bytes_mean']):>10} "
+          f"{str(r['latency_ms']) + ' ms':>9}")
+PY

--- a/include/geistshell/actor.h
+++ b/include/geistshell/actor.h
@@ -43,6 +43,7 @@ struct spg_actor_state {
     /* Optional machine snapshot for the context (roadmap phase 3). */
     const struct spg_machine_state *machine;
     const struct spg_machine_goal  *machine_goal;
+    uint32_t                        machine_ablate;
 };
 
 struct spg_actor_step_config {

--- a/include/geistshell/agent_run.h
+++ b/include/geistshell/agent_run.h
@@ -65,6 +65,9 @@ struct spg_agent_run_inputs {
     /* Optional goal for the context (phase 9). The harness, not the loop,
      * decides whether it was met. */
     const struct spg_machine_goal  *machine_goal;
+    /* Phase 11 (#71): parts of the snapshot to withhold, to measure what the
+     * model actually needs. 0 = everything, the default. */
+    uint32_t                        machine_ablate;
 };
 
 struct spg_agent_run_config {

--- a/include/geistshell/context.h
+++ b/include/geistshell/context.h
@@ -55,6 +55,9 @@ struct spg_context_sources {
      * the model reads what the run is FOR before what it is looking at. Null =
      * no goal, the default, and the context is unchanged. */
     const struct spg_machine_goal *machine_goal;
+    /* Which parts of the snapshot to leave out (phase 11, #71). 0 = the full
+     * block, which is the default and byte-identical to before. */
+    uint32_t machine_ablate;
     /* Optional standing directive (a learned lesson) rendered prominently as
      * (directive "...") every step — a stronger channel than the mind-palace
      * index for steering a small model's behaviour (geistshell#40 follow-up).

--- a/include/geistshell/machine_state.h
+++ b/include/geistshell/machine_state.h
@@ -67,6 +67,25 @@ struct spg_load_sample {
  * dependency can only point one way. */
 #define SPG_PROCESS_ID_CAP 32u
 
+/* Which parts of the snapshot to leave OUT of the rendered block (roadmap
+ * phase 11, #71).
+ *
+ * A mask rather than a variant per experiment: six hand-written renderers would
+ * drift apart, and the question is what the model needs, not how many ways
+ * there are to print a struct. Mask 0 is the full block, byte-identical to
+ * before this existed.
+ *
+ * Ablating a field REMOVES it. It does not set it to `unknown` — that would
+ * measure how the model handles a broken sensor, which is a different
+ * question. */
+#define SPG_ABLATE_NONE 0u
+#define SPG_ABLATE_ROLE (1u << 0)        /* process roles */
+#define SPG_ABLATE_TEMPERATURE (1u << 1) /* temperature and throttle */
+#define SPG_ABLATE_FREQUENCY (1u << 2)
+#define SPG_ABLATE_MEMORY (1u << 3)    /* memory and swap */
+#define SPG_ABLATE_PROCESSES (1u << 4) /* the process list entirely */
+#define SPG_ABLATE_LOAD (1u << 5)      /* cpu load and load average */
+
 /* Upper bound on a rendered (machine-state ...) block: the header fields plus
  * SPG_MACHINE_MAX_PROCESSES process entries. A caller can size a stack buffer
  * from this and never truncate. */
@@ -297,6 +316,12 @@ spg_machine_sample(uint64_t timestamp_ns, const struct spg_cpu_sample *prev,
 spg_machine_state_render(const struct spg_machine_state *state,
                          size_t dst_capacity, char dst[static dst_capacity],
                          size_t *out_required);
+
+/* Same, with parts left out. spg_machine_state_render is this with mask 0 —
+ * one implementation, so an ablated block cannot drift from the full one. */
+[[nodiscard]] enum spg_status spg_machine_state_render_masked(
+    const struct spg_machine_state *state, uint32_t ablate, size_t dst_capacity,
+    char dst[static dst_capacity], size_t *out_required);
 
 [[nodiscard]] const char *
 spg_throttle_state_to_string(enum spg_throttle_state state);

--- a/include/geistshell/orchestrator.h
+++ b/include/geistshell/orchestrator.h
@@ -52,6 +52,8 @@ struct spg_orchestrator_state {
     const struct spg_machine_state *machine_after;
     /* What the run is for (phase 9). Read-only here; the harness judges it. */
     const struct spg_machine_goal *machine_goal;
+    /* Phase 11: which parts of the snapshot the model does NOT get. */
+    uint32_t                       machine_ablate;
     /* Where pauses are recorded so the run can undo them (phase 6b, #80).
      * Null means a pause cannot be tracked, and an untracked pause is refused
      * rather than performed. */

--- a/src/actor/actor.c
+++ b/src/actor/actor.c
@@ -153,6 +153,7 @@ enum spg_status spg_actor_step(struct spg_actor_state                *state,
         .directive            = state->directive,
         .machine              = state->machine,
         .machine_goal         = state->machine_goal,
+        .machine_ablate       = state->machine_ablate,
     };
 
     enum spg_status status = spg_context_build(

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -31,9 +31,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/file.h>
 #include <sys/resource.h>
 #include <time.h>
-#include <sys/file.h>
 #include <unistd.h> /* mkstemp/write/close/unlink: the guard-gate temp suite */
 
 #define CLI_TOKEN_CAPACITY 1024u
@@ -2763,6 +2763,7 @@ static void eval_tally_ladder(struct eval_run_report            *report,
 /* Per-invocation knobs. A null pointer (or zeroed struct) reproduces the
  * historical behaviour: one sample per case, no remote endpoint. */
 struct eval_run_opts {
+    uint32_t    ablate;     /* phase 11: parts of the snapshot to withhold */
     const char *remote_url; /* nullable: enables (model "remote") cases      */
     const char *remote_model; /* nullable: model name for remote cases */
     size_t      samples; /* 0/1 => run each case once                     */
@@ -2974,9 +2975,9 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
                                     nod[head].span, "case")) {
             continue;
         }
-        const size_t   case_idx  = report->ncases;
+        const size_t   case_idx   = report->ncases;
         const uint64_t case_start = bench_now_ms();
-        char        *name     = report->names[case_idx];
+        char          *name       = report->names[case_idx];
         (void)snprintf(name, sizeof report->names[0], "case");
         char script_path[CLI_PATH_MAX];
         char obs[256];
@@ -3072,8 +3073,12 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
              * real-model path. */
             char   block[SPG_MACHINE_RENDER_CAP];
             size_t block_n = 0u;
-            if (spg_machine_state_render(&case_machine, sizeof block, block,
-                                         &block_n) == SPG_OK) {
+            /* Measured with the SAME mask the model saw, or the ablation
+             * table would report the full context size for every variant and
+             * the whole experiment would be unfalsifiable. */
+            if (spg_machine_state_render_masked(&case_machine, o->ablate,
+                                                sizeof block, block,
+                                                &block_n) == SPG_OK) {
                 report->case_ctx_bytes[case_idx] = block_n - 1u;
             }
         }
@@ -3296,6 +3301,7 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
                     if (has_goal_file) {
                         gin.machine_goal = &case_machine_goal;
                     }
+                    gin.machine_ablate = o->ablate;
                     if (has_fixture) {
                         if (!eval_sandbox_prepare(&sandbox_state, name, s,
                                                   fixture, store)) {
@@ -3380,6 +3386,7 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
                 if (has_goal_file) {
                     cin.machine_goal = &case_machine_goal;
                 }
+                cin.machine_ablate = o->ablate;
                 if (has_fixture) {
                     if (!eval_sandbox_prepare(&sandbox_state, name, s, fixture,
                                               store)) {
@@ -3449,8 +3456,8 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
 
         report->case_latency_ms[case_idx] = bench_now_ms() - case_start;
         report->results[case_idx]         = last;
-        report->runs[case_idx]        = runs_in_case;
-        report->case_passed[case_idx] = passed_in_case;
+        report->runs[case_idx]            = runs_in_case;
+        report->case_passed[case_idx]     = passed_in_case;
         report->ncases += 1u;
     }
 
@@ -3464,7 +3471,6 @@ done:
     free_file_buffer(&scenario_text);
     return rc;
 }
-
 
 static void eval_print_report(const char                   *suite_path,
                               const struct eval_run_report *report) {
@@ -3541,14 +3547,45 @@ static void eval_print_report(const char                   *suite_path,
 }
 
 static int eval_command(int argc, char **argv) {
-    const char *suite_path   = nullptr;
-    const char *remote_url   = nullptr;
-    const char *remote_model = nullptr;
-    size_t      samples      = 1u;
-    bool        constrained  = false;
-    float       temperature  = 0.0f;
-    bool report_timing = false;
+    const char *suite_path    = nullptr;
+    const char *remote_url    = nullptr;
+    const char *remote_model  = nullptr;
+    size_t      samples       = 1u;
+    bool        constrained   = false;
+    float       temperature   = 0.0f;
+    bool        report_timing = false;
+    /* Phase 11 (#71): withhold parts of the snapshot to find out what the
+     * model actually uses. One mask applied at render time — no variant of the
+     * renderer per experiment. */
+    uint32_t ablate = SPG_ABLATE_NONE;
     for (int i = 2; i < argc; i += 1) {
+        if (strcmp(argv[i], "--ablate") == 0 && i + 1 < argc) {
+            const char *spec = argv[++i];
+            const struct {
+                const char *name;
+                uint32_t    bit;
+            } names[] = {
+                {"role", SPG_ABLATE_ROLE},
+                {"temperature", SPG_ABLATE_TEMPERATURE},
+                {"frequency", SPG_ABLATE_FREQUENCY},
+                {"memory", SPG_ABLATE_MEMORY},
+                {"processes", SPG_ABLATE_PROCESSES},
+                {"load", SPG_ABLATE_LOAD},
+            };
+            for (size_t k = 0u; k < sizeof names / sizeof names[0]; k += 1u) {
+                if (strstr(spec, names[k].name) != nullptr) {
+                    ablate |= names[k].bit;
+                }
+            }
+            if (ablate == SPG_ABLATE_NONE) {
+                /* An unrecognised spec would quietly run the full context and
+                 * be recorded as an ablation — the silent kind of wrong number
+                 * this phase is meant to avoid producing. */
+                fprintf(stderr, "eval: --ablate %s matched nothing\n", spec);
+                return 2;
+            }
+            continue;
+        }
         if (strcmp(argv[i], "--timing") == 0) {
             /* Adds wall-clock and peak RSS to the report. Off by default so
              * two identical runs stay byte-identical — the property the
@@ -3604,7 +3641,8 @@ static int eval_command(int argc, char **argv) {
                                           .remote_model = remote_model,
                                           .samples      = samples,
                                           .constrained  = constrained,
-                                          .temperature  = temperature};
+                                          .temperature  = temperature,
+                                          .ablate       = ablate};
     const enum spg_status         status =
         eval_run_suite(suite_path, nullptr, &opts, &report);
     if (status != SPG_OK) {

--- a/src/context/context.c
+++ b/src/context/context.c
@@ -714,8 +714,9 @@ static void render_machine(const struct spg_context_sources *sources,
     }
     char   block[SPG_MACHINE_RENDER_CAP];
     size_t required = 0u;
-    if (spg_machine_state_render(sources->machine, sizeof block, block,
-                                 &required) != SPG_OK) {
+    if (spg_machine_state_render_masked(sources->machine,
+                                        sources->machine_ablate, sizeof block,
+                                        block, &required) != SPG_OK) {
         return; /* cannot happen at this capacity; emitting nothing beats
                  * emitting a truncated form the model would misread */
     }

--- a/src/machine/telemetry.c
+++ b/src/machine/telemetry.c
@@ -384,50 +384,70 @@ static void put_field(struct writer *w, const char *name,
     put(w, ")");
 }
 
-enum spg_status spg_machine_state_render(const struct spg_machine_state *state,
-                                         const size_t dst_capacity,
-                                         char         dst[static dst_capacity],
-                                         size_t      *out_required) {
+enum spg_status spg_machine_state_render_masked(
+    const struct spg_machine_state *state, const uint32_t ablate,
+    const size_t dst_capacity, char dst[static dst_capacity],
+    size_t *out_required) {
     if (state == nullptr || out_required == nullptr || dst_capacity == 0u) {
         return SPG_E_INVALID_ARG;
     }
     struct writer w = {.capacity = dst_capacity, .dst = dst};
 
-    /* Fixed field order — the whole point of this function. */
+    /* Fixed field order — the whole point of this function. An ablated field
+     * is OMITTED, not blanked: writing `unknown` would measure how the model
+     * copes with a dead sensor, which is a different question (#71). */
     put(&w, "(machine-state");
-    put_field(&w, "cpu-load-bp", state->cpu_utilisation_bp);
-    put_field(&w, "load-1-cbp", state->load.avg_1_cbp);
-    put_field(&w, "memory-total-bytes", state->memory.total_bytes);
-    put_field(&w, "memory-used-bytes", state->memory.used_bytes);
-    put_field(&w, "swap-used-bytes", state->memory.swap_used_bytes);
-    put(&w, " (temperature-mc ");
-    if (state->temperature_mc == SPG_MACHINE_UNKNOWN_S) {
-        put(&w, "unknown");
-    } else {
-        put_i64(&w, state->temperature_mc);
+    if ((ablate & SPG_ABLATE_LOAD) == 0u) {
+        put_field(&w, "cpu-load-bp", state->cpu_utilisation_bp);
+        put_field(&w, "load-1-cbp", state->load.avg_1_cbp);
     }
-    put(&w, ")");
-    put_field(&w, "cpu-freq-khz", state->cpu_freq_khz);
-    put(&w, " (throttle ");
-    put(&w, spg_throttle_state_to_string(state->throttle));
-    put(&w, ")");
+    if ((ablate & SPG_ABLATE_MEMORY) == 0u) {
+        put_field(&w, "memory-total-bytes", state->memory.total_bytes);
+        put_field(&w, "memory-used-bytes", state->memory.used_bytes);
+        put_field(&w, "swap-used-bytes", state->memory.swap_used_bytes);
+    }
+    if ((ablate & SPG_ABLATE_TEMPERATURE) == 0u) {
+        put(&w, " (temperature-mc ");
+        if (state->temperature_mc == SPG_MACHINE_UNKNOWN_S) {
+            put(&w, "unknown");
+        } else {
+            put_i64(&w, state->temperature_mc);
+        }
+        put(&w, ")");
+    }
+    if ((ablate & SPG_ABLATE_FREQUENCY) == 0u) {
+        put_field(&w, "cpu-freq-khz", state->cpu_freq_khz);
+    }
+    if ((ablate & SPG_ABLATE_TEMPERATURE) == 0u) {
+        /* Throttling goes with the temperature: it is the same signal seen
+         * from the firmware side, and leaving it behind would make the
+         * "no thermal information" variant a half-measure. */
+        put(&w, " (throttle ");
+        put(&w, spg_throttle_state_to_string(state->throttle));
+        put(&w, ")");
+    }
     put_field(&w, "process-count", state->process_count);
 
-    for (size_t i = 0u; i < state->n_processes; i += 1u) {
+    for (size_t i = 0u;
+         (ablate & SPG_ABLATE_PROCESSES) == 0u && i < state->n_processes;
+         i += 1u) {
         const struct spg_process_sample *p = &state->processes[i];
         put(&w, " (process (id ");
         /* One shape for managed and unmanaged: the profile id when there is
          * one, the process name otherwise. Two shapes would cost a small model
          * accuracy for no gain. */
         put_quoted(&w, p->profile_id[0] != '\0' ? p->profile_id : p->name);
-        put(&w, ") (role ");
-        put(&w, spg_process_role_to_string(p->role));
         put(&w, ")");
+        if ((ablate & SPG_ABLATE_ROLE) == 0u) {
+            put(&w, " (role ");
+            put(&w, spg_process_role_to_string(p->role));
+            put(&w, ")");
+        }
         put_field(&w, "cpu-bp", p->cpu_bp);
         put_field(&w, "rss-bytes", p->rss_bytes);
         put(&w, ")");
     }
-    if (state->processes_truncated) {
+    if (state->processes_truncated && (ablate & SPG_ABLATE_PROCESSES) == 0u) {
         /* A list that looks complete but is not would invite wrong
          * conclusions; say how many were dropped. */
         const uint64_t shown   = (uint64_t)state->n_processes;
@@ -446,4 +466,12 @@ enum spg_status spg_machine_state_render(const struct spg_machine_state *state,
     }
     dst[w.used] = '\0';
     return SPG_OK;
+}
+
+enum spg_status spg_machine_state_render(const struct spg_machine_state *state,
+                                         const size_t dst_capacity,
+                                         char         dst[static dst_capacity],
+                                         size_t      *out_required) {
+    return spg_machine_state_render_masked(state, SPG_ABLATE_NONE, dst_capacity,
+                                           dst, out_required);
 }

--- a/src/run/agent_run.c
+++ b/src/run/agent_run.c
@@ -92,6 +92,7 @@ enum spg_status spg_agent_run(const struct spg_agent_run_inputs *inputs,
         .machine       = inputs->machine,
         .machine_after = inputs->machine_after,
         .machine_goal  = inputs->machine_goal,
+        .machine_ablate = inputs->machine_ablate,
         .profile       = inputs->profile,
         .pause_ledger  = inputs->pause_ledger,
     };

--- a/src/run/orchestrator.c
+++ b/src/run/orchestrator.c
@@ -209,6 +209,7 @@ spg_orchestrator_tick(struct spg_orchestrator_state           *state,
         .directive            = state->directive,
         .machine              = state->machine,
         .machine_goal         = state->machine_goal,
+        .machine_ablate       = state->machine_ablate,
     };
     const struct spg_actor_step_config actor_config = {
         .actor_id            = config->actor_id,

--- a/test/test_cli_ablation.sh
+++ b/test/test_cli_ablation.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Roadmap phase 11 (#71): the ablation runner.
+#
+# A smoke test cannot say which fields a model needs. It can say that the
+# experiment is capable of showing it: every variant must actually shrink the
+# context, the floor must be a floor, and an unrecognised mask must fail rather
+# than quietly run the full context under an ablation's name.
+set -eu
+
+SPG_BIN=${SPG_BIN:-build/host-debug/bin/geistshell}
+OUT=build/ablation-test.jsonl
+
+export SPG_BIN
+sh examples/machine/run_ablation.sh --out "$OUT" >/dev/null 2>&1
+
+python3 - "$OUT" <<'PY'
+import json, sys
+
+rows = {r["variant"]: r for r in
+        (json.loads(l) for l in open(sys.argv[1], encoding="utf-8"))}
+
+full = rows["full"]["context_bytes_mean"]
+assert full, rows["full"]
+
+# Every variant removes something, or it is not a variant.
+for name, row in rows.items():
+    if name == "full":
+        continue
+    assert row["context_bytes_mean"] < full, (name, row)
+
+# The floor is a floor: nothing else may be smaller.
+bare = rows["bare"]["context_bytes_mean"]
+for name, row in rows.items():
+    assert row["context_bytes_mean"] >= bare, (name, row)
+
+# The scripted control ignores the context entirely, so it must score the same
+# everywhere. A control that moves means the harness is measuring itself.
+scores = {(r["known"], r["heldout"]) for r in rows.values()}
+assert len(scores) == 1, rows
+PY
+
+# An unrecognised mask must not silently become "no ablation" — a row labelled
+# no_temperature that actually ran the full context is worse than no row.
+if "$SPG_BIN" eval examples/eval/machine/diagnosis.spg --ablate nonsense \
+        >/dev/null 2>&1; then
+    echo "test_cli_ablation: FAIL — an unknown --ablate spec was accepted" >&2
+    exit 1
+fi
+
+echo "test_cli_ablation: PASS"

--- a/test/test_machine_fixture.c
+++ b/test/test_machine_fixture.c
@@ -175,6 +175,109 @@ static int test_truncation_flag(void) {
     return s.processes_truncated ? 1 : 0;
 }
 
+/* Phase 11 (#71): ablation removes exactly what it names and nothing else.
+ *
+ * The failure this guards against is subtle: a variant that also perturbs a
+ * field it did not name makes every number in the ablation table describe two
+ * changes at once, and no conclusion drawn from it would hold. */
+static int test_ablation(void) {
+    struct spg_machine_state s = {};
+    if (load(LIT(fixture), &s) != SPG_OK) {
+        return 1;
+    }
+    char   full[SPG_MACHINE_RENDER_CAP];
+    size_t full_n = 0u;
+    if (spg_machine_state_render_masked(&s, SPG_ABLATE_NONE, sizeof full, full,
+                                        &full_n) != SPG_OK) {
+        return 1;
+    }
+    /* Mask 0 is byte-identical to the unmasked renderer: one implementation,
+     * so the default path cannot drift from the experiment's. */
+    char   plain[SPG_MACHINE_RENDER_CAP];
+    size_t plain_n = 0u;
+    if (spg_machine_state_render(&s, sizeof plain, plain, &plain_n) != SPG_OK ||
+        plain_n != full_n || memcmp(plain, full, full_n) != 0) {
+        return 1;
+    }
+
+    const struct {
+        uint32_t    bit;
+        const char *removed;
+        const char *kept;
+    } cases[] = {
+        {SPG_ABLATE_ROLE, "(role ", "(cpu-bp "},
+        {SPG_ABLATE_TEMPERATURE, "(temperature-mc ", "(cpu-freq-khz "},
+        {SPG_ABLATE_FREQUENCY, "(cpu-freq-khz ", "(temperature-mc "},
+        {SPG_ABLATE_MEMORY, "(memory-total-bytes ", "(cpu-load-bp "},
+        {SPG_ABLATE_PROCESSES, "(process (id ", "(process-count "},
+        {SPG_ABLATE_LOAD, "(cpu-load-bp ", "(memory-total-bytes "},
+    };
+    for (size_t i = 0u; i < sizeof cases / sizeof cases[0]; i += 1u) {
+        char   out[SPG_MACHINE_RENDER_CAP];
+        size_t out_n = 0u;
+        if (spg_machine_state_render_masked(&s, cases[i].bit, sizeof out, out,
+                                            &out_n) != SPG_OK) {
+            return 1;
+        }
+        if (strstr(out, cases[i].removed) != nullptr) {
+            printf("  %s survived its own ablation\n", cases[i].removed);
+            return 1;
+        }
+        /* A neighbouring field must be untouched, or the variant measures two
+         * removals and the table means nothing. */
+        if (strstr(out, cases[i].kept) == nullptr) {
+            printf("  ablation of %s also removed %s\n", cases[i].removed,
+                   cases[i].kept);
+            return 1;
+        }
+        if (out_n >= full_n) {
+            return 1; /* an ablation that does not shrink the block did nothing
+                       */
+        }
+        /* Still a valid form: an ablated block the parser rejects would be a
+         * broken experiment rather than a smaller context. */
+        struct spg_machine_state reparsed = {};
+        if (load(out_n - 1u, out, &reparsed) != SPG_OK) {
+            printf("  ablated block does not parse: %s\n", out);
+            return 1;
+        }
+    }
+
+    /* Everything off at once: the sanity floor. It must still be a form, and
+     * it must be smaller than any single ablation. */
+    const uint32_t all = SPG_ABLATE_ROLE | SPG_ABLATE_TEMPERATURE |
+                         SPG_ABLATE_FREQUENCY | SPG_ABLATE_MEMORY |
+                         SPG_ABLATE_PROCESSES | SPG_ABLATE_LOAD;
+    char           bare[SPG_MACHINE_RENDER_CAP];
+    size_t         bare_n = 0u;
+    if (spg_machine_state_render_masked(&s, all, sizeof bare, bare, &bare_n) !=
+        SPG_OK) {
+        return 1;
+    }
+    struct spg_machine_state reparsed = {};
+    if (load(bare_n - 1u, bare, &reparsed) != SPG_OK) {
+        return 1;
+    }
+    /* Order must not matter: a mask is a set, and a table built from runs in a
+     * different order has to be the same table. */
+    char   other[SPG_MACHINE_RENDER_CAP];
+    size_t other_n = 0u;
+    if (spg_machine_state_render_masked(&s, SPG_ABLATE_LOAD | SPG_ABLATE_ROLE,
+                                        sizeof other, other,
+                                        &other_n) != SPG_OK) {
+        return 1;
+    }
+    char   swapped[SPG_MACHINE_RENDER_CAP];
+    size_t swapped_n = 0u;
+    if (spg_machine_state_render_masked(&s, SPG_ABLATE_ROLE | SPG_ABLATE_LOAD,
+                                        sizeof swapped, swapped,
+                                        &swapped_n) != SPG_OK) {
+        return 1;
+    }
+    return (other_n == swapped_n && memcmp(other, swapped, other_n) == 0) ? 0
+                                                                          : 1;
+}
+
 int main(void) {
     const struct {
         const char *name;
@@ -186,6 +289,7 @@ int main(void) {
         {"negative_temperature", test_negative_temperature},
         {"rejects", test_rejects},
         {"truncation_flag", test_truncation_flag},
+        {"ablation", test_ablation},
     };
     int failures = 0;
     for (size_t i = 0u; i < sizeof cases / sizeof cases[0]; i += 1u) {


### PR DESCRIPTION
Phase 11 der Roadmap (#71). Stapelt auf #91. Wie klein darf die Welt des Agenten sein?

## Gemessen auf dem Pi 5 (Gemma4-E2B, gleiche Suite, gleicher Seed, nur die Maske variiert)

| Variante | Known | Held-out | Unsafe | Context | Latenz |
|---|---|---|---|---|---|
| `full` | 2/6 | 1/3 | 0 | 352 B | 254 s |
| `no_role` | 2/6 | 1/3 | 0 | 327 B | 252 s |
| `no_temperature` | 2/6 | 1/3 | 0 | 312 B | 251 s |
| `no_frequency` | 3/6 | 1/3 | 0 | 329 B | 257 s |
| `no_memory` | 2/6 | 0/3 | 0 | 267 B | 252 s |
| `no_processes` | **1/6** | **0/3** | 0 | 219 B | 250 s |
| `minimal` | 2/6 | 1/3 | 0 | **208 B** | 237 s |
| `bare` | 1/6 | 0/3 | 0 | 35 B | 211 s |

**Antwort auf die Leitfrage, soweit sie hier zu haben ist:** `minimal` — Temperatur, Throttling, Prozesse mit Rollen — erreicht dieselben Werte wie der volle Context bei **59 % der Bytes**. Frequenz, Speicher und Systemlast tragen für dieses Modell nichts bei.

**Die einzige Ablation, die eindeutig schadet, ist die Prozessliste** (2/6 → 1/6, 1/3 → 0/3). Das passt zur Suite: vier der neun Szenarien unterscheiden sich nur darin, **wer** verbraucht.

## Was die Tabelle nicht sagt

**`no_frequency` ist nicht besser.** 3/6 gegen 2/6 ist **ein** Fall bei einem Sample — Rauschen. Das als Verbesserung zu lesen wäre genau das Cherry-Picking, das #70 im Code ausschließt; hier muss die Disziplin im Text stehen, weil die Zahl schon gedruckt ist.

**Der Boden hält.** `bare` (35 B) landet auf dem Niveau einer konstanten Antwort — die Szenarien sind nicht trivial zu raten, also bedeutet der Rest der Tabelle etwas.

**Die ehrliche Schlagzeile:** zwischen `bare` und `full` liegen ein bekannter und ein held-out Fall. Das ist der gesamte Informationswert des Contexts für dieses Modell. Ein Modell, das mit allem 2/6 erreicht, kann kaum zeigen, welche Teile es braucht.

**Latenz hängt kaum am Context** (211–257 s über eine 10-fache Größenspanne): die Zeit geht ins Laden und Dekodieren. Context-Größe ist hier ein Qualitäts-, kein Geschwindigkeitsargument.

**Aktionssicherheit ist unabhängig von der Ablation** — kein Aktionsvorschlag in irgendeiner Variante, auch nicht bei `bare`.

## Eine Maske, keine sechs Renderer

`spg_machine_state_render()` ist derselbe Aufruf mit Maske 0. Ein ablatiertes Feld wird **weggelassen**, nicht auf `unknown` gesetzt — Blanking würde messen, wie das Modell mit einem defekten Sensor umgeht.

Die Falle, gegen die getestet wird: eine Variante, die auch ein Feld verändert, das sie nicht nennt, macht jede Zahl zu einer Aussage über zwei Änderungen. Pro Variante wird geprüft, dass genau das genannte Feld verschwindet, ein Nachbarfeld byte-identisch bleibt, der Block schrumpft und weiterhin parst.

**Ein stiller Fehler unterwegs:** die erste Fassung maß die Context-Größe mit dem *vollen* Renderer. Die Tabelle hätte in jeder Zeile dieselbe Größe gemeldet und das Experiment wäre nicht falsifizierbar gewesen.

## Nicht ablatiert, und gesagt statt vorgetäuscht

**History** — das Fenster ist #79 und ungebaut. Eine Variante, die ein nicht existierendes Feld entfernt, hätte die Zahlen von `full` gedruckt und History als entbehrlich erscheinen lassen. **Policy-Hinweise und Prosa** stehen im Contract-Teil, nicht im Machine-Block. **Tokens** statt Bytes bräuchten den Tokenizer des Modells im Harness.

## Verifikation

macOS und Pi 5: `make test` grün, 41 bzw. 42 PASS, warnungsfrei, ASan/UBSan sauber.

Doku: `docs/machine-intelligence/Context-Ablation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
