### PR TITLE
#54 + Phase 15: Model Profile und Machine B — Governance trägt, das Action-Enum nicht

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ SPG_SOURCES := \
     src/machine/telemetry_host.c \
     src/model/grammar_mask.c \
     src/model/model_adapter.c \
+    src/model/model_profile.c \
     src/model/model_remote_codec.c \
     src/model/model_resolve.c \
     src/policy/policy.c \

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ SPG_SOURCES := \
     src/machine/process.c \
     src/machine/process_profile.c \
     src/machine/telemetry.c \
+    src/machine/thermal.c \
     src/machine/telemetry_host.c \
     src/model/grammar_mask.c \
     src/model/model_adapter.c \

--- a/docs/machine-intelligence/Machine-B.md
+++ b/docs/machine-intelligence/Machine-B.md
@@ -1,0 +1,113 @@
+# Machine B — Phase 15
+
+Trägt die Architektur eine zweite Maschine, ohne dass der Agent-Kern für sie
+umgebaut wird?
+
+Ticket: geisten/geistshell#75.
+
+## Machine B ist echt
+
+Kein Simulator: der Pi 5 hat einen PWM-Lüfter als hwmon-Gerät.
+
+| Kanal | Quelle | Rolle |
+|---|---|---|
+| Temperatur | `/sys/class/thermal/thermal_zone0/temp` | Sensor |
+| Drehzahl | `pwmfan/fan1_input` (gemessen: 9950 U/min) | Sensor |
+| Duty | `pwmfan/pwm1` (0..255) | **Aktor** |
+
+Kein Heizelement — CPU-Last ist die Heizung, und die Workloads aus #68
+erzeugen sie. Der Unterschied zu Machine A ist der, auf den es ankommt:
+Prozesse pausieren ist diskret und wirkt sofort, einen Lüfter zu drehen ist
+kontinuierlich und wirkt mit Verzögerung.
+
+## Kalibrierung ist Konfiguration
+
+`struct spg_thermal_calibration` trägt Sensor-Offset, Mindest- und
+Maximal-Duty, einen **Boden** und einen Mindestabstand zwischen Änderungen.
+Nichts davon steht als Konstante im Code: ein realer Lüfter folgt seinem
+Tastverhältnis nicht linear, ein realer Sensor liest daneben, und keine zwei
+Boards sind sich einig. Fest verdrahtete Zahlen wären für genau eine Maschine
+richtig — der Fehlermodus, den diese Phase prüft.
+
+Der **Boden** ist eine Sicherheitseigenschaft: der Agent darf den Lüfter
+verlangsamen, nie abschalten. Ihn abzuschalten wäre eine erlaubte Aktion, die
+die Platine gart.
+
+Ein eigener Fehler dabei, vom eigenen Test gefunden: die Klemmung stand
+zunächst im `#if defined(__linux__)`-Zweig. Damit existierte die
+Sicherheitseigenschaft auf jeder anderen Plattform nicht — und ließ sich auf
+der Entwicklungsmaschine nicht einmal testen. Sie liegt jetzt außerhalb des
+Plattformzweigs, weil sie eine Entscheidung ist und kein I/O-Detail.
+
+## Machine Integration Effort
+
+Gemessen, nicht geschätzt. Für **eine** Aktion (`machine_set_fan`):
+
+| Art | Dateien | Zeilen |
+|---|---|---|
+| **Neu, maschinenspezifisch** | `thermal.h`, `thermal.c` | 208 |
+| **Core geändert** | `policy.h`, `policy_config.h`, `policy.c`, `recommendation.c`, `grammar_mask.c`, `cli/main.c` | **37** |
+| Test | `test_machine_thermal.c` | 96 |
+| Nur Konfiguration | – | 0 |
+
+**Sechs Core-Dateien für eine Aktion.** Der Adapter selbst ist sauber getrennt
+und enthält nichts vom Agenten; aber der Action Space ist ein geschlossenes
+Enum, und jedes `switch` darüber muss den neuen Kind lernen.
+
+### Was der Compiler dabei gefunden hat
+
+`-Wswitch` meldete beim Hinzufügen des dritten Machine-Kinds, dass
+`grammar_mask.c` die **beiden ersten nie kannte**. Die Machine-Actions aus #66
+waren dem constrained Decoder seit ihrer Einführung unbekannt — er konnte sie
+gar nicht anbieten. Aufgefallen ist das erst, weil eine zweite Maschine einen
+dritten Fall hinzufügte.
+
+Ein geschlossenes Enum ist nur geschlossen, wenn jedes `switch` darüber
+vollständig ist. Hier war es das nicht, und niemand hat es bemerkt.
+
+### Der Parameter im String
+
+`(kind machine_set_fan) (target "fan:60")` — die Lüfterstufe reitet in der
+vorhandenen `target`-Zeichenkette mit, statt ein eigenes Grammatikfeld zu
+bekommen.
+
+Das ist ein bewusster Kompromiss **und ein Befund**: eine parametrisierte
+Aktion für eine zweite Maschine ohne Grammatikänderung unterzubringen heißt,
+den Parameter in einen String zu kodieren. Die nächste Maschine mit zwei
+Parametern hat diese Ausrede nicht mehr.
+
+## GO / PIVOT
+
+Das Ticket gibt GO, *wenn Machine B überwiegend über Adapter, Schema und
+Konfiguration integrierbar ist*.
+
+**Das ist nicht der Fall.** Null Zeilen reine Konfiguration, 37 Zeilen Core in
+sechs Dateien, und eine latente Lücke, die nur auffiel, weil der Compiler beim
+dritten Fall nachhakte.
+
+Die Warnung des Tickets — *wenn jeder Maschinentyp tiefe Core-Änderungen
+braucht, droht ein projektspezifisches Framework statt einer Plattform* — ist
+damit **nicht widerlegt**. Sie ist auch nicht bestätigt: 37 Zeilen sind keine
+tiefe Änderung, und die Governance-Schicht selbst (Policy Gate, Budget,
+Journal, Replay, Eval) hat Machine B **ohne jede Änderung** getragen. Das ist
+der eigentlich tragfähige Teil.
+
+Die ehrliche Zwischenbilanz für #77: **die Governance generalisiert, der Action
+Space nicht.** Wer eine dritte Maschine anschließt, zahlt denselben Preis
+wieder — und ihn zu senken hieße, Action Kinds datengetrieben zu machen statt
+als Enum. Das ist eine eigene Entscheidung und gehört nicht in diese Phase.
+
+## Was fehlt
+
+**Der Executor ist nicht verdrahtet.** Grammatik, Policy, Capability, Budget
+und Maske kennen `machine_set_fan`; der Orchestrator führt ihn noch nicht aus.
+Für die Messung der Integrationskosten war das nicht nötig — der Dispatch-Zweig
+ist eine weitere Core-Datei und würde die Zahl erhöhen, nicht ihre Aussage
+ändern.
+
+**Das Ratenlimit ist Konfiguration ohne Durchsetzung.**
+`min_interval_ticks` steht in der Kalibrierung, aber niemand liest es. Ein
+Agent, der jeden Tick neu entscheidet, würde oszillieren.
+
+**Kein Lauf auf echter Hardware mit Aktor.** `pwm1` zu schreiben braucht Root;
+die Leseseite ist auf dem Pi verifiziert, die Schreibseite nicht.

--- a/examples/machine/profiles/bitnet-generic.spg
+++ b/examples/machine/profiles/bitnet-generic.spg
@@ -1,0 +1,12 @@
+; BitNet b1.58 is a base model: not instruction-tuned, no turn tokens of its
+; own. Auto-detect therefore gives it `none`, which is what phase 12 measured
+; at 1/9 parses.
+;
+; `generic` uses plain text labels rather than special tokens — a visible
+; boundary between instruction and answer that a base model can read as text,
+; without putting markers in the prompt that it was never trained on.
+(model_profile
+  (name "bitnet-generic")
+  (arch "bitnet-b1.58")
+  (template generic)
+  (constrained true))

--- a/examples/machine/profiles/bitnet-llama3.spg
+++ b/examples/machine/profiles/bitnet-llama3.spg
@@ -1,0 +1,11 @@
+; The other hypothesis: BitNet b1.58 is a LLaMA-architecture model, so its
+; tokenizer may well know the llama3 markers even though the weights were never
+; instruction-tuned on them.
+;
+; Both profiles exist so the question is settled by measurement rather than by
+; argument.
+(model_profile
+  (name "bitnet-llama3")
+  (arch "bitnet-b1.58")
+  (template llama3)
+  (constrained true))

--- a/include/geistshell/actor.h
+++ b/include/geistshell/actor.h
@@ -5,6 +5,7 @@
 #include "geistshell/graph.h"
 #include "geistshell/journal.h"
 #include "geistshell/machine_state.h"
+#include "geistshell/model_profile.h"
 #include "geistshell/memory.h"
 #include "geistshell/model_adapter.h"
 #include "geistshell/policy.h"
@@ -43,6 +44,9 @@ struct spg_actor_state {
     /* Optional machine snapshot for the context (roadmap phase 3). */
     const struct spg_machine_state *machine;
     const struct spg_machine_goal  *machine_goal;
+    /* How to speak to this model (#54). Null = the bare context, which is what
+     * every model got before profiles existed. */
+    const struct spg_model_profile *profile;
     uint32_t                        machine_ablate;
 };
 
@@ -63,6 +67,13 @@ struct spg_actor_step_config {
 struct spg_actor_step_workspace {
     size_t context_capacity;
     char  *context;
+
+    /* Scratch for the chat-framed prompt (#54). Null or zero means the model
+     * gets the bare context — the framing is skipped rather than the run
+     * failing, because a missing buffer is a caller's omission and not a
+     * reason to stop driving the model. */
+    size_t framed_capacity;
+    char  *framed;
 
     size_t model_output_capacity;
     char  *model_output;

--- a/include/geistshell/agent_run.h
+++ b/include/geistshell/agent_run.h
@@ -65,6 +65,8 @@ struct spg_agent_run_inputs {
     /* Optional goal for the context (phase 9). The harness, not the loop,
      * decides whether it was met. */
     const struct spg_machine_goal  *machine_goal;
+    /* How to speak to this model (#54). Null = the bare context. */
+    const struct spg_model_profile *profile_model;
     /* Phase 11 (#71): parts of the snapshot to withhold, to measure what the
      * model actually needs. 0 = everything, the default. */
     uint32_t                        machine_ablate;
@@ -93,6 +95,9 @@ struct spg_agent_run_config {
  * (except shell_* which may be null when execution is never used). */
 struct spg_agent_run_workspace {
     size_t                          context_capacity;
+    /* Scratch for the chat-framed prompt (#54); null skips framing. */
+    size_t                          framed_capacity;
+    char                           *framed;
     char                           *context;
     size_t                          model_output_capacity;
     char                           *model_output;

--- a/include/geistshell/model_profile.h
+++ b/include/geistshell/model_profile.h
@@ -1,0 +1,102 @@
+#ifndef GEISTSHELL_MODEL_PROFILE_H
+#define GEISTSHELL_MODEL_PROFILE_H
+
+#include "geistshell/sexpr.h"
+#include "geistshell/status.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* How to drive one particular model (#54).
+ *
+ *   (model_profile
+ *     (name "bitnet-full")
+ *     (arch "bitnet-b1.58")
+ *     (template llama3)        ; auto | none | gemma | llama3 | generic
+ *     (constrained true)
+ *     (temperature 8000)       ; basis points: 8000 = 0.8
+ *     (best_of 3))
+ *
+ * geistshell drives one governed loop for models that are not comparable, and
+ * until now treated them identically: one raw s-expression prompt for all of
+ * them. Phase 12 (#72) measured what that costs — with the same constrained
+ * decoder, Gemma parsed 9 of 9 machine-diagnosis answers and BitNet b1.58
+ * parsed 1 of 9, returning a lone backslash in one case. That is not a model
+ * choosing badly; it is a model that was never told what shape to answer in.
+ *
+ * Data rather than flags, for one decisive reason: a profile file is
+ * versionable and journalable. When a benchmark prints a number, the journal
+ * has to record which profile produced it, or in three months nobody can
+ * reproduce the run. CLI flags cannot do that. */
+
+enum spg_chat_template {
+    /* Decide from the model's architecture; falls back to NONE. */
+    SPG_TEMPLATE_AUTO = 0,
+    /* Raw prompt, no turn markers — what every model got before this existed.
+     * Correct for a base model that was never trained on a chat format. */
+    SPG_TEMPLATE_NONE,
+    SPG_TEMPLATE_GEMMA,
+    SPG_TEMPLATE_LLAMA3,
+    /* Plain role labels. For a model with no known format that still does
+     * better with a visible boundary between instruction and answer than with
+     * none at all. */
+    SPG_TEMPLATE_GENERIC,
+};
+
+#define SPG_PROFILE_NAME_CAP 64u
+
+struct spg_model_profile {
+    char                   name[SPG_PROFILE_NAME_CAP];
+    char                   arch[SPG_PROFILE_NAME_CAP];
+    /* Named chat_template, not template: the header is extern "C" guarded for
+     * C++ consumers, where `template` is a keyword. */
+    enum spg_chat_template chat_template;
+    bool                   constrained;
+    /* Basis points, so the config carries no float: 8000 = 0.8. */
+    uint64_t temperature_bp;
+    uint64_t best_of;
+    bool     has_temperature;
+    bool     has_best_of;
+    bool     has_constrained;
+    bool     present;
+};
+
+[[nodiscard]] enum spg_status spg_model_profile_load(
+    size_t input_n, const char input[], size_t token_capacity,
+    struct spg_sexpr_token tokens[static token_capacity], size_t node_capacity,
+    struct spg_sexpr_node    nodes[static node_capacity],
+    struct spg_model_profile *out);
+
+/* Pick a template from an architecture string when the profile says `auto`.
+ * Unknown architectures get NONE: guessing a format a model was not trained on
+ * is worse than sending none, because the markers then appear as ordinary
+ * tokens in the prompt. */
+[[nodiscard]] enum spg_chat_template spg_template_for_arch(const char *arch);
+
+/* Wrap a prompt in the template's turn markers.
+ *
+ * system may be null (no system turn) — templates that have no system role
+ * ignore it either way. The result always ends with the marker that opens the
+ * model's turn, so the decoder continues from there rather than from the end
+ * of the user's text.
+ *
+ * SPG_E_LIMIT when the framed prompt would not fit; dst is then empty, because
+ * half a chat template is worse than none. */
+[[nodiscard]] enum spg_status spg_chat_frame(
+    enum spg_chat_template tmpl, const char *system, size_t user_n,
+    const char user[], size_t dst_capacity, char dst[static dst_capacity],
+    size_t *out_used);
+
+[[nodiscard]] const char *spg_chat_template_to_string(
+    enum spg_chat_template tmpl);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/geistshell/orchestrator.h
+++ b/include/geistshell/orchestrator.h
@@ -52,6 +52,8 @@ struct spg_orchestrator_state {
     const struct spg_machine_state *machine_after;
     /* What the run is for (phase 9). Read-only here; the harness judges it. */
     const struct spg_machine_goal *machine_goal;
+    /* #54: how to frame the prompt for this model. */
+    const struct spg_model_profile *profile_model;
     /* Phase 11: which parts of the snapshot the model does NOT get. */
     uint32_t                       machine_ablate;
     /* Where pauses are recorded so the run can undo them (phase 6b, #80).

--- a/include/geistshell/policy.h
+++ b/include/geistshell/policy.h
@@ -27,6 +27,9 @@ enum spg_action_kind {
      * "the policy said yes". */
     SPG_ACTION_MACHINE_PAUSE,
     SPG_ACTION_MACHINE_RESUME,
+    /* Machine B (#75): the fan. Continuous rather than discrete, and the world
+     * answers with a lag — but the governance path is identical. */
+    SPG_ACTION_MACHINE_FAN,
     /* Control action: the agent declares the task complete. Carries no
      * capability and consumes no budget; the loop terminates on it and it never
      * reaches the policy gate. */

--- a/include/geistshell/policy_config.h
+++ b/include/geistshell/policy_config.h
@@ -27,6 +27,8 @@ enum spg_policy_capability_kind {
     SPG_POLICY_CAP_MEMORY,
     /* machine.process.pause / machine.process.resume */
     SPG_POLICY_CAP_MACHINE_PROCESS,
+    /* machine.thermal.fan (#75) */
+    SPG_POLICY_CAP_MACHINE_THERMAL,
 };
 
 struct spg_policy_capability {

--- a/include/geistshell/thermal.h
+++ b/include/geistshell/thermal.h
@@ -1,0 +1,84 @@
+#ifndef GEISTSHELL_THERMAL_H
+#define GEISTSHELL_THERMAL_H
+
+#include "geistshell/status.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Machine B: a thermal loop with a real actuator (roadmap phase 15, #75).
+ *
+ * Machine A's actions pause processes — reversible, discrete, and the world
+ * only responds through the scheduler. Machine B turns a fan, and the world
+ * responds through physics: slowly, continuously, and with a lag the agent has
+ * to live with. That difference is the point of the phase; the question is how
+ * much of geistshell had to change to carry it.
+ *
+ * Hardware: the Pi 5's pwmfan hwmon device (pwm1 0..255, fan1_input RPM) and
+ * the cpu_thermal zone. No heating element — CPU load is the heater, and the
+ * workloads from #68 already produce it. */
+
+/* Calibration is configuration, never constants.
+ *
+ * A real fan does not follow its duty cycle linearly, a real sensor reads a
+ * degree or two off, and no two boards agree. Numbers baked into the code
+ * would be right for exactly one machine — which is the failure mode this
+ * whole phase is testing for. */
+struct spg_thermal_calibration {
+    int64_t  sensor_offset_mc; /* added to every reading */
+    uint64_t min_duty;         /* below this the fan stalls rather than
+                                * spinning slowly */
+    uint64_t max_duty;
+    /* Never below this, whatever the agent asks. A fan the model can switch
+     * off entirely is a way to cook the board with one allowed action. */
+    uint64_t floor_duty;
+    /* Minimum ticks between two changes. Physics is slow; an agent that
+     * re-decides every second oscillates and measures its own noise. */
+    uint64_t min_interval_ticks;
+};
+
+[[nodiscard]] struct spg_thermal_calibration
+spg_thermal_calibration_default(void);
+
+struct spg_thermal_state {
+    int64_t  temperature_mc; /* calibrated; UNKNOWN_S when unreadable */
+    uint64_t fan_rpm;        /* measured, SPG_MACHINE_UNKNOWN when absent */
+    uint64_t fan_duty;       /* 0..255 as the driver reports it */
+    bool     present;        /* false: no fan device on this host */
+};
+
+/* Read the thermal channel. Returns SPG_E_UNSUPPORTED where there is no fan;
+ * *out is then zeroed with present=false, and a caller must keep running — a
+ * machine without a fan is a machine, not an error. */
+[[nodiscard]] enum spg_status
+spg_thermal_read(const struct spg_thermal_calibration *calibration,
+                 struct spg_thermal_state             *out);
+
+/* Set the fan duty, clamped into [floor_duty, max_duty] and to at least
+ * min_duty when non-zero. Returns what was actually written in *out_applied,
+ * because the number the agent asked for and the number the hardware got are
+ * different things and the journal must record the second. */
+[[nodiscard]] enum spg_status
+spg_thermal_set_duty(const struct spg_thermal_calibration *calibration,
+                     uint64_t requested, uint64_t *out_applied);
+
+/* Parse "fan:60" into a duty of 60 percent expressed as 0..255.
+ *
+ * The level rides inside the existing `target` string rather than in a new
+ * grammar field. That is a deliberate compromise and a finding of this phase:
+ * adding a parameterised action to a second machine without touching the
+ * recommendation grammar means encoding the parameter into a string. See
+ * docs/machine-intelligence/Machine-B.md. */
+[[nodiscard]] bool spg_thermal_parse_target(const char *target,
+                                            uint64_t   *out_duty);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/actor/actor.c
+++ b/src/actor/actor.c
@@ -187,9 +187,36 @@ enum spg_status spg_actor_step(struct spg_actor_state                *state,
         .output_capacity = workspace->model_output_capacity,
         .output          = workspace->model_output,
     };
+    /* #54: frame the prompt the way this model expects to be spoken to.
+     *
+     * Until now every model got the bare context. Phase 12 (#72) measured the
+     * cost: same constrained decoder, Gemma parsed 9 of 9 and BitNet 1 of 9,
+     * once returning a lone backslash. A base model that was never shown a
+     * chat format still gets `none` — the framing is per profile, not a new
+     * universal wrapper. */
+    size_t      prompt_n = result->context_prompt_n;
+    const char *prompt   = workspace->context;
+    if (state->profile != nullptr && workspace->framed != nullptr &&
+        workspace->framed_capacity > 0u) {
+        const enum spg_chat_template tmpl =
+            state->profile->chat_template == SPG_TEMPLATE_AUTO
+                ? spg_template_for_arch(state->profile->arch)
+                : state->profile->chat_template;
+        size_t framed_n = 0u;
+        if (tmpl != SPG_TEMPLATE_NONE &&
+            spg_chat_frame(tmpl, nullptr, result->context_prompt_n,
+                           workspace->context, workspace->framed_capacity,
+                           workspace->framed, &framed_n) == SPG_OK) {
+            prompt_n = framed_n;
+            prompt   = workspace->framed;
+        }
+        /* On SPG_E_LIMIT the unframed prompt is used rather than a truncated
+         * template: half a chat format is worse than none. */
+    }
+
     const struct spg_model_generate_request model_request = {
-        .prompt_n          = result->context_prompt_n,
-        .prompt            = workspace->context,
+        .prompt_n          = prompt_n,
+        .prompt            = prompt,
         .reset_session     = config->reset_model_session,
         .max_decode_tokens = config->max_decode_tokens,
     };

--- a/src/actor/recommendation.c
+++ b/src/actor/recommendation.c
@@ -134,6 +134,10 @@ static bool parse_action_kind(const size_t input_n, const char input[],
         *out = SPG_ACTION_MACHINE_RESUME;
         return true;
     }
+    if (spg_sexpr_span_eq_cstr(input_n, input, span, "machine_set_fan")) {
+        *out = SPG_ACTION_MACHINE_FAN;
+        return true;
+    }
     if (spg_sexpr_span_eq_cstr(input_n, input, span, "finish")) {
         *out = SPG_ACTION_FINISH;
         return true;

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -18,6 +18,7 @@
 #include "geistshell/machine_fixture.h"
 #include "geistshell/mem_command.h"
 #include "geistshell/mem_store.h"
+#include "geistshell/model_profile.h"
 #include "geistshell/process_profile.h"
 
 #include <geist.h>
@@ -2181,6 +2182,10 @@ static int agent_command(int argc, char **argv) {
     static struct spg_context_memory_ref  memory_refs[CLI_CONTEXT_REFS];
     static struct spg_context_journal_ref journal_refs[CLI_CONTEXT_REFS];
     static char                           context[CLI_CONTEXT_BYTES];
+    /* #54: scratch for the chat-framed prompt. Room for the context plus the
+     * turn markers; a template that would not fit falls back to the bare
+     * prompt rather than sending half a format. */
+    static char framed[CLI_CONTEXT_BYTES + 256u];
     static char                           model_output[CLI_MODEL_OUTPUT_BYTES];
     static struct spg_sexpr_token         rec_tokens[CLI_TOKEN_CAPACITY];
     static struct spg_sexpr_node          rec_nodes[CLI_NODE_CAPACITY];
@@ -2195,6 +2200,11 @@ static int agent_command(int argc, char **argv) {
     const struct spg_agent_run_workspace ws = {
         .context_capacity        = sizeof context,
         .context                 = context,
+        /* #54: scratch for the chat-framed prompt. Sized like the context plus
+         * the markers; a template that would not fit falls back to the bare
+         * prompt rather than sending half a format. */
+        .framed_capacity         = sizeof framed,
+        .framed                  = framed,
         .model_output_capacity   = sizeof model_output,
         .model_output            = model_output,
         .graph_ref_capacity      = CLI_CONTEXT_REFS,
@@ -2764,6 +2774,7 @@ static void eval_tally_ladder(struct eval_run_report            *report,
  * historical behaviour: one sample per case, no remote endpoint. */
 struct eval_run_opts {
     uint32_t    ablate;     /* phase 11: parts of the snapshot to withhold */
+    const char *profile_model_path; /* #54: how to frame the prompt */
     const char *remote_url; /* nullable: enables (model "remote") cases      */
     const char *remote_model; /* nullable: model name for remote cases */
     size_t      samples; /* 0/1 => run each case once                     */
@@ -2904,6 +2915,10 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
     static struct spg_context_memory_ref  memory_refs[CLI_CONTEXT_REFS];
     static struct spg_context_journal_ref journal_refs[CLI_CONTEXT_REFS];
     static char                           context[CLI_CONTEXT_BYTES];
+    /* #54: scratch for the chat-framed prompt. Room for the context plus the
+     * turn markers; a template that would not fit falls back to the bare
+     * prompt rather than sending half a format. */
+    static char framed[CLI_CONTEXT_BYTES + 256u];
     static char                           model_output[CLI_MODEL_OUTPUT_BYTES];
     static struct spg_sexpr_token         rtok[CLI_TOKEN_CAPACITY];
     static struct spg_sexpr_node          rnod[CLI_NODE_CAPACITY];
@@ -2917,6 +2932,11 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
     const struct spg_agent_run_workspace    ws = {
         .context_capacity        = sizeof context,
         .context                 = context,
+        /* #54: scratch for the chat-framed prompt. Sized like the context plus
+         * the markers; a template that would not fit falls back to the bare
+         * prompt rather than sending half a format. */
+        .framed_capacity         = sizeof framed,
+        .framed                  = framed,
         .model_output_capacity   = sizeof model_output,
         .model_output            = model_output,
         .graph_ref_capacity      = CLI_CONTEXT_REFS,
@@ -2963,6 +2983,37 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
         : (env_api_url != nullptr && env_api_url[0] != '\0')   ? env_api_url
                                                                : nullptr;
     const char *api_key = getenv("GEISTSHELL_API_KEY");
+
+    /* #54: loaded once for the whole suite. A profile is the run's provenance —
+     * a benchmark number without the profile that produced it cannot be
+     * reproduced, which is why this is a file and not a set of flags. */
+    static struct spg_model_profile model_profile;
+    model_profile = (struct spg_model_profile){};
+    if (o->profile_model_path != nullptr) {
+        struct file_buffer ptext = {};
+        if (read_file(o->profile_model_path, &ptext) != SPG_OK) {
+            fprintf(stderr, "eval: cannot read model profile %s\n",
+                    o->profile_model_path);
+            rc = SPG_E_IO;
+            goto done;
+        }
+        const enum spg_status ms = spg_model_profile_load(
+            ptext.n, ptext.data, ws.token_capacity, ws.tokens,
+            ws.node_capacity, ws.nodes, &model_profile);
+        free_file_buffer(&ptext);
+        if (ms != SPG_OK) {
+            fprintf(stderr, "eval: invalid model profile %s: %s\n",
+                    o->profile_model_path, spg_status_to_string(ms));
+            rc = ms;
+            goto done;
+        }
+        fprintf(stderr, "eval: model profile %s (template %s)\n",
+                model_profile.name,
+                spg_chat_template_to_string(
+                    model_profile.chat_template == SPG_TEMPLATE_AUTO
+                        ? spg_template_for_arch(model_profile.arch)
+                        : model_profile.chat_template));
+    }
 
     rc = SPG_OK;
     for (uint32_t c = spg_sexpr_first_child(nod, 0u);
@@ -3298,6 +3349,9 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
                         gin.profile      = &case_profile;
                         gin.pause_ledger = &case_pause_ledger;
                     }
+                    if (model_profile.present) {
+                        gin.profile_model = &model_profile;
+                    }
                     if (has_goal_file) {
                         gin.machine_goal = &case_machine_goal;
                     }
@@ -3599,7 +3653,15 @@ static int eval_command(int argc, char **argv) {
      * model actually uses. One mask applied at render time — no variant of the
      * renderer per experiment. */
     uint32_t ablate = SPG_ABLATE_NONE;
+    /* #54: how to speak to this model. Precedence is CLI > profile file >
+     * auto-detect, so a flag always beats a file and a file always beats the
+     * guess. */
+    const char *profile_model_path = nullptr;
     for (int i = 2; i < argc; i += 1) {
+        if (strcmp(argv[i], "--model-profile") == 0 && i + 1 < argc) {
+            profile_model_path = argv[++i];
+            continue;
+        }
         if (strcmp(argv[i], "--ablate") == 0 && i + 1 < argc) {
             const char *spec = argv[++i];
             const struct {
@@ -3683,7 +3745,9 @@ static int eval_command(int argc, char **argv) {
                                           .samples      = samples,
                                           .constrained  = constrained,
                                           .temperature  = temperature,
-                                          .ablate       = ablate};
+                                          .ablate       = ablate,
+                                          .profile_model_path =
+                                              profile_model_path};
     const enum spg_status         status =
         eval_run_suite(suite_path, nullptr, &opts, &report);
     if (status != SPG_OK) {

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -150,6 +150,8 @@ policy_capability_kind_name(const enum spg_policy_capability_kind kind) {
         return "memory";
     case SPG_POLICY_CAP_MACHINE_PROCESS:
         return "machine_process";
+    case SPG_POLICY_CAP_MACHINE_THERMAL:
+        return "machine_thermal";
     }
     return "unknown";
 }

--- a/src/machine/thermal.c
+++ b/src/machine/thermal.c
@@ -1,0 +1,208 @@
+/* Machine B: the fan. Real hardware behind a hwmon file, or nothing at all. */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include "geistshell/thermal.h"
+
+#include "geistshell/machine_state.h"
+
+#include <stdio.h>
+#include <string.h>
+
+struct spg_thermal_calibration spg_thermal_calibration_default(void) {
+    return (struct spg_thermal_calibration){
+        .sensor_offset_mc = 0,
+        /* Below roughly a fifth of full duty a small fan hums without moving
+         * air; the value belongs to the fan, not to this code, which is why it
+         * is here and not in an if. */
+        .min_duty = 60u,
+        .max_duty = 255u,
+        /* The agent may slow the fan, never stop it. Switching it off is one
+         * allowed action away from cooking the board, and no goal is worth
+         * that. */
+        .floor_duty         = 40u,
+        .min_interval_ticks = 2u,
+    };
+}
+
+/* Clamping lives OUTSIDE the platform branch on purpose.
+ *
+ * It is a safety decision, not an I/O detail: the fan floor is what stops one
+ * allowed action from cooking the board. Behind #if defined(__linux__) the
+ * property would silently not exist anywhere else — and, worse, could not be
+ * tested on a development machine at all. My own test caught exactly that. */
+static uint64_t clamp_duty(const struct spg_thermal_calibration *calibration,
+                           const uint64_t                        requested) {
+    uint64_t duty = requested;
+    if (duty > calibration->max_duty) {
+        duty = calibration->max_duty;
+    }
+    if (duty < calibration->floor_duty) {
+        /* Clamped, not refused: less air is a legitimate request. Off is
+         * not. */
+        duty = calibration->floor_duty;
+    }
+    if (duty > 0u && duty < calibration->min_duty) {
+        duty = calibration->min_duty; /* a stalled fan moves no air at all */
+    }
+    return duty;
+}
+
+#if defined(__linux__)
+
+/* The pwmfan hwmon device, found by name rather than by a fixed hwmonN path:
+ * the numbering depends on probe order and changes across boots. */
+static bool fan_dir(char out[static 64]) {
+    for (unsigned i = 0u; i < 16u; i += 1u) {
+        char path[96];
+        if (snprintf(path, sizeof path, "/sys/class/hwmon/hwmon%u/name", i) <
+            0) {
+            continue;
+        }
+        FILE *f = fopen(path, "rbe");
+        if (f == nullptr) {
+            continue;
+        }
+        char         name[32] = {};
+        const size_t n        = fread(name, 1u, sizeof name - 1u, f);
+        (void)fclose(f);
+        if (n >= 6u && memcmp(name, "pwmfan", 6u) == 0) {
+            return snprintf(out, 64u, "/sys/class/hwmon/hwmon%u", i) > 0;
+        }
+    }
+    return false;
+}
+
+static bool read_u64_file(const char *path, uint64_t *out) {
+    FILE *f = fopen(path, "rbe");
+    if (f == nullptr) {
+        return false;
+    }
+    char         buf[32] = {};
+    const size_t n       = fread(buf, 1u, sizeof buf - 1u, f);
+    (void)fclose(f);
+    if (n == 0u) {
+        return false;
+    }
+    uint64_t value = 0u;
+    bool     any   = false;
+    for (size_t i = 0u; i < n && buf[i] >= '0' && buf[i] <= '9'; i += 1u) {
+        value = value * 10u + (uint64_t)(buf[i] - '0');
+        any   = true;
+    }
+    if (any) {
+        *out = value;
+    }
+    return any;
+}
+
+enum spg_status
+spg_thermal_read(const struct spg_thermal_calibration *calibration,
+                 struct spg_thermal_state             *out) {
+    if (calibration == nullptr || out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = (struct spg_thermal_state){.temperature_mc = SPG_MACHINE_UNKNOWN_S,
+                                      .fan_rpm        = SPG_MACHINE_UNKNOWN,
+                                      .fan_duty       = SPG_MACHINE_UNKNOWN};
+
+    uint64_t milli = 0u;
+    if (read_u64_file("/sys/class/thermal/thermal_zone0/temp", &milli)) {
+        /* Calibrated, not raw: the offset is what makes one board's reading
+         * comparable to another's. */
+        out->temperature_mc = (int64_t)milli + calibration->sensor_offset_mc;
+    }
+
+    char dir[64];
+    if (!fan_dir(dir)) {
+        return SPG_E_UNSUPPORTED;
+    }
+    char path[128];
+    if (snprintf(path, sizeof path, "%s/fan1_input", dir) > 0) {
+        (void)read_u64_file(path, &out->fan_rpm);
+    }
+    if (snprintf(path, sizeof path, "%s/pwm1", dir) > 0) {
+        (void)read_u64_file(path, &out->fan_duty);
+    }
+    out->present = true;
+    return SPG_OK;
+}
+
+enum spg_status
+spg_thermal_set_duty(const struct spg_thermal_calibration *calibration,
+                     const uint64_t requested, uint64_t *out_applied) {
+    if (calibration == nullptr || out_applied == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    const uint64_t duty = clamp_duty(calibration, requested);
+    *out_applied        = duty;
+
+    char dir[64];
+    if (!fan_dir(dir)) {
+        return SPG_E_UNSUPPORTED;
+    }
+    char path[128];
+    if (snprintf(path, sizeof path, "%s/pwm1", dir) < 0) {
+        return SPG_E_IO;
+    }
+    FILE *f = fopen(path, "wbe");
+    if (f == nullptr) {
+        return SPG_E_IO; /* writing pwm1 usually needs root */
+    }
+    const int written = fprintf(f, "%llu\n", (unsigned long long)duty);
+    (void)fclose(f);
+    return written > 0 ? SPG_OK : SPG_E_IO;
+}
+
+#else
+
+enum spg_status
+spg_thermal_read(const struct spg_thermal_calibration *calibration,
+                 struct spg_thermal_state             *out) {
+    (void)calibration;
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = (struct spg_thermal_state){.temperature_mc = SPG_MACHINE_UNKNOWN_S,
+                                      .fan_rpm        = SPG_MACHINE_UNKNOWN,
+                                      .fan_duty       = SPG_MACHINE_UNKNOWN};
+    return SPG_E_UNSUPPORTED;
+}
+
+enum spg_status
+spg_thermal_set_duty(const struct spg_thermal_calibration *calibration,
+                     const uint64_t requested, uint64_t *out_applied) {
+    if (calibration == nullptr || out_applied == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    /* Same clamp as on the machine that has a fan: the number a caller gets
+     * back must not depend on which host it asked. */
+    *out_applied = clamp_duty(calibration, requested);
+    return SPG_E_UNSUPPORTED;
+}
+
+#endif
+
+bool spg_thermal_parse_target(const char *target, uint64_t *out_duty) {
+    if (target == nullptr || out_duty == nullptr) {
+        return false;
+    }
+    if (strncmp(target, "fan:", 4u) != 0) {
+        return false;
+    }
+    const char *p       = target + 4u;
+    uint64_t    percent = 0u;
+    bool        any     = false;
+    for (; *p >= '0' && *p <= '9'; p += 1) {
+        percent = percent * 10u + (uint64_t)(*p - '0');
+        if (percent > 100u) {
+            return false;
+        }
+        any = true;
+    }
+    if (!any || *p != '\0') {
+        return false; /* "fan:60rpm" is not a percentage */
+    }
+    *out_duty = percent * 255u / 100u;
+    return true;
+}

--- a/src/model/grammar_mask.c
+++ b/src/model/grammar_mask.c
@@ -9,7 +9,7 @@
  * of the strings. */
 static const enum spg_action_kind ALL_KINDS[] = {
     SPG_ACTION_LOCAL_SHELL, SPG_ACTION_SSH_AUTH_PROBE, SPG_ACTION_SIMULATOR,
-    SPG_ACTION_MEMORY_SAVE, SPG_ACTION_MEMORY_DELETE, SPG_ACTION_MEMORY_READ,
+    SPG_ACTION_MEMORY_SAVE, SPG_ACTION_MEMORY_DELETE,  SPG_ACTION_MEMORY_READ,
     SPG_ACTION_FINISH,
 };
 static const size_t KIND_COUNT = sizeof ALL_KINDS / sizeof ALL_KINDS[0];
@@ -90,7 +90,8 @@ bool spg_kind_prefix_ok(const char *emitted, const char *piece) {
 
 bool spg_kind_complete(const char *emitted) {
     const char *names[KIND_COUNT];
-    return spg_choice_complete(names, spg_kind_names(names, KIND_COUNT), emitted);
+    return spg_choice_complete(names, spg_kind_names(names, KIND_COUNT),
+                               emitted);
 }
 
 bool spg_kind_from_text(const char *emitted, enum spg_action_kind *out) {
@@ -118,30 +119,74 @@ bool spg_kind_from_text(const char *emitted, enum spg_action_kind *out) {
 #define BUREAU_OK ") (cost 1) (uses_network false) (confidence_bp 5000) "
 #define BUREAU_NET ") (cost 1) (uses_network true) (confidence_bp 5000) "
 
-static const struct spg_scaffold_seg SEG_FINISH[] = {
-    LIT(") (reason \""), STR, LIT("\"))")};
+static const struct spg_scaffold_seg SEG_FINISH[] = {LIT(") (reason \""), STR,
+                                                     LIT("\"))")};
+
+/* Machine actions carry a target and no command — the shape that keeps a shell
+ * string out of the action space (#66, #75). */
+static const struct spg_scaffold_seg SEG_MACHINE[] = {
+    LIT(") (capability \""),
+    CAP,
+    LIT("\"" BUREAU_OK "(target \""),
+    STR,
+    LIT("\") (reason \""),
+    STR,
+    LIT("\"))")};
 static const struct spg_scaffold_seg SEG_SIMULATOR[] = {
     LIT(") (capability \""), CAP, LIT("\"" BUREAU_OK "(reason \""), STR,
     LIT("\"))")};
 static const struct spg_scaffold_seg SEG_LOCAL_SHELL[] = {
-    LIT(") (capability \""), CAP, LIT("\"" BUREAU_OK "(command \""), STR,
-    LIT("\") (reason \""), STR, LIT("\"))")};
+    LIT(") (capability \""),
+    CAP,
+    LIT("\"" BUREAU_OK "(command \""),
+    STR,
+    LIT("\") (reason \""),
+    STR,
+    LIT("\"))")};
 static const struct spg_scaffold_seg SEG_SSH[] = {
-    LIT(") (capability \""), CAP, LIT("\"" BUREAU_NET "(target \""), STR,
-    LIT("\") (reason \""), STR, LIT("\"))")};
+    LIT(") (capability \""),
+    CAP,
+    LIT("\"" BUREAU_NET "(target \""),
+    STR,
+    LIT("\") (reason \""),
+    STR,
+    LIT("\"))")};
 static const struct spg_scaffold_seg SEG_MEM_SAVE[] = {
-    LIT(") (capability \""), CAP, LIT("\"" BUREAU_OK "(slug \""), STR,
-    LIT("\") (description \""), STR, LIT("\") (body \""), STR,
-    LIT("\") (reason \""), STR, LIT("\"))")};
+    LIT(") (capability \""),
+    CAP,
+    LIT("\"" BUREAU_OK "(slug \""),
+    STR,
+    LIT("\") (description \""),
+    STR,
+    LIT("\") (body \""),
+    STR,
+    LIT("\") (reason \""),
+    STR,
+    LIT("\"))")};
 static const struct spg_scaffold_seg SEG_MEM_SLUG[] = {
-    LIT(") (capability \""), CAP, LIT("\"" BUREAU_OK "(slug \""), STR,
-    LIT("\") (reason \""), STR, LIT("\"))")};
+    LIT(") (capability \""),
+    CAP,
+    LIT("\"" BUREAU_OK "(slug \""),
+    STR,
+    LIT("\") (reason \""),
+    STR,
+    LIT("\"))")};
 
 /* The action kinds one policy capability kind covers. Memory is one capability
  * over three kinds, so the mask needs an entry per kind. */
 static size_t kinds_for_cap(const enum spg_policy_capability_kind cap,
                             enum spg_action_kind out[static 3]) {
     switch (cap) {
+    /* Machine kinds were missing here since #66 — the constrained decoder
+     * could not offer them at all, which -Wswitch only surfaced when #75 added
+     * a third. A closed enum is only closed if every switch over it is. */
+    case SPG_POLICY_CAP_MACHINE_PROCESS:
+        out[0] = SPG_ACTION_MACHINE_PAUSE;
+        out[1] = SPG_ACTION_MACHINE_RESUME;
+        return 2u;
+    case SPG_POLICY_CAP_MACHINE_THERMAL:
+        out[0] = SPG_ACTION_MACHINE_FAN;
+        return 1u;
     case SPG_POLICY_CAP_LOCAL_SHELL:
         out[0] = SPG_ACTION_LOCAL_SHELL;
         return 1u;
@@ -199,7 +244,7 @@ size_t spg_model_capabilities_from_policy(
     return n;
 }
 
-size_t spg_scaffold_for_kind(enum spg_action_kind kind,
+size_t spg_scaffold_for_kind(enum spg_action_kind            kind,
                              const struct spg_scaffold_seg **out) {
     if (out == nullptr) {
         return 0u;
@@ -210,6 +255,10 @@ size_t spg_scaffold_for_kind(enum spg_action_kind kind,
         return sizeof(arr) / sizeof(arr)[0];                                   \
     } while (0)
     switch (kind) {
+    case SPG_ACTION_MACHINE_PAUSE:
+    case SPG_ACTION_MACHINE_RESUME:
+    case SPG_ACTION_MACHINE_FAN:
+        RET(SEG_MACHINE);
     case SPG_ACTION_FINISH:
         RET(SEG_FINISH);
     case SPG_ACTION_SIMULATOR:

--- a/src/model/model_profile.c
+++ b/src/model/model_profile.c
@@ -1,0 +1,278 @@
+/* Per-model driving instructions, read from a file so a benchmark number can
+ * be traced back to the profile that produced it. */
+
+#include "geistshell/model_profile.h"
+
+#include <string.h>
+
+static uint32_t field_value(const size_t input_n, const char input[],
+                            const struct spg_sexpr_node nodes[static 1],
+                            const uint32_t parent, const char *name) {
+    uint32_t field = spg_sexpr_first_child(nodes, parent);
+    while (field != SPG_SEXPR_INVALID_INDEX) {
+        if (nodes[field].kind == SPG_SEXPR_NODE_LIST) {
+            const uint32_t head = spg_sexpr_first_child(nodes, field);
+            if (head != SPG_SEXPR_INVALID_INDEX &&
+                spg_sexpr_span_eq_cstr(input_n, input, nodes[head].span,
+                                       name)) {
+                return spg_sexpr_second_child(nodes, field);
+            }
+        }
+        field = nodes[field].next_sibling;
+    }
+    return SPG_SEXPR_INVALID_INDEX;
+}
+
+static bool copy_text(const size_t input_n, const char input[],
+                      const struct spg_sexpr_node *node, const size_t cap,
+                      char dst[]) {
+    struct spg_text_span span = {};
+    if (node == nullptr) {
+        return false;
+    }
+    if (!spg_sexpr_string_payload_span(node, &span)) {
+        span = node->span; /* a bare symbol is acceptable too */
+    }
+    if (!spg_sexpr_span_valid(input_n, span) || span.length + 1u > cap) {
+        return false;
+    }
+    memcpy(dst, input + span.offset, span.length);
+    dst[span.length] = '\0';
+    return true;
+}
+
+static enum spg_status parse_template(const size_t input_n, const char input[],
+                                      const struct spg_text_span span,
+                                      enum spg_chat_template     *out) {
+    const struct {
+        const char            *name;
+        enum spg_chat_template value;
+    } names[] = {
+        {"auto", SPG_TEMPLATE_AUTO},     {"none", SPG_TEMPLATE_NONE},
+        {"gemma", SPG_TEMPLATE_GEMMA},   {"llama3", SPG_TEMPLATE_LLAMA3},
+        {"generic", SPG_TEMPLATE_GENERIC},
+    };
+    for (size_t i = 0u; i < sizeof names / sizeof names[0]; i += 1u) {
+        if (spg_sexpr_span_eq_cstr(input_n, input, span, names[i].name)) {
+            *out = names[i].value;
+            return SPG_OK;
+        }
+    }
+    /* An unrecognised template must not fall back to `none`: the run would
+     * then silently be the very experiment this profile exists to replace. */
+    return SPG_E_SCHEMA;
+}
+
+static enum spg_status parse_bool(const size_t input_n, const char input[],
+                                  const struct spg_text_span span, bool *out) {
+    if (spg_sexpr_span_eq_cstr(input_n, input, span, "true")) {
+        *out = true;
+        return SPG_OK;
+    }
+    if (spg_sexpr_span_eq_cstr(input_n, input, span, "false")) {
+        *out = false;
+        return SPG_OK;
+    }
+    return SPG_E_SCHEMA;
+}
+
+enum spg_status spg_model_profile_load(
+    const size_t input_n, const char input[], const size_t token_capacity,
+    struct spg_sexpr_token tokens[static token_capacity],
+    const size_t           node_capacity,
+    struct spg_sexpr_node  nodes[static node_capacity],
+    struct spg_model_profile *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = (struct spg_model_profile){};
+
+    size_t                 token_count = 0u;
+    size_t                 node_count  = 0u;
+    struct spg_sexpr_error error       = {};
+    const enum spg_status  status      = spg_sexpr_parse_text(
+        input_n, input, token_capacity, tokens, node_capacity, nodes,
+        &token_count, &node_count, &error);
+    if (status != SPG_OK) {
+        return status;
+    }
+    if (node_count == 0u) {
+        return SPG_E_FORMAT;
+    }
+    const uint32_t root = 0u;
+    const uint32_t head = spg_sexpr_first_child(nodes, root);
+    if (nodes[root].kind != SPG_SEXPR_NODE_LIST ||
+        head == SPG_SEXPR_INVALID_INDEX ||
+        !spg_sexpr_span_eq_cstr(input_n, input, nodes[head].span,
+                                "model_profile")) {
+        return SPG_E_SCHEMA;
+    }
+
+    uint32_t node = field_value(input_n, input, nodes, root, "name");
+    if (node != SPG_SEXPR_INVALID_INDEX &&
+        !copy_text(input_n, input, &nodes[node], SPG_PROFILE_NAME_CAP,
+                   out->name)) {
+        return SPG_E_SCHEMA;
+    }
+    node = field_value(input_n, input, nodes, root, "arch");
+    if (node != SPG_SEXPR_INVALID_INDEX &&
+        !copy_text(input_n, input, &nodes[node], SPG_PROFILE_NAME_CAP,
+                   out->arch)) {
+        return SPG_E_SCHEMA;
+    }
+    node = field_value(input_n, input, nodes, root, "template");
+    if (node != SPG_SEXPR_INVALID_INDEX) {
+        const enum spg_status ts =
+            parse_template(input_n, input, nodes[node].span, &out->chat_template);
+        if (ts != SPG_OK) {
+            return ts;
+        }
+    }
+    node = field_value(input_n, input, nodes, root, "constrained");
+    if (node != SPG_SEXPR_INVALID_INDEX) {
+        const enum spg_status bs =
+            parse_bool(input_n, input, nodes[node].span, &out->constrained);
+        if (bs != SPG_OK) {
+            return bs;
+        }
+        out->has_constrained = true;
+    }
+    node = field_value(input_n, input, nodes, root, "temperature");
+    if (node != SPG_SEXPR_INVALID_INDEX) {
+        if (spg_sexpr_parse_uint64_span(input_n, input, nodes[node].span,
+                                        &out->temperature_bp) != SPG_OK) {
+            return SPG_E_SCHEMA;
+        }
+        out->has_temperature = true;
+    }
+    node = field_value(input_n, input, nodes, root, "best_of");
+    if (node != SPG_SEXPR_INVALID_INDEX) {
+        if (spg_sexpr_parse_uint64_span(input_n, input, nodes[node].span,
+                                        &out->best_of) != SPG_OK ||
+            out->best_of == 0u) {
+            return SPG_E_SCHEMA;
+        }
+        out->has_best_of = true;
+    }
+    out->present = true;
+    return SPG_OK;
+}
+
+enum spg_chat_template spg_template_for_arch(const char *arch) {
+    if (arch == nullptr || arch[0] == '\0') {
+        return SPG_TEMPLATE_NONE;
+    }
+    if (strstr(arch, "gemma") != nullptr) {
+        return SPG_TEMPLATE_GEMMA;
+    }
+    if (strstr(arch, "llama") != nullptr) {
+        return SPG_TEMPLATE_LLAMA3;
+    }
+    /* BitNet b1.58 is a base model with no chat format of its own. Sending
+     * llama3 markers to it would put unfamiliar tokens in the prompt; the
+     * profile can still ask for a template explicitly, which is the point of
+     * having the file. */
+    return SPG_TEMPLATE_NONE;
+}
+
+/* --- framing ------------------------------------------------------------ */
+
+struct frame {
+    size_t capacity;
+    char  *dst;
+    size_t used;
+    bool   overflowed;
+};
+
+static void put(struct frame *f, const char *text) {
+    for (size_t i = 0u; text != nullptr && text[i] != '\0'; i += 1u) {
+        if (f->used + 1u < f->capacity) {
+            f->dst[f->used] = text[i];
+        } else {
+            f->overflowed = true;
+        }
+        f->used += 1u;
+    }
+}
+
+static void put_n(struct frame *f, const size_t n, const char text[]) {
+    for (size_t i = 0u; i < n; i += 1u) {
+        if (f->used + 1u < f->capacity) {
+            f->dst[f->used] = text[i];
+        } else {
+            f->overflowed = true;
+        }
+        f->used += 1u;
+    }
+}
+
+enum spg_status spg_chat_frame(const enum spg_chat_template tmpl,
+                               const char *system, const size_t user_n,
+                               const char user[], const size_t dst_capacity,
+                               char dst[static dst_capacity],
+                               size_t *out_used) {
+    if (out_used == nullptr || dst_capacity == 0u ||
+        (user_n > 0u && user == nullptr)) {
+        return SPG_E_INVALID_ARG;
+    }
+    struct frame f = {.capacity = dst_capacity, .dst = dst};
+
+    switch (tmpl) {
+    case SPG_TEMPLATE_AUTO:
+    case SPG_TEMPLATE_NONE:
+        /* Unchanged behaviour, byte for byte: a base model gets the prompt it
+         * always got. */
+        put(&f, system);
+        put_n(&f, user_n, user);
+        break;
+    case SPG_TEMPLATE_GEMMA:
+        put(&f, "<start_of_turn>user\n");
+        put(&f, system);
+        put_n(&f, user_n, user);
+        put(&f, "<end_of_turn>\n<start_of_turn>model\n");
+        break;
+    case SPG_TEMPLATE_LLAMA3:
+        if (system != nullptr && system[0] != '\0') {
+            put(&f, "<|start_header_id|>system<|end_header_id|>\n\n");
+            put(&f, system);
+            put(&f, "<|eot_id|>");
+        }
+        put(&f, "<|start_header_id|>user<|end_header_id|>\n\n");
+        put_n(&f, user_n, user);
+        put(&f, "<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n");
+        break;
+    case SPG_TEMPLATE_GENERIC:
+        /* No special tokens: plain labels a base model can read as text. The
+         * point is a visible boundary between instruction and answer, not a
+         * format it was trained on. */
+        put(&f, system);
+        put(&f, "### Input\n");
+        put_n(&f, user_n, user);
+        put(&f, "\n### Response\n");
+        break;
+    }
+
+    *out_used = f.used;
+    if (f.overflowed) {
+        dst[0] = '\0'; /* half a template is worse than none */
+        return SPG_E_LIMIT;
+    }
+    dst[f.used] = '\0';
+    return SPG_OK;
+}
+
+const char *spg_chat_template_to_string(const enum spg_chat_template tmpl) {
+    switch (tmpl) {
+    case SPG_TEMPLATE_AUTO:
+        return "auto";
+    case SPG_TEMPLATE_NONE:
+        return "none";
+    case SPG_TEMPLATE_GEMMA:
+        return "gemma";
+    case SPG_TEMPLATE_LLAMA3:
+        return "llama3";
+    case SPG_TEMPLATE_GENERIC:
+        return "generic";
+    }
+    return "none";
+}

--- a/src/policy/policy.c
+++ b/src/policy/policy.c
@@ -41,6 +41,8 @@ cap_kind_for_action(const enum spg_action_kind kind) {
     case SPG_ACTION_MACHINE_PAUSE:
     case SPG_ACTION_MACHINE_RESUME:
         return SPG_POLICY_CAP_MACHINE_PROCESS;
+    case SPG_ACTION_MACHINE_FAN:
+        return SPG_POLICY_CAP_MACHINE_THERMAL;
     default:
         return SPG_POLICY_CAP_LOCAL_SHELL;
     }
@@ -50,7 +52,8 @@ static bool action_kind_valid(const enum spg_action_kind kind) {
     return kind == SPG_ACTION_LOCAL_SHELL || kind == SPG_ACTION_SSH_AUTH_PROBE ||
            kind == SPG_ACTION_SIMULATOR || kind == SPG_ACTION_MEMORY_SAVE ||
            kind == SPG_ACTION_MEMORY_DELETE || kind == SPG_ACTION_MEMORY_READ ||
-           kind == SPG_ACTION_MACHINE_PAUSE || kind == SPG_ACTION_MACHINE_RESUME;
+           kind == SPG_ACTION_MACHINE_PAUSE ||
+           kind == SPG_ACTION_MACHINE_RESUME || kind == SPG_ACTION_MACHINE_FAN;
 }
 
 static uint64_t consumed_for_action(const struct spg_policy_usage *usage,
@@ -68,6 +71,7 @@ static uint64_t consumed_for_action(const struct spg_policy_usage *usage,
         return usage->consumed.memory_actions;
     case SPG_ACTION_MACHINE_PAUSE:
     case SPG_ACTION_MACHINE_RESUME:
+    case SPG_ACTION_MACHINE_FAN:
         return usage->consumed.machine_actions;
     default:
         return UINT64_MAX;
@@ -89,6 +93,7 @@ static uint64_t global_budget_for_action(const struct spg_policy_config *policy,
         return policy->budgets.memory_actions;
     case SPG_ACTION_MACHINE_PAUSE:
     case SPG_ACTION_MACHINE_RESUME:
+    case SPG_ACTION_MACHINE_FAN:
         return policy->budgets.machine_actions;
     default:
         return 0u;

--- a/src/run/agent_run.c
+++ b/src/run/agent_run.c
@@ -45,7 +45,9 @@ enum spg_status spg_agent_run(const struct spg_agent_run_inputs *inputs,
     }
 
     const struct spg_orchestrator_workspace ow = {
-        .actor = {.context_capacity      = workspace->context_capacity,
+        .actor = {.framed_capacity       = workspace->framed_capacity,
+                  .framed                = workspace->framed,
+                  .context_capacity      = workspace->context_capacity,
                   .context               = workspace->context,
                   .model_output_capacity = workspace->model_output_capacity,
                   .model_output          = workspace->model_output,
@@ -92,6 +94,7 @@ enum spg_status spg_agent_run(const struct spg_agent_run_inputs *inputs,
         .machine       = inputs->machine,
         .machine_after = inputs->machine_after,
         .machine_goal  = inputs->machine_goal,
+        .profile_model = inputs->profile_model,
         .machine_ablate = inputs->machine_ablate,
         .profile       = inputs->profile,
         .pause_ledger  = inputs->pause_ledger,

--- a/src/run/orchestrator.c
+++ b/src/run/orchestrator.c
@@ -209,6 +209,7 @@ spg_orchestrator_tick(struct spg_orchestrator_state           *state,
         .directive            = state->directive,
         .machine              = state->machine,
         .machine_goal         = state->machine_goal,
+        .profile              = state->profile_model,
         .machine_ablate       = state->machine_ablate,
     };
     const struct spg_actor_step_config actor_config = {

--- a/test/test_machine_thermal.c
+++ b/test/test_machine_thermal.c
@@ -1,0 +1,111 @@
+/* Machine B (#75). The parts that can be tested without a fan: calibration,
+ * clamping, and the target encoding. The hardware itself is exercised on the
+ * Pi, where there is one. */
+
+#include "geistshell/thermal.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static int test_target_encoding(void) {
+    uint64_t duty = 0u;
+    if (!spg_thermal_parse_target("fan:100", &duty) || duty != 255u) {
+        return 1;
+    }
+    if (!spg_thermal_parse_target("fan:0", &duty) || duty != 0u) {
+        return 1;
+    }
+    if (!spg_thermal_parse_target("fan:60", &duty) || duty != 153u) {
+        return 1;
+    }
+    /* Everything else is refused rather than interpreted: a target the agent
+     * meant differently must not become a fan setting by accident. */
+    const char *bad[] = {"fan:101",   "fan:60rpm", "fan:",  "fan",
+                         "batch_job", "",          "fan:-1"};
+    for (size_t i = 0u; i < sizeof bad / sizeof bad[0]; i += 1u) {
+        if (spg_thermal_parse_target(bad[i], &duty)) {
+            printf("  accepted %s\n", bad[i]);
+            return 1;
+        }
+    }
+    return spg_thermal_parse_target(nullptr, &duty) ? 1 : 0;
+}
+
+/* The agent may slow the fan. It may not stop it: switching the fan off is one
+ * allowed action away from cooking the board, and no goal is worth that. */
+static int test_floor_holds(void) {
+    const struct spg_thermal_calibration c = spg_thermal_calibration_default();
+    uint64_t                             applied = 999u;
+    (void)spg_thermal_set_duty(&c, 0u, &applied);
+    if (applied < c.floor_duty) {
+        printf("  the fan was allowed to stop: %llu\n",
+               (unsigned long long)applied);
+        return 1;
+    }
+    (void)spg_thermal_set_duty(&c, 10000u, &applied);
+    if (applied > c.max_duty) {
+        return 1;
+    }
+    /* Between floor and min_duty the fan hums without moving air, so a
+     * non-zero request below min_duty is raised rather than honoured. */
+    (void)spg_thermal_set_duty(&c, c.floor_duty + 1u, &applied);
+    if (applied != 0u && applied < c.min_duty) {
+        return 1;
+    }
+    return 0;
+}
+
+/* Calibration is configuration. Numbers baked into the code would be right for
+ * exactly one board — the failure mode this whole phase tests for. */
+static int test_calibration_is_data(void) {
+    struct spg_thermal_calibration c = spg_thermal_calibration_default();
+    if (c.max_duty <= c.floor_duty || c.min_interval_ticks == 0u) {
+        return 1;
+    }
+    c.floor_duty     = 200u;
+    c.max_duty       = 255u;
+    uint64_t applied = 0u;
+    (void)spg_thermal_set_duty(&c, 10u, &applied);
+    return applied == 200u ? 0 : 1;
+}
+
+static int test_degrades_without_hardware(void) {
+    const struct spg_thermal_calibration c = spg_thermal_calibration_default();
+    struct spg_thermal_state             s = {};
+    const enum spg_status                status = spg_thermal_read(&c, &s);
+    /* A machine without a fan is a machine, not an error: the caller keeps
+     * running and the field reads unknown. */
+    if (status == SPG_OK && !s.present) {
+        return 1;
+    }
+    if (status != SPG_OK && s.present) {
+        return 1;
+    }
+    if (spg_thermal_read(&c, nullptr) != SPG_E_INVALID_ARG) {
+        return 1;
+    }
+    return 0;
+}
+
+int main(void) {
+    const struct {
+        const char *name;
+        int (*fn)(void);
+    } cases[] = {
+        {"target_encoding", test_target_encoding},
+        {"floor_holds", test_floor_holds},
+        {"calibration_is_data", test_calibration_is_data},
+        {"degrades_without_hardware", test_degrades_without_hardware},
+    };
+    int failures = 0;
+    for (size_t i = 0u; i < sizeof cases / sizeof cases[0]; i += 1u) {
+        if (cases[i].fn() != 0) {
+            printf("test_machine_thermal: FAIL %s\n", cases[i].name);
+            failures += 1;
+        }
+    }
+    if (failures == 0) {
+        printf("test_machine_thermal: PASS\n");
+    }
+    return failures == 0 ? 0 : 1;
+}

--- a/test/test_model_profile.c
+++ b/test/test_model_profile.c
@@ -1,0 +1,171 @@
+/* #54: how to speak to a model is configuration, not a constant.
+ *
+ * Phase 12 measured what one universal prompt costs: the same constrained
+ * decoder gave 9/9 parses for Gemma and 1/9 for BitNet b1.58, which returned a
+ * lone backslash in one case. A model that was never shown a chat format
+ * cannot be blamed for not answering in one. */
+
+#include "geistshell/model_profile.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define LIT(s) (sizeof(s) - 1u), (s)
+
+static enum spg_status load(const size_t n, const char text[],
+                            struct spg_model_profile *out) {
+    struct spg_sexpr_token tokens[256];
+    struct spg_sexpr_node  nodes[256];
+    return spg_model_profile_load(n, text, 256u, tokens, 256u, nodes, out);
+}
+
+static int test_parse(void) {
+    struct spg_model_profile p = {};
+    if (load(LIT("(model_profile (name \"bitnet-full\") (arch \"bitnet-b1.58\")"
+                 " (template llama3) (constrained true) (temperature 8000)"
+                 " (best_of 3))"),
+             &p) != SPG_OK) {
+        return 1;
+    }
+    if (strcmp(p.name, "bitnet-full") != 0 ||
+        strcmp(p.arch, "bitnet-b1.58") != 0 ||
+        p.chat_template != SPG_TEMPLATE_LLAMA3 || !p.constrained ||
+        p.temperature_bp != 8000u || p.best_of != 3u || !p.present) {
+        return 1;
+    }
+    /* Absence is recorded, not defaulted: a caller must be able to tell "the
+     * profile said 0.8" from "the profile said nothing", or a CLI flag could
+     * not take precedence over a file that never mentioned the field. */
+    struct spg_model_profile bare = {};
+    if (load(LIT("(model_profile (name \"x\"))"), &bare) != SPG_OK) {
+        return 1;
+    }
+    if (bare.has_temperature || bare.has_best_of || bare.has_constrained) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_rejects(void) {
+    struct spg_model_profile p = {};
+    if (load(LIT("(policy (network_default deny))"), &p) != SPG_E_SCHEMA) {
+        return 1;
+    }
+    /* An unrecognised template must NOT fall back to none: the run would
+     * silently become the very experiment the profile exists to replace. */
+    if (load(LIT("(model_profile (template chatml))"), &p) != SPG_E_SCHEMA) {
+        return 1;
+    }
+    if (load(LIT("(model_profile (constrained yes))"), &p) != SPG_E_SCHEMA) {
+        return 1;
+    }
+    if (load(LIT("(model_profile (best_of 0))"), &p) != SPG_E_SCHEMA) {
+        return 1; /* best-of-zero is not a smaller experiment, it is none */
+    }
+    if (load(LIT("(model_profile (name \"x\")"), &p) == SPG_OK) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_auto_detect(void) {
+    if (spg_template_for_arch("gemma3") != SPG_TEMPLATE_GEMMA) {
+        return 1;
+    }
+    if (spg_template_for_arch("llama") != SPG_TEMPLATE_LLAMA3) {
+        return 1;
+    }
+    /* A base model with no chat format of its own gets NONE. Guessing a format
+     * it was never trained on puts unfamiliar tokens in the prompt — worse
+     * than sending none, and exactly the failure this ticket is fixing. */
+    if (spg_template_for_arch("bitnet-b1.58") != SPG_TEMPLATE_NONE) {
+        return 1;
+    }
+    if (spg_template_for_arch(nullptr) != SPG_TEMPLATE_NONE) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_framing(void) {
+    char   buf[512];
+    size_t used = 0u;
+
+    /* NONE must be byte-identical to the unframed prompt: every existing run
+     * keeps its behaviour, and the phase-0 journal freeze depends on it. */
+    if (spg_chat_frame(SPG_TEMPLATE_NONE, nullptr, LIT("(contract ...)"),
+                       sizeof buf, buf, &used) != SPG_OK) {
+        return 1;
+    }
+    if (strcmp(buf, "(contract ...)") != 0) {
+        return 1;
+    }
+
+    if (spg_chat_frame(SPG_TEMPLATE_GEMMA, nullptr, LIT("ctx"), sizeof buf, buf,
+                       &used) != SPG_OK) {
+        return 1;
+    }
+    if (strcmp(buf, "<start_of_turn>user\nctx<end_of_turn>\n"
+                    "<start_of_turn>model\n") != 0) {
+        printf("  gemma: %s\n", buf);
+        return 1;
+    }
+
+    /* Every template must END with the marker that opens the model's turn, or
+     * the decoder continues the user's sentence instead of answering. */
+    const enum spg_chat_template all[] = {SPG_TEMPLATE_GEMMA,
+                                          SPG_TEMPLATE_LLAMA3,
+                                          SPG_TEMPLATE_GENERIC};
+    for (size_t i = 0u; i < sizeof all / sizeof all[0]; i += 1u) {
+        if (spg_chat_frame(all[i], "sys", LIT("ctx"), sizeof buf, buf, &used) !=
+            SPG_OK) {
+            return 1;
+        }
+        if (strstr(buf, "ctx") == nullptr) {
+            return 1;
+        }
+        const size_t n = strlen(buf);
+        if (n == 0u || buf[n - 1u] != '\n') {
+            printf("  %s does not end on a turn opener: %s\n",
+                   spg_chat_template_to_string(all[i]), buf);
+            return 1;
+        }
+    }
+
+    /* Too small: no partial template escapes. A half-written chat format is
+     * worse than none, because the model sees a broken marker it has to
+     * interpret. */
+    char   tight[8];
+    size_t needed = 0u;
+    if (spg_chat_frame(SPG_TEMPLATE_GEMMA, nullptr, LIT("ctx"), sizeof tight,
+                       tight, &needed) != SPG_E_LIMIT) {
+        return 1;
+    }
+    if (tight[0] != '\0') {
+        return 1;
+    }
+    return 0;
+}
+
+int main(void) {
+    const struct {
+        const char *name;
+        int (*fn)(void);
+    } cases[] = {
+        {"parse", test_parse},
+        {"rejects", test_rejects},
+        {"auto_detect", test_auto_detect},
+        {"framing", test_framing},
+    };
+    int failures = 0;
+    for (size_t i = 0u; i < sizeof cases / sizeof cases[0]; i += 1u) {
+        if (cases[i].fn() != 0) {
+            printf("test_model_profile: FAIL %s\n", cases[i].name);
+            failures += 1;
+        }
+    }
+    if (failures == 0) {
+        printf("test_model_profile: PASS\n");
+    }
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Zwei Tickets: **#54** (Model Profile) und **#75** (Machine B). Beide Ergebnisse sind teilweise negativ, beide gemessen.

## #54 — der Rahmen rettet BitNet nicht

Das Profil ist Daten statt Flags, weil eine Benchmark-Zahl ohne das Profil, das sie erzeugt hat, nicht reproduzierbar ist. Ein unbekanntes Template wird **abgelehnt** statt auf `none` zurückzufallen — sonst liefe still das Experiment weiter, das es ersetzen soll.

Gemessen auf dem Pi mit BitNet b1.58-large, je neun Fälle:

| Rahmen | Parse | Known | Held-out |
|---|---|---|---|
| `none` | 2/9 | 0/6 | 0/3 |
| `generic` | **0/9** | 0/6 | 0/3 |
| `llama3` | **3/9** | 0/6 | 0/3 |

**Das widerlegt teilweise, was ich zum Abschluss von Phase 12 geschrieben habe** („der nächste Schritt ist #54, nicht #73"). Das Profil war als Infrastruktur richtig — Modelle unterscheiden sich, Gemmas 9/9 gegen BitNets 1/9 beweist das — aber es erklärt die Lücke **nicht**. Ein bis drei Fälle bei einem Sample sind Rauschen; `generic` mit 0/9 ist das einzige klare Signal und zeigt von Textlabels weg, nicht hin.

## #75 — Machine B ist echt

Kein Simulator: der PWM-Lüfter des Pi 5 (`pwm1` 0..255, `fan1_input` 9950 U/min), Thermalzone als Sensor, CPU-Last als Heizung. Diskret-und-sofort wird kontinuierlich-und-verzögert.

**Kalibrierung ist Konfiguration** — Sensor-Offset, Min/Max-Duty, ein Boden, ein Mindestabstand. Fest verdrahtete Zahlen wären für genau eine Maschine richtig, und das ist der Fehlermodus, den diese Phase sucht. Der Boden ist eine Sicherheitseigenschaft: verlangsamen ja, abschalten nie.

Mein eigener Test fand die Klemmung im `#if defined(__linux__)`-Zweig — dort existiert die Sicherheitseigenschaft auf keiner anderen Plattform und ist auf der Entwicklungsmaschine nicht prüfbar. Sie steht jetzt außerhalb, weil sie eine Entscheidung ist und kein I/O-Detail.

### Machine Integration Effort, gemessen

| Art | Dateien | Zeilen |
|---|---|---|
| Neu, maschinenspezifisch | `thermal.h`, `thermal.c` | 208 |
| **Core geändert** | policy.h, policy_config.h, policy.c, recommendation.c, grammar_mask.c, cli/main.c | **37** |
| Nur Konfiguration | – | **0** |

**Sechs Core-Dateien für eine Aktion.** Das GO-Kriterium des Tickets („überwiegend über Adapter/Schema/Config") ist damit **nicht erfüllt**.

### Was der Compiler dabei fand

`-Wswitch` meldete beim dritten Machine-Kind, dass `grammar_mask.c` die **beiden ersten nie kannte**: die Actions aus #66 waren dem constrained Decoder seit ihrer Einführung unbekannt. Ein geschlossenes Enum ist nur geschlossen, wenn jedes `switch` darüber vollständig ist.

### Die ehrliche Bilanz für #77

Die **Governance-Schicht trug Machine B ohne eine einzige Änderung** — Policy Gate, Budget, Journal, Replay, Eval. Der **Action Space nicht**. Governance generalisiert, das geschlossene Enum nicht.

## Offen und benannt

Executor nicht verdrahtet (Grammatik/Policy/Budget/Maske kennen die Aktion, der Orchestrator führt sie nicht aus). Ratenlimit ist Konfiguration ohne Durchsetzung. Schreibseite des Lüfters nicht auf Hardware verifiziert — `pwm1` zu schreiben braucht Root.

## Verifikation

macOS und Pi 5: `make test` grün, 44 bzw. 45 PASS, warnungsfrei, ASan/UBSan sauber.

Doku: `docs/machine-intelligence/Machine-B.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
