### PR TITLE
Phase 17: Go/No-Go — PIVOT, und die Regeln gewinnen

### DIFF
--- a/docs/machine-intelligence/Go-No-Go.md
+++ b/docs/machine-intelligence/Go-No-Go.md
@@ -1,0 +1,174 @@
+# Go / No-Go — Phase 17
+
+Nüchterne Auswertung aller Benchmarks. Keine neuen Features.
+
+Ticket: geisten/geistshell#77. Jede Antwort verweist auf eine gemessene Zahl;
+wo keine existiert, steht das statt einer Schätzung.
+
+## Die zwölf Fragen
+
+### 1. Schlägt AI die Rule Baseline?
+
+**Nein. Nicht annähernd.**
+
+| Methode | Known | Held-out | Halluzination | Unsafe | Zeit |
+|---|---|---|---|---|---|
+| **Regeln** | **6/6** | **3/3** | 0 | 0 | < 1 ms |
+| Gemma4-E2B Q4_K_M (2,89 GB) | 2/6 | 1/3 | 0 | 0 | 253 s |
+| BitNet b1.58-3B (0,94 GB) | 0/6 | 0/3 | 0 | 0 | 388 s |
+| BitNet b1.58-large (0,20 GB) | 0/6 | 0/3 | 0 | 0 | 89 s |
+
+Quelle: [Diagnosis-Benchmark.md](Diagnosis-Benchmark.md),
+[Small-Model-Gap.md](Small-Model-Gap.md).
+
+### 2. Bei welchen Szenarien?
+
+Bei **allen neun**. Das beste Modell löst drei, und einer davon
+(`critical_cpu`) ist schwer von Glück zu unterscheiden: dieselbe Antwort war im
+`healthy`-Szenario falsch.
+
+### 3. Wie groß ist der Gewinn?
+
+Negativ: **6 von 9 Fällen zugunsten der Regeln**, bei rund fünf Größenordnungen
+weniger Rechenzeit.
+
+**Aber die Regeln sind nicht robust.** Der Sensitivitätslauf über die
+Schwellwerte:
+
+| Schwellwerte | Treffer |
+|---|---|
+| Default | 9/9 |
+| alle −10 % | 9/9 |
+| alle **+10 %** | **6/9** |
+
+Nach oben verschoben brechen drei Fälle — vor allem die Speicherfälle, die bei
+95 % und 96,6 % Auslastung dicht an der 90-%-Schwelle liegen. Die 9/9 sind
+echt, aber sie stehen auf Zahlen, die nicht weit von den Daten entfernt sind.
+
+**Und der schwerste Vorbehalt:** Regeln und Szenarien haben denselben Autor.
+Die Szenarien entstanden in Phase 4 vor den Regeln in Phase 5, was hilft, aber
+es ersetzt keine unabhängige Testmenge.
+
+### 4. Wie oft schlägt das Modell unsichere Aktionen vor?
+
+**Nie** — in keinem Modell, keiner Ablationsvariante, keinem Lauf.
+
+Für Gemma ist das eine Aussage. Für die BitNets nicht: wer keine wohlgeformte
+Antwort erzeugt (1/9 bzw. 2/9 Parse), kann auch nichts Unsicheres vorschlagen.
+Eine Unsafe-Rate von 0 bei einer Parse-Rate von 1/9 ist eine Nebenwirkung.
+
+### 5. Wie oft verhindert die Policy erfolgreich Schaden?
+
+In **jedem** dafür konstruierten Fall — aber die Fälle waren scripted, nicht
+von einem Modell erzeugt.
+
+Neun von zwölf Red-Team-Angriffen werden durch eine Schicht gestoppt, mit der
+ein Modell nicht diskutieren kann. Siehe [Security-Review.md](Security-Review.md).
+Der Bypass-Test ist der aussagekräftigste: ein Modell greift nach `local_shell`,
+und die Konfiguration vergibt diese Capability gar nicht.
+
+**Die Policy hat noch nie echten Schaden verhindert**, weil kein Modell je
+Schaden versucht hat. Gemessen ist die Sperre, nicht ihre Notwendigkeit.
+
+### 6. Welches kleinste Modell liegt innerhalb von 3 Prozentpunkten des besten?
+
+**Keines.** Das beste Modell erreicht 3/9; das zweitbeste 0/9. Die Frage setzt
+eine Qualitätskurve voraus, die es nicht gibt — es gibt eine Klippe.
+
+### 7. RAM-, Latency- und CPU-Bedarf?
+
+Für das beste Modell (Gemma4-E2B): 2,89 GB Datei auf einem 4-GB-Pi, 253 s für
+neun Fälle. **Peak RSS und CPU während der Inferenz sind nicht instrumentiert**
+— der Harness misst Wanduhr, nicht Speicher.
+
+### 8. Welche Context-Informationen sind wirklich nötig?
+
+`minimal` — Temperatur, Throttling, Prozesse mit Rollen — erreicht dieselben
+Werte wie der volle Context bei **59 % der Bytes**. Die einzige Ablation, die
+eindeutig schadet, ist die Prozessliste.
+
+Einschränkung aus [Context-Ablation.md](Context-Ablation.md): zwischen leerem
+und vollem Context liegen für Gemma ein bekannter und ein held-out Fall. Das
+ist der gesamte Informationswert des Contexts für dieses Modell.
+
+### 9. Generalisiert es auf Machine B?
+
+**Die Governance ja, der Action Space nein.**
+
+Policy Gate, Budget, Journal, Replay und Eval trugen den Lüfter **ohne eine
+einzige Änderung**. Siehe [Machine-B.md](Machine-B.md).
+
+### 10. Wie viel maschinenspezifischer Code war nötig?
+
+208 Zeilen Adapter, **37 Zeilen in sechs Core-Dateien**, **null Zeilen reine
+Konfiguration** — für *eine* Aktion.
+
+### 11. Ist der Agent-Layer generisch oder nur für den Pi passend?
+
+**Generisch in der Governance, Pi-spezifisch in der Telemetrie.**
+
+Die Telemetrie ist Linux-only und liest `/proc` und `/sys`; macOS degradiert
+sauber zu `unknown`. Die Governance-Schicht enthält nichts Maschinenspezifisches.
+
+Der geschlossene Action-Enum liegt dazwischen: er ist nicht Pi-spezifisch, aber
+jede neue Maschine kostet Änderungen an sechs Stellen.
+
+### 12. Welche Probleme löst klassische Software besser?
+
+**Diese.** Vier Schwellwertvergleiche über eine feste Feldliste lösen die Suite
+vollständig in unter einer Millisekunde. Ein 2,89-GB-Modell braucht 253 s für
+ein Drittel davon.
+
+Genauer: klassische Software gewinnt überall dort, wo die Zustandsmenge klein,
+die Signale numerisch und die Ursachenmenge geschlossen ist — also genau in dem
+Regime, das die Kernhypothese als „kleine, strukturierte, kontrollierbare Welt"
+beschreibt. **Je besser die Welt zur Hypothese passt, desto weniger braucht sie
+ein Modell.**
+
+## Die drei Forschungsmetriken
+
+| Metrik | Ergebnis |
+|---|---|
+| **Quality vs. Model Size** | Keine Kurve, eine Klippe. Zwischen 2,89 GB und 0,94 GB bricht die **Form** zusammen (9/9 → 1/9 Parse), nicht die Qualität. |
+| **Safety under Model Failure** | Die Sperre hält in jedem konstruierten Fall; ihre Notwendigkeit ist ungemessen, weil kein Modell je etwas Unsicheres vorschlug. |
+| **Machine Integration Effort** | 6 Core-Dateien, 37 Zeilen, 0 Konfigurationszeilen pro Aktion. Governance: 0 Änderungen. |
+
+## Empfehlung: **PIVOT**
+
+> geistshell als Governance- und Evaluations-Runtime, aber kein eigenes kleines
+> Modell.
+
+Begründet ausschließlich mit den Messungen oben:
+
+**Gegen ein eigenes Modell** sprechen Frage 1, 3, 6 und 12. Die Regel-Baseline
+schlägt jedes getestete Modell in jedem Szenario bei fünf Größenordnungen
+weniger Rechenzeit. Es gibt kein kleinstes Modell innerhalb von 3 Prozentpunkten
+des besten, weil es keine Kurve gibt. Und der dominante Fehler der kleinen
+Modelle ist Formtreue — die Aufgabe des Decoders, nicht des Gewichts (#72).
+
+**Für die Runtime** sprechen Frage 5, 9 und 11. Die Governance trug eine zweite
+Maschine ohne Änderung. Der Bypass-Versuch scheiterte an der Konfiguration, nicht
+an einer Prompt-Formulierung. Der Journal-Freeze aus Phase 0 hielt über sechzehn
+Phasen und über zwei Architekturen byte-identisch.
+
+**Kein STOP**, weil die Governance-Schicht messbar funktioniert und das Ergebnis
+selbst — dass Regeln hier gewinnen — nur zu haben war, weil eine Eval-Runtime
+existierte, die es zeigen konnte.
+
+**Kein GO**, weil ein OEM Machine Agent Runtime ein Modell voraussetzt, das
+seinen Platz verdient, und keines hat ihn verdient.
+
+## Was diese Empfehlung nicht trägt
+
+- **Kein Remote-Frontier-Modell getestet.** Kein Endpunkt konfiguriert. Die
+  Aussage „AI schlägt die Regeln nicht" gilt für zwei lokale Architekturen auf
+  einem Pi, nicht für die Klasse.
+- **Ein Sample pro Fall.** Unterschiede von ein bis drei Fällen sind Rauschen.
+- **Neun Szenarien, ein Autor.** Regeln und Testfälle stammen von derselben
+  Hand; die Regeln überstehen −10 %, aber nicht +10 %.
+- **Keine echte Prozesslast.** Die Diagnose-Szenarien sind Fixtures. Die
+  Workloads aus #68 sind gebaut, aber nie gegen ein Modell gefahren.
+
+Der ehrlichste Satz zum Schluss: **das wertvollste Ergebnis dieser Roadmap ist
+ein negatives**, und es war nur zu haben, weil die Infrastruktur existierte, um
+es zu messen.

--- a/examples/machine/rule_sensitivity.c
+++ b/examples/machine/rule_sensitivity.c
@@ -1,0 +1,48 @@
+/* Does the rule baseline survive a perturbation of its own thresholds?
+ *
+ * #65 asked for it and #77 needs the answer: rules and scenarios in this
+ * roadmap share an author, so "9 of 9" is only worth something if it does not
+ * sit exactly on the numbers that were chosen for it.
+ *
+ * Build:
+ *   clang -std=c23 -Iinclude -Iinclude/geistshell -o /tmp/sens \
+ *     examples/machine/rule_sensitivity.c build/host-debug/lib/libgeistshell.a \
+ *     deps/geist/lib/<target>/libgeist.a
+ *
+ * Result at the time of writing: 9/9 at default, 9/9 at -10%, 6/9 at +10%.
+ * The memory cases sit at 95% and 96.6% against a 90% threshold, so raising it
+ * by a tenth takes them out. */
+
+#include "geistshell/diagnose.h"
+#include "geistshell/machine_fixture.h"
+#include <stdio.h>
+#include <string.h>
+static struct spg_sexpr_token tk[512]; static struct spg_sexpr_node nd[512];
+static const char *files[] = {"1_batch_cpu","2_critical_cpu","3_memory_batch","4_thermal",
+  "5_contradictory","6_healthy","7_heldout_thermal_batch","8_heldout_memory_critical","9_no_processes"};
+static const char *want[] = {"batch_pressure","critical_pressure","memory_pressure","thermal_anomaly",
+  "inconclusive","healthy","thermal_anomaly","memory_pressure","inconclusive"};
+static int run(struct spg_rule_thresholds t, const char *label){
+  int ok=0;
+  for(size_t i=0;i<9;i++){
+    char path[256]; snprintf(path,sizeof path,"examples/eval/machine/states/%s.spg",files[i]);
+    FILE *f=fopen(path,"rb"); if(!f){printf("fehlt: %s\n",path); return -1;}
+    char buf[8192]; size_t n=fread(buf,1,sizeof buf,f); fclose(f);
+    struct spg_machine_state s={};
+    if(spg_machine_state_parse(n,buf,512u,tk,512u,nd,&s)!=SPG_OK) continue;
+    struct spg_diagnosis_result r={};
+    if(spg_rule_diagnose(&s,&t,&r)!=SPG_OK) continue;
+    if(strcmp(spg_diagnosis_to_string(r.diagnosis),want[i])==0) ok++;
+  }
+  printf("%-14s %d/9\n",label,ok); return ok;
+}
+int main(void){
+  struct spg_rule_thresholds base=spg_rule_thresholds_default();
+  run(base,"default");
+  struct spg_rule_thresholds lo=base, hi=base;
+  lo.cpu_high_bp=base.cpu_high_bp*9/10; lo.memory_high_bp=base.memory_high_bp*9/10;
+  lo.temperature_high_mc=base.temperature_high_mc*9/10; lo.process_share_bp=base.process_share_bp*9/10;
+  hi.cpu_high_bp=base.cpu_high_bp*11/10; hi.memory_high_bp=base.memory_high_bp*11/10;
+  hi.temperature_high_mc=base.temperature_high_mc*11/10; hi.process_share_bp=base.process_share_bp*11/10;
+  run(lo,"-10%"); run(hi,"+10%");
+  return 0;}


### PR DESCRIPTION
Phase 17 der Roadmap (#77). Stapelt auf #95. Keine neuen Features — zwölf Fragen, jede mit einer gemessenen Zahl beantwortet, und wo keine existiert, steht das statt einer Schätzung.

## Die entscheidende Zahl fehlte noch

Phase 5 blieb unfertig. Nachgeholt:

| Methode | Known | Held-out | Unsafe | Zeit |
|---|---|---|---|---|
| **Regeln** | **6/6** | **3/3** | 0 | **< 1 ms** |
| Gemma4-E2B (2,89 GB) | 2/6 | 1/3 | 0 | 253 s |
| BitNet b1.58-3B (0,94 GB) | 0/6 | 0/3 | 0 | 388 s |
| BitNet b1.58-large (0,20 GB) | 0/6 | 0/3 | 0 | 89 s |

Die Regeln gewinnen **jedes** Szenario, bei rund fünf Größenordnungen weniger Rechenzeit.

## Sofort eingeschränkt, sonst wäre die Zahl weniger wert als sie aussieht

| Schwellwerte | Treffer |
|---|---|
| Default | 9/9 |
| alle −10 % | 9/9 |
| alle **+10 %** | **6/9** |

Die Speicherfälle liegen bei 95 % und 96,6 % gegen eine 90-%-Schwelle — ein Zehntel höher, und sie fallen raus. Dazu: **Regeln und Szenarien haben denselben Autor**. Die Szenarien entstanden vor den Regeln, was hilft, aber keine unabhängige Testmenge ersetzt. Der Sweep liegt als `examples/machine/rule_sensitivity.c` bei, damit die Zahl nachrechenbar ist statt geglaubt.

## Empfehlung: PIVOT

> geistshell als Governance- und Evaluations-Runtime, aber kein eigenes kleines Modell.

**Gegen ein Modell:** kein kleinstes Modell innerhalb von 3 Prozentpunkten des besten, weil es keine Kurve gibt — es gibt eine Klippe, und sie liegt bei der **Form** (9/9 Parse gegen 1/9), nicht beim Urteil.

**Gegen STOP:** die Governance trug eine zweite Maschine ohne eine einzige Änderung, der Shell-Bypass scheiterte an der Konfiguration statt an einer Prompt-Formulierung, und der Journal-Freeze aus Phase 0 hielt über sechzehn Phasen und zwei Architekturen byte-identisch.

## Antworten, die unbequem sind

**Frage 5** („wie oft verhindert die Policy Schaden?"): die Sperre hält in jedem konstruierten Fall — aber **die Policy hat nie echten Schaden verhindert**, weil kein Modell je Schaden versucht hat. Gemessen ist die Sperre, nicht ihre Notwendigkeit.

**Frage 4** (Unsafe-Rate 0): für Gemma eine Aussage, für die BitNets nicht. Wer keine gültige Form erzeugt, kann nichts Unsicheres vorschlagen.

**Frage 12** („was löst klassische Software besser?"): diese Aufgabe. Und allgemeiner — klassische Software gewinnt dort, wo die Zustandsmenge klein, die Signale numerisch und die Ursachen geschlossen sind. Also genau in dem Regime, das die Kernhypothese als „kleine, strukturierte, kontrollierbare Welt" beschreibt. **Je besser die Welt zur Hypothese passt, desto weniger braucht sie ein Modell.**

## Was die Empfehlung nicht trägt

Kein Remote-Frontier-Modell getestet (kein Endpunkt). Ein Sample pro Fall. Neun Szenarien, ein Autor. Die Workloads aus #68 sind gebaut, aber nie gegen ein Modell gefahren.

Doku: `docs/machine-intelligence/Go-No-Go.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
