### PR TITLE
Portabilität: ein Backend pro Plattform — macOS liest jetzt eine echte Maschine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,18 @@ DEPS_DIR  := deps
 GEIST_DIR := $(DEPS_DIR)/geist
 # Official upstream engine. Pin GEIST_REF to a commit/tag for reproducible
 # builds; override either on the command line to track a fork or branch.
+# One backend per platform, chosen at link time. The alternative — #if inside
+# the sampler — is what this replaces: it hid a safety decision in an I/O
+# branch where no test on a developer machine could reach it.
+HOST_OS := $(shell uname -s)
+ifeq ($(HOST_OS),Linux)
+    MACHINE_BACKEND := src/machine/backend_linux.c
+else ifeq ($(HOST_OS),Darwin)
+    MACHINE_BACKEND := src/machine/backend_macos.c
+else
+    MACHINE_BACKEND := src/machine/backend_generic.c
+endif
+
 GEIST_REPO ?= https://github.com/geisten/geistlib.git
 GEIST_REF  ?= v0.8.2
 
@@ -115,6 +127,7 @@ SPG_SOURCES := \
     src/machine/telemetry.c \
     src/machine/thermal.c \
     src/machine/telemetry_host.c \
+    $(MACHINE_BACKEND) \
     src/model/grammar_mask.c \
     src/model/model_adapter.c \
     src/model/model_profile.c \

--- a/docs/machine-intelligence/Portability.md
+++ b/docs/machine-intelligence/Portability.md
@@ -1,0 +1,115 @@
+# Portability
+
+Welche Maschine geistshell lesen kann — und wie eine neue dazukommt.
+
+## Die Portgrenze
+
+`include/geistshell/machine_backend.h` ist die **gesamte** Oberfläche, die
+geistshell von einem Betriebssystem braucht. Alles darüber ist portables C:
+Parser, Auswahl, Renderer, Policy, Ledger, Ziele. Alles darunter ist **eine
+Datei pro Plattform**, ausgewählt beim Linken.
+
+```
+include/geistshell/machine_backend.h   der Vertrag
+src/machine/backend_linux.c            /proc, /sys, hwmon
+src/machine/backend_macos.c            Mach, sysctl, libproc
+src/machine/backend_generic.c          alles unbekannt, ehrlich
+```
+
+Keine Funktionszeiger, kein Makro-Dispatch, kein `#if defined(__linux__)`
+mitten in Logik, die mit Betriebssystemen nichts zu tun hat. Das Makefile
+wählt über `uname -s`:
+
+```make
+ifeq ($(HOST_OS),Linux)
+    MACHINE_BACKEND := src/machine/backend_linux.c
+else ifeq ($(HOST_OS),Darwin)
+    MACHINE_BACKEND := src/machine/backend_macos.c
+else
+    MACHINE_BACKEND := src/machine/backend_generic.c
+endif
+```
+
+**Warum diese Grenze existiert:** die Lüfterklemmung aus Phase 15 stand einmal
+im `#if defined(__linux__)`-Zweig. Eine Sicherheitseigenschaft, die auf keiner
+anderen Plattform existierte und auf der Entwicklungsmaschine nicht getestet
+werden konnte. Eine Portgrenze ist genau deshalb wertvoll: sie verhindert, dass
+sich **Entscheidungen** in **I/O** verstecken.
+
+## Was jede Plattform liefert
+
+| Kanal | Linux | macOS | generic |
+|---|---|---|---|
+| CPU-Auslastung | `/proc/stat` | `host_statistics` | – |
+| Speicher | `/proc/meminfo` | `hw.memsize` + `HOST_VM_INFO64` | – |
+| Swap | `/proc/meminfo` | `vm.swapusage` | – |
+| Load Average | `/proc/loadavg` | `getloadavg` | – |
+| Temperatur | `thermal_zone0` | **nicht verfügbar** | – |
+| CPU-Frequenz | `scaling_cur_freq` | `hw.cpufrequency` (nur Intel) | – |
+| Throttling | hwmon `rpi_volt` | **nicht verfügbar** | – |
+| Prozesse | `/proc/<pid>/stat` | `KERN_PROC_ALL` + `proc_pidinfo` | – |
+| Prozess-Identität | Startzeit in Ticks | `p_starttime` in µs | – |
+| Lüfter | hwmon `pwmfan` | **nicht verfügbar** | – |
+
+**Was fehlt, wird gesagt statt gefälscht.** macOS hat keine öffentliche
+Temperatur- oder Lüfterschnittstelle; die SMC-Schlüssel, die überall
+kursieren, sind privat und ändern sich zwischen Modellen. Für eine Runtime,
+die auditierbar sein soll, ist eine private API ein schlechter Tausch gegen
+eine Zahl, die das Schema ohnehin als `unknown` zulässt.
+
+## Zwei Statusarten, ein Unterschied
+
+`spg_backend_is_live()` unterscheidet **„dieser Sensor fehlt"** von **„diese
+Plattform wurde nie portiert"**. Ein Bericht, der beides gleich behandelt, wird
+irgendwann falsch gelesen: 20 % Temperaturabdeckung heißt etwas anderes, wenn
+die Hälfte der Hosts gar keinen Port hat.
+
+## Der Vertrag, der beim Portieren zuerst bricht
+
+**Aggregierte CPU-Zeit und `spg_process_sample.cpu_time` müssen dieselbe
+Einheit haben.** Prozessauslastung ist das Verhältnis der beiden.
+
+Der macOS-Port hat genau das im ersten Lauf verletzt: aggregiert in Mach-Ticks,
+pro Prozess in Mikrosekunden. Ergebnis war nicht ein kleiner Fehler, sondern
+**jeder Prozess bei 100 %** — eine Zahl, die plausibel genug aussieht, um durch
+ein Review zu kommen. Deshalb steht die Regel jetzt im Header und nicht in
+jemandes Kopf.
+
+## CPU-Architekturen
+
+Nichts in diesem Code ist architekturspezifisch: kein SIMD, keine Annahme über
+Wortbreite, Endianness oder Seitengröße. Tickraten, Seitengrößen und
+Zähler-Einheiten bleiben im Backend, das sie kennt; nach oben gehen nur
+Verhältnisse und Bytes.
+
+Verifiziert auf **aarch64** (Pi 5, Linux) und **arm64** (Apple Silicon, macOS).
+x86-64 sollte ohne Änderung laufen, ist aber **nicht getestet** — und
+ungetestet heißt hier ungetestet.
+
+## Eine neue Plattform hinzufügen
+
+1. `src/machine/backend_<os>.c` schreiben, alle Funktionen aus
+   `machine_backend.h` implementieren.
+2. Fehlendes gibt `SPG_E_UNSUPPORTED` **und** setzt den Ausgabewert auf
+   `unknown` — nie auf 0.
+3. Einheitenvertrag für CPU-Zeit einhalten (siehe oben).
+4. Im Makefile eine `uname`-Zeile ergänzen.
+
+Kein Test muss angefasst werden. Die Suite fragt `spg_backend_is_live()`, nicht
+den Präprozessor — vorher stand in drei Tests `#if defined(__linux__)`, und
+jeder davon hätte beim nächsten Port erneut editiert werden müssen.
+
+## Was der macOS-Port an Testfehlern aufgedeckt hat
+
+Zwei Prüfungen waren nur auf Linux-Daten korrekt:
+
+- `test_cli_machine.sh` zählte Klammern, um die Wohlgeformtheit des Blocks zu
+  prüfen. Auf Linux enthalten Prozessnamen selten Klammern; macOS liefert
+  `Claude Helper (`, und der Zähler schlug an. Klammern **innerhalb einer
+  Zeichenkette** sind Inhalt — die Prüfung ist jetzt String-bewusst.
+- `test_cli_machine_run.sh` schaltete auf `uname -s = Linux` und las
+  `/proc/<pid>/stat` für den Prozesszustand. Beides ersetzt durch
+  `ps -o stat=`, das beide Kernel beantworten.
+
+Beide Fehler prüften seit Monaten weniger, als sie behaupteten. Ein zweiter
+Port ist das billigste Werkzeug, um so etwas zu finden.

--- a/include/geistshell/machine_backend.h
+++ b/include/geistshell/machine_backend.h
@@ -1,0 +1,111 @@
+#ifndef GEISTSHELL_MACHINE_BACKEND_H
+#define GEISTSHELL_MACHINE_BACKEND_H
+
+#include "geistshell/machine_state.h"
+#include "geistshell/status.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* The whole surface geistshell needs from an operating system.
+ *
+ * Everything above this line is portable C: the parsers, the selection, the
+ * renderer, the policy, the ledger. Everything below it is one file per
+ * platform, chosen at link time by the Makefile — no function pointers, no
+ * macro dispatch, and no `#if defined(__linux__)` scattered through logic that
+ * has nothing to do with an operating system.
+ *
+ * That split was not free of charge to learn. The fan clamp in thermal.c sat
+ * inside a platform branch until a test caught it: a safety property that
+ * silently did not exist off Linux and could not be tested on the machine it
+ * was written on. A port boundary is worth having precisely because it stops
+ * decisions from hiding inside I/O.
+ *
+ * Every function here follows one rule: **a value that cannot be read is
+ * unknown, never zero, and never an error that stops the run.** A host without
+ * a temperature sensor is a host, not a failure.
+ *
+ * Nothing in this interface is CPU-architecture specific. Counters are
+ * normalised to ratios by the callers, so tick rates, page sizes and word
+ * widths stay inside the backend that knows them. */
+
+/* Which backend was linked. Goes into the journal and the benchmark records:
+ * a measurement without the platform that produced it cannot be compared. */
+[[nodiscard]] const char *spg_backend_name(void);
+
+/* True when this backend reads a real machine. The generic fallback returns
+ * false, which lets a caller distinguish "the sensor is missing" from "this
+ * platform was never ported". */
+[[nodiscard]] bool spg_backend_is_live(void);
+
+/* Aggregate CPU time counters. Units are the platform's own — only deltas
+ * between two samples are ever used, so the tick rate never leaves here.
+ * Returns SPG_E_UNSUPPORTED when the platform cannot report them.
+ *
+ * ONE CONTRACT BINDS A BACKEND: this counter and spg_process_sample.cpu_time
+ * MUST share a unit. Per-process utilisation is the ratio of the two, and a
+ * ratio between microseconds and ticks is not a small error — it pins every
+ * process at 100%. The macOS port did exactly that on its first run, which is
+ * why the rule is written down here rather than assumed. */
+[[nodiscard]] enum spg_status spg_backend_cpu(struct spg_cpu_sample *out);
+
+/* Total and used memory in bytes. "Used" means what a workload cannot have:
+ * total minus what the kernel would hand out on demand. */
+[[nodiscard]] enum spg_status spg_backend_memory(struct spg_memory_sample *out);
+
+/* Load averages, x100. */
+[[nodiscard]] enum spg_status spg_backend_load(struct spg_load_sample *out);
+
+/* Millidegrees Celsius. SPG_E_UNSUPPORTED where no public interface exists —
+ * macOS is such a platform, and pretending otherwise would mean shipping a
+ * private-API dependency for a number the roadmap already treats as optional.
+ */
+[[nodiscard]] enum spg_status spg_backend_temperature(int64_t *out_mc);
+
+[[nodiscard]] enum spg_status spg_backend_frequency_khz(uint64_t *out_khz);
+
+[[nodiscard]] enum spg_status
+spg_backend_throttle(enum spg_throttle_state *out);
+
+/* Fill up to `cap` process samples and report how many exist in total, which
+ * is not the same number: the snapshot is deliberately smaller than the
+ * machine. Each sample carries pid, start identity, name, state, nice, raw CPU
+ * time and RSS; cpu_bp is left unknown because a rate needs two samples.
+ *
+ * `total` may exceed `*out_n` — a caller uses it to report truncation. */
+[[nodiscard]] enum spg_status
+spg_backend_processes(size_t cap, struct spg_process_sample out[],
+                      size_t *out_n, uint64_t *out_total);
+
+/* The start identity of one live process, for the re-validation phase 6 does
+ * immediately before signalling. Returns SPG_E_NOT_FOUND when the pid is gone
+ * — which is the answer that matters, because a pid that no longer exists must
+ * never be signalled.
+ *
+ * Separate from spg_backend_processes on purpose: the executor asks about ONE
+ * pid at the last possible moment, and walking the whole process table to
+ * answer that would widen the window it exists to close. */
+[[nodiscard]] enum spg_status
+spg_backend_process_identity(uint64_t pid, uint64_t *out_start_identity);
+
+/* --- machine B ---------------------------------------------------------- */
+
+/* Fan speed and duty. SPG_E_UNSUPPORTED on hosts with no controllable fan,
+ * which is most of them. */
+[[nodiscard]] enum spg_status spg_backend_fan_read(uint64_t *out_rpm,
+                                                   uint64_t *out_duty);
+
+/* Write the fan duty. The clamp is applied by the caller — it is a safety
+ * decision and belongs above the port boundary, not inside it. */
+[[nodiscard]] enum spg_status spg_backend_fan_write(uint64_t duty);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/geistshell/machine_state.h
+++ b/include/geistshell/machine_state.h
@@ -59,6 +59,13 @@ struct spg_load_sample {
  * which ones survive; see spg_process_select. */
 #define SPG_MACHINE_MAX_PROCESSES 64u
 
+/* How many processes the sampler looks at before choosing. Larger than the
+ * snapshot on purpose: a selection that only ever sees the first sixty-four
+ * the kernel listed is not a selection. Found the hard way on a Pi with 167
+ * processes, where kernel threads filled the context and the busiest process
+ * was never considered. */
+#define SPG_MACHINE_RAW_PROCESSES 1024u
+
 /* profile_index of a process no profile entry matched. */
 #define SPG_PROCESS_NO_PROFILE UINT32_MAX
 

--- a/src/executor/machine_executor.c
+++ b/src/executor/machine_executor.c
@@ -9,6 +9,8 @@
 
 #include "geistshell/machine_executor.h"
 
+#include "geistshell/machine_backend.h"
+
 #include "geistshell/machine_fixture.h"
 #include "geistshell/sexpr.h"
 
@@ -19,7 +21,12 @@
  * been recycled since the snapshot. An executor that cannot verify what it is
  * about to stop must not stop anything, so every other platform reports
  * UNSUPPORTED rather than acting blind. */
-#if defined(__linux__)
+/* Signals wherever POSIX offers kill() and the backend can answer "is this
+ * still the same process". Both halves are required: an executor that cannot
+ * verify what it is about to stop must not stop anything. The identity now
+ * comes from the port boundary, so adding a platform means writing a backend
+ * rather than touching this file. */
+#if defined(__unix__) || defined(__APPLE__)
 #    include <errno.h>
 #    include <signal.h>
 #    include <stdio.h>
@@ -71,26 +78,14 @@ find_target(const struct spg_machine_state *machine, const char *target) {
  * could be a tick old, and a tick is long enough for a pid to be reused. */
 static bool identity_still_matches(const uint64_t pid,
                                    const uint64_t start_identity) {
-    char path[64];
-    if (snprintf(path, sizeof path, "/proc/%llu/stat",
-                 (unsigned long long)pid) < 0) {
+    /* Asked of the backend at the last possible moment. A pid that no longer
+     * exists answers NOT_FOUND, which is the answer that matters: never signal
+     * something you cannot name. */
+    uint64_t current = 0u;
+    if (spg_backend_process_identity(pid, &current) != SPG_OK) {
         return false;
     }
-    FILE *f = fopen(path, "rbe");
-    if (f == nullptr) {
-        return false;
-    }
-    char         buf[2048];
-    const size_t n = fread(buf, 1u, sizeof buf, f);
-    (void)fclose(f);
-    if (n == 0u) {
-        return false;
-    }
-    struct spg_process_sample now = {};
-    if (spg_process_parse_stat(n, buf, 4096u, &now) != SPG_OK) {
-        return false;
-    }
-    return now.pid == pid && now.start_identity == start_identity;
+    return current == start_identity;
 }
 #endif
 

--- a/src/machine/backend_generic.c
+++ b/src/machine/backend_generic.c
@@ -1,0 +1,109 @@
+/* The backend for a platform nobody has ported yet.
+ *
+ * Every value is unknown and every call says SPG_E_UNSUPPORTED. That is not a
+ * stub to be ashamed of: it is the contract the whole schema was built around
+ * — a machine whose sensors cannot be read is a machine, and the agent keeps
+ * running with an honest snapshot instead of a fabricated one.
+ *
+ * spg_backend_is_live() returns false here, which is the one thing that
+ * distinguishes "this sensor is missing" from "this platform was never
+ * ported". A report that cannot tell those apart is a report that will
+ * eventually be misread. */
+
+#include "geistshell/machine_backend.h"
+
+const char *spg_backend_name(void) { return "generic"; }
+bool        spg_backend_is_live(void) { return false; }
+
+enum spg_status spg_backend_cpu(struct spg_cpu_sample *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = (struct spg_cpu_sample){};
+    return SPG_E_UNSUPPORTED;
+}
+
+enum spg_status spg_backend_memory(struct spg_memory_sample *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = (struct spg_memory_sample){.total_bytes     = SPG_MACHINE_UNKNOWN,
+                                      .used_bytes      = SPG_MACHINE_UNKNOWN,
+                                      .swap_used_bytes = SPG_MACHINE_UNKNOWN};
+    return SPG_E_UNSUPPORTED;
+}
+
+enum spg_status spg_backend_load(struct spg_load_sample *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = (struct spg_load_sample){.avg_1_cbp  = SPG_MACHINE_UNKNOWN,
+                                    .avg_5_cbp  = SPG_MACHINE_UNKNOWN,
+                                    .avg_15_cbp = SPG_MACHINE_UNKNOWN};
+    return SPG_E_UNSUPPORTED;
+}
+
+enum spg_status spg_backend_temperature(int64_t *out_mc) {
+    if (out_mc == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out_mc = SPG_MACHINE_UNKNOWN_S;
+    return SPG_E_UNSUPPORTED;
+}
+
+enum spg_status spg_backend_frequency_khz(uint64_t *out_khz) {
+    if (out_khz == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out_khz = SPG_MACHINE_UNKNOWN;
+    return SPG_E_UNSUPPORTED;
+}
+
+enum spg_status spg_backend_throttle(enum spg_throttle_state *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = SPG_THROTTLE_UNKNOWN;
+    return SPG_E_UNSUPPORTED;
+}
+
+enum spg_status spg_backend_processes(const size_t              cap,
+                                      struct spg_process_sample out[],
+                                      size_t *out_n, uint64_t *out_total) {
+    (void)cap;
+    (void)out;
+    if (out_n == nullptr || out_total == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out_n     = 0u;
+    *out_total = 0u;
+    return SPG_E_UNSUPPORTED;
+}
+
+enum spg_status spg_backend_process_identity(const uint64_t pid,
+                                             uint64_t *out_start_identity) {
+    (void)pid;
+    if (out_start_identity == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out_start_identity = 0u;
+    /* NOT_FOUND rather than UNSUPPORTED, and deliberately so: the executor
+     * refuses to signal anything it cannot identify, so an unported platform
+     * must look like "this process is gone" rather than like a condition a
+     * caller might decide to ignore. */
+    return SPG_E_NOT_FOUND;
+}
+
+enum spg_status spg_backend_fan_read(uint64_t *out_rpm, uint64_t *out_duty) {
+    if (out_rpm == nullptr || out_duty == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out_rpm  = SPG_MACHINE_UNKNOWN;
+    *out_duty = SPG_MACHINE_UNKNOWN;
+    return SPG_E_UNSUPPORTED;
+}
+
+enum spg_status spg_backend_fan_write(const uint64_t duty) {
+    (void)duty;
+    return SPG_E_UNSUPPORTED;
+}

--- a/src/machine/backend_linux.c
+++ b/src/machine/backend_linux.c
@@ -1,0 +1,293 @@
+/* Linux backend: /proc and /sys.
+ *
+ * Extracted from the sampler so the sampler no longer knows what an operating
+ * system is. The parsers stay where they were — they are pure functions over
+ * buffers and belong to the portable half; only the reading of files lives
+ * here. */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include "geistshell/machine_backend.h"
+
+#include <dirent.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h> /* sysconf: not pulled in transitively on glibc */
+
+const char *spg_backend_name(void) { return "linux"; }
+bool        spg_backend_is_live(void) { return true; }
+
+/* Caller-provided buffer, no allocation. Returns the byte count read, or 0
+ * when the file is missing — a missing sysfs file is normal, not an error. */
+static size_t read_file(const char *path, const size_t cap, char buf[cap]) {
+    FILE *f = fopen(path, "rbe");
+    if (f == nullptr) {
+        return 0u;
+    }
+    const size_t n = fread(buf, 1u, cap, f);
+    (void)fclose(f);
+    return n;
+}
+
+enum spg_status spg_backend_cpu(struct spg_cpu_sample *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = (struct spg_cpu_sample){};
+    char         buf[4096];
+    const size_t n = read_file("/proc/stat", sizeof buf, buf);
+    if (n == 0u) {
+        return SPG_E_UNSUPPORTED;
+    }
+    return spg_telemetry_parse_stat(n, buf, out);
+}
+
+enum spg_status spg_backend_memory(struct spg_memory_sample *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    char         buf[4096];
+    const size_t n = read_file("/proc/meminfo", sizeof buf, buf);
+    if (n == 0u) {
+        *out =
+            (struct spg_memory_sample){.total_bytes     = SPG_MACHINE_UNKNOWN,
+                                       .used_bytes      = SPG_MACHINE_UNKNOWN,
+                                       .swap_used_bytes = SPG_MACHINE_UNKNOWN};
+        return SPG_E_UNSUPPORTED;
+    }
+    return spg_telemetry_parse_meminfo(n, buf, out);
+}
+
+enum spg_status spg_backend_load(struct spg_load_sample *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    char         buf[256];
+    const size_t n = read_file("/proc/loadavg", sizeof buf, buf);
+    if (n == 0u) {
+        *out = (struct spg_load_sample){.avg_1_cbp  = SPG_MACHINE_UNKNOWN,
+                                        .avg_5_cbp  = SPG_MACHINE_UNKNOWN,
+                                        .avg_15_cbp = SPG_MACHINE_UNKNOWN};
+        return SPG_E_UNSUPPORTED;
+    }
+    return spg_telemetry_parse_loadavg(n, buf, out);
+}
+
+enum spg_status spg_backend_temperature(int64_t *out_mc) {
+    if (out_mc == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out_mc = SPG_MACHINE_UNKNOWN_S;
+    char         buf[64];
+    const size_t n =
+        read_file("/sys/class/thermal/thermal_zone0/temp", sizeof buf, buf);
+    if (n == 0u) {
+        return SPG_E_UNSUPPORTED;
+    }
+    return spg_telemetry_parse_int(n, buf, out_mc);
+}
+
+enum spg_status spg_backend_frequency_khz(uint64_t *out_khz) {
+    if (out_khz == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out_khz = SPG_MACHINE_UNKNOWN;
+    char         buf[64];
+    const size_t n =
+        read_file("/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq",
+                  sizeof buf, buf);
+    if (n == 0u) {
+        return SPG_E_UNSUPPORTED;
+    }
+    int64_t khz = 0;
+    if (spg_telemetry_parse_int(n, buf, &khz) != SPG_OK || khz < 0) {
+        return SPG_E_FORMAT;
+    }
+    *out_khz = (uint64_t)khz;
+    return SPG_OK;
+}
+
+/* Under-voltage on a Pi 5 is an hwmon alarm, not a firmware sysfs node: the
+ * firmware path does not exist on current kernels, which left the field
+ * permanently unknown on the very hardware the roadmap targets. */
+enum spg_status spg_backend_throttle(enum spg_throttle_state *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = SPG_THROTTLE_UNKNOWN;
+    char   buf[64];
+    size_t n = read_file("/sys/devices/platform/soc/soc:firmware/get_throttled",
+                         sizeof buf, buf);
+    if (n > 0u) {
+        *out = spg_telemetry_parse_throttle(n, buf);
+        return SPG_OK;
+    }
+    char path[96];
+    for (unsigned i = 0u; i < 16u; i += 1u) {
+        if (snprintf(path, sizeof path, "/sys/class/hwmon/hwmon%u/name", i) <
+            0) {
+            continue;
+        }
+        n = read_file(path, sizeof buf, buf);
+        if (n < 8u || memcmp(buf, "rpi_volt", 8u) != 0) {
+            continue;
+        }
+        if (snprintf(path, sizeof path,
+                     "/sys/class/hwmon/hwmon%u/in0_lcrit_alarm", i) < 0) {
+            continue;
+        }
+        n = read_file(path, sizeof buf, buf);
+        if (n == 0u) {
+            return SPG_E_UNSUPPORTED;
+        }
+        *out = buf[0] == '0' ? SPG_THROTTLE_NONE : SPG_THROTTLE_ACTIVE;
+        return SPG_OK;
+    }
+    return SPG_E_UNSUPPORTED;
+}
+
+enum spg_status spg_backend_processes(const size_t              cap,
+                                      struct spg_process_sample out[],
+                                      size_t *out_n, uint64_t *out_total) {
+    if (out_n == nullptr || out_total == nullptr ||
+        (cap > 0u && out == nullptr)) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out_n     = 0u;
+    *out_total = 0u;
+
+    DIR *dir = opendir("/proc");
+    if (dir == nullptr) {
+        return SPG_E_UNSUPPORTED;
+    }
+    const long     page_size  = sysconf(_SC_PAGESIZE);
+    const uint64_t page_bytes = page_size > 0 ? (uint64_t)page_size : 0u;
+    char           path[64];
+    char           buf[2048];
+
+    const struct dirent *entry;
+    while ((entry = readdir(dir)) != nullptr) {
+        bool numeric = entry->d_name[0] != '\0';
+        for (size_t i = 0u; numeric && entry->d_name[i] != '\0'; i += 1u) {
+            numeric = entry->d_name[i] >= '0' && entry->d_name[i] <= '9';
+        }
+        if (!numeric) {
+            continue;
+        }
+        *out_total += 1u;
+        if (*out_n >= cap) {
+            continue; /* still counted: the caller reports what it dropped */
+        }
+        if (snprintf(path, sizeof path, "/proc/%s/stat", entry->d_name) < 0) {
+            continue;
+        }
+        const size_t n = read_file(path, sizeof buf, buf);
+        if (n == 0u) {
+            continue; /* it exited between readdir and open */
+        }
+        if (spg_process_parse_stat(n, buf, page_bytes, &out[*out_n]) ==
+            SPG_OK) {
+            *out_n += 1u;
+        }
+    }
+    (void)closedir(dir);
+    return SPG_OK;
+}
+
+enum spg_status spg_backend_process_identity(const uint64_t pid,
+                                             uint64_t *out_start_identity) {
+    if (out_start_identity == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out_start_identity = 0u;
+    char path[64];
+    if (snprintf(path, sizeof path, "/proc/%llu/stat",
+                 (unsigned long long)pid) < 0) {
+        return SPG_E_NOT_FOUND;
+    }
+    char         buf[2048];
+    const size_t n = read_file(path, sizeof buf, buf);
+    if (n == 0u) {
+        return SPG_E_NOT_FOUND;
+    }
+    struct spg_process_sample sample = {};
+    if (spg_process_parse_stat(n, buf, 4096u, &sample) != SPG_OK) {
+        return SPG_E_NOT_FOUND;
+    }
+    *out_start_identity = sample.start_identity;
+    return SPG_OK;
+}
+
+/* The pwmfan hwmon device, found by name rather than a fixed hwmonN path: the
+ * numbering depends on probe order and changes across boots. */
+static bool fan_dir(char out[static 64]) {
+    for (unsigned i = 0u; i < 16u; i += 1u) {
+        char path[96];
+        if (snprintf(path, sizeof path, "/sys/class/hwmon/hwmon%u/name", i) <
+            0) {
+            continue;
+        }
+        char         name[32] = {};
+        const size_t n        = read_file(path, sizeof name - 1u, name);
+        if (n >= 6u && memcmp(name, "pwmfan", 6u) == 0) {
+            return snprintf(out, 64u, "/sys/class/hwmon/hwmon%u", i) > 0;
+        }
+    }
+    return false;
+}
+
+static bool read_u64_file(const char *path, uint64_t *out) {
+    char         buf[32] = {};
+    const size_t n       = read_file(path, sizeof buf - 1u, buf);
+    if (n == 0u) {
+        return false;
+    }
+    uint64_t value = 0u;
+    bool     any   = false;
+    for (size_t i = 0u; i < n && buf[i] >= '0' && buf[i] <= '9'; i += 1u) {
+        value = value * 10u + (uint64_t)(buf[i] - '0');
+        any   = true;
+    }
+    if (any) {
+        *out = value;
+    }
+    return any;
+}
+
+enum spg_status spg_backend_fan_read(uint64_t *out_rpm, uint64_t *out_duty) {
+    if (out_rpm == nullptr || out_duty == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out_rpm  = SPG_MACHINE_UNKNOWN;
+    *out_duty = SPG_MACHINE_UNKNOWN;
+    char dir[64];
+    if (!fan_dir(dir)) {
+        return SPG_E_UNSUPPORTED;
+    }
+    char path[128];
+    if (snprintf(path, sizeof path, "%s/fan1_input", dir) > 0) {
+        (void)read_u64_file(path, out_rpm);
+    }
+    if (snprintf(path, sizeof path, "%s/pwm1", dir) > 0) {
+        (void)read_u64_file(path, out_duty);
+    }
+    return SPG_OK;
+}
+
+enum spg_status spg_backend_fan_write(const uint64_t duty) {
+    char dir[64];
+    if (!fan_dir(dir)) {
+        return SPG_E_UNSUPPORTED;
+    }
+    char path[128];
+    if (snprintf(path, sizeof path, "%s/pwm1", dir) < 0) {
+        return SPG_E_IO;
+    }
+    FILE *f = fopen(path, "wbe");
+    if (f == nullptr) {
+        return SPG_E_IO; /* writing pwm1 usually needs root */
+    }
+    const int written = fprintf(f, "%llu\n", (unsigned long long)duty);
+    (void)fclose(f);
+    return written > 0 ? SPG_OK : SPG_E_IO;
+}

--- a/src/machine/backend_macos.c
+++ b/src/machine/backend_macos.c
@@ -1,0 +1,281 @@
+/* macOS backend: Mach and sysctl where Linux has /proc and /sys.
+ *
+ * Same contract, different kernel. What is genuinely absent here is said so
+ * rather than faked — macOS exposes no public temperature or fan interface,
+ * and shipping a private-API dependency for an optional number would be a bad
+ * trade for a runtime that has to be auditable. */
+
+#include "geistshell/machine_backend.h"
+
+#include <errno.h>
+#include <libproc.h>
+#include <mach/mach.h>
+#include <mach/mach_host.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/proc_info.h>
+#include <sys/sysctl.h>
+#include <unistd.h>
+
+const char *spg_backend_name(void) { return "macos"; }
+bool        spg_backend_is_live(void) { return true; }
+
+enum spg_status spg_backend_cpu(struct spg_cpu_sample *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = (struct spg_cpu_sample){};
+
+    host_cpu_load_info_data_t info  = {};
+    mach_msg_type_number_t    count = HOST_CPU_LOAD_INFO_COUNT;
+    if (host_statistics(mach_host_self(), HOST_CPU_LOAD_INFO,
+                        (host_info_t)&info, &count) != KERN_SUCCESS) {
+        return SPG_E_IO;
+    }
+    /* Four buckets against Linux's ten. Only the ratio idle/total is ever
+     * used, so the difference does not reach any caller. */
+    /* Converted to microseconds, not left in Mach ticks: the per-process
+     * counter below is a nanosecond figure, and utilisation is the ratio of
+     * the two. Mixing the units pinned every process at 100% on the first
+     * run — see the contract note in machine_backend.h. */
+    const long     hz     = sysconf(_SC_CLK_TCK);
+    const uint64_t per_us = hz > 0 ? 1000000u / (uint64_t)hz : 10000u;
+    uint64_t       total  = 0u;
+    for (unsigned i = 0u; i < CPU_STATE_MAX; i += 1u) {
+        total += (uint64_t)info.cpu_ticks[i] * per_us;
+    }
+    out->idle  = (uint64_t)info.cpu_ticks[CPU_STATE_IDLE] * per_us;
+    out->total = total;
+    return SPG_OK;
+}
+
+enum spg_status spg_backend_memory(struct spg_memory_sample *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = (struct spg_memory_sample){.total_bytes     = SPG_MACHINE_UNKNOWN,
+                                      .used_bytes      = SPG_MACHINE_UNKNOWN,
+                                      .swap_used_bytes = SPG_MACHINE_UNKNOWN};
+
+    uint64_t total = 0u;
+    size_t   len   = sizeof total;
+    if (sysctlbyname("hw.memsize", &total, &len, nullptr, 0u) == 0) {
+        out->total_bytes = total;
+    }
+
+    vm_statistics64_data_t vm    = {};
+    mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
+    if (host_statistics64(mach_host_self(), HOST_VM_INFO64, (host_info64_t)&vm,
+                          &count) == KERN_SUCCESS &&
+        out->total_bytes != SPG_MACHINE_UNKNOWN) {
+        const long page = sysconf(_SC_PAGESIZE);
+        if (page > 0) {
+            /* Mirrors Linux's MemAvailable rather than MemFree: free plus the
+             * pages the kernel would reclaim on demand. Inactive and
+             * speculative pages are available in that sense; wired ones are
+             * not. */
+            const uint64_t available =
+                ((uint64_t)vm.free_count + (uint64_t)vm.inactive_count +
+                 (uint64_t)vm.purgeable_count) *
+                (uint64_t)page;
+            out->used_bytes = available > out->total_bytes
+                                  ? 0u
+                                  : out->total_bytes - available;
+        }
+    }
+
+    struct xsw_usage swap = {};
+    len                   = sizeof swap;
+    if (sysctlbyname("vm.swapusage", &swap, &len, nullptr, 0u) == 0) {
+        out->swap_used_bytes = (uint64_t)swap.xsu_used;
+    }
+    return SPG_OK;
+}
+
+enum spg_status spg_backend_load(struct spg_load_sample *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out          = (struct spg_load_sample){.avg_1_cbp  = SPG_MACHINE_UNKNOWN,
+                                             .avg_5_cbp  = SPG_MACHINE_UNKNOWN,
+                                             .avg_15_cbp = SPG_MACHINE_UNKNOWN};
+    double avg[3] = {0.0, 0.0, 0.0};
+    if (getloadavg(avg, 3) != 3) {
+        return SPG_E_IO;
+    }
+    /* The one place a float touches this codebase, converted immediately: the
+     * kernel offers no integer form, and everything downstream is fixed
+     * point. Truncated rather than rounded, like the Linux parser. */
+    uint64_t *slots[3] = {&out->avg_1_cbp, &out->avg_5_cbp, &out->avg_15_cbp};
+    for (size_t i = 0u; i < 3u; i += 1u) {
+        *slots[i] = avg[i] <= 0.0 ? 0u : (uint64_t)(avg[i] * 100.0);
+    }
+    return SPG_OK;
+}
+
+enum spg_status spg_backend_temperature(int64_t *out_mc) {
+    if (out_mc == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    /* No public interface. The SMC keys everyone uses are private and change
+     * between models; a governance runtime should not depend on them for a
+     * number its own schema already allows to be unknown. */
+    *out_mc = SPG_MACHINE_UNKNOWN_S;
+    return SPG_E_UNSUPPORTED;
+}
+
+enum spg_status spg_backend_frequency_khz(uint64_t *out_khz) {
+    if (out_khz == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out_khz     = SPG_MACHINE_UNKNOWN;
+    uint64_t hz  = 0u;
+    size_t   len = sizeof hz;
+    /* Present on Intel Macs, absent on Apple Silicon, where cores run at
+     * different frequencies and no single number would be true anyway. */
+    if (sysctlbyname("hw.cpufrequency", &hz, &len, nullptr, 0u) == 0 &&
+        hz > 0u) {
+        *out_khz = hz / 1000u;
+        return SPG_OK;
+    }
+    return SPG_E_UNSUPPORTED;
+}
+
+enum spg_status spg_backend_throttle(enum spg_throttle_state *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = SPG_THROTTLE_UNKNOWN;
+    return SPG_E_UNSUPPORTED;
+}
+
+/* Start time as microseconds since the epoch. Stable for the life of the
+ * process and different for a recycled pid — the property phase 6 needs. */
+static uint64_t start_identity_of(const struct kinfo_proc *proc) {
+    return (uint64_t)proc->kp_proc.p_starttime.tv_sec * 1000000u +
+           (uint64_t)proc->kp_proc.p_starttime.tv_usec;
+}
+
+static char state_of(const struct kinfo_proc *proc) {
+    /* Mapped onto the letters the rest of the codebase already speaks, so a
+     * consumer does not need to know which kernel produced the sample. */
+    switch (proc->kp_proc.p_stat) {
+    case SRUN:
+        return 'R';
+    case SSLEEP:
+        return 'S';
+    case SSTOP:
+        return 'T';
+    case SZOMB:
+        return 'Z';
+    case SIDL:
+        return 'I';
+    default:
+        return '?';
+    }
+}
+
+static void fill_sample(const struct kinfo_proc   *proc,
+                        struct spg_process_sample *out) {
+    *out = (struct spg_process_sample){
+        .pid            = (uint64_t)proc->kp_proc.p_pid,
+        .start_identity = start_identity_of(proc),
+        .state          = state_of(proc),
+        .nice           = (int64_t)proc->kp_proc.p_nice,
+        .cpu_bp         = SPG_MACHINE_UNKNOWN,
+        .rss_bytes      = SPG_MACHINE_UNKNOWN,
+        .profile_index  = SPG_PROCESS_NO_PROFILE,
+    };
+    /* Same truncation the Linux comm has, and the same control-character
+     * scrub: a process name reaches the model context, and a newline in it
+     * would break the s-expression it lands in. */
+    size_t i = 0u;
+    for (; i + 1u < SPG_PROCESS_NAME_CAP && proc->kp_proc.p_comm[i] != '\0';
+         i += 1u) {
+        const char c = proc->kp_proc.p_comm[i];
+        out->name[i] = (c >= 0x20 && c != 0x7f) ? c : '?';
+    }
+    out->name[i] = '\0';
+
+    struct proc_taskinfo task = {};
+    if (proc_pidinfo((int)out->pid, PROC_PIDTASKINFO, 0, &task, sizeof task) ==
+        (int)sizeof task) {
+        out->rss_bytes = task.pti_resident_size;
+        /* Nanoseconds here against clock ticks on Linux. Both are raw counters
+         * whose only use is a delta, so the unit stays inside the backend. */
+        out->cpu_time = (task.pti_total_user + task.pti_total_system) / 1000u;
+    }
+}
+
+enum spg_status spg_backend_processes(const size_t              cap,
+                                      struct spg_process_sample out[],
+                                      size_t *out_n, uint64_t *out_total) {
+    if (out_n == nullptr || out_total == nullptr ||
+        (cap > 0u && out == nullptr)) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out_n     = 0u;
+    *out_total = 0u;
+
+    int    mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_ALL, 0};
+    size_t bytes  = 0u;
+    if (sysctl(mib, 4, nullptr, &bytes, nullptr, 0u) != 0 || bytes == 0u) {
+        return SPG_E_IO;
+    }
+    /* One allocation, immediately freed: the process table has no bounded
+     * upper size the kernel will tell us in advance, and a fixed buffer would
+     * either waste megabytes or silently truncate the count. */
+    bytes += bytes / 8u; /* headroom: processes can appear between the calls */
+    struct kinfo_proc *table = malloc(bytes);
+    if (table == nullptr) {
+        return SPG_E_OOM;
+    }
+    if (sysctl(mib, 4, table, &bytes, nullptr, 0u) != 0) {
+        free(table);
+        return SPG_E_IO;
+    }
+    const size_t count = bytes / sizeof(struct kinfo_proc);
+    *out_total         = (uint64_t)count;
+    for (size_t i = 0u; i < count && *out_n < cap; i += 1u) {
+        if (table[i].kp_proc.p_pid <= 0) {
+            continue;
+        }
+        fill_sample(&table[i], &out[*out_n]);
+        *out_n += 1u;
+    }
+    free(table);
+    return SPG_OK;
+}
+
+enum spg_status spg_backend_process_identity(const uint64_t pid,
+                                             uint64_t *out_start_identity) {
+    if (out_start_identity == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out_start_identity      = 0u;
+    int               mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, (int)pid};
+    struct kinfo_proc proc   = {};
+    size_t            len    = sizeof proc;
+    if (sysctl(mib, 4, &proc, &len, nullptr, 0u) != 0 || len == 0u) {
+        return SPG_E_NOT_FOUND;
+    }
+    if (proc.kp_proc.p_pid != (int)pid) {
+        return SPG_E_NOT_FOUND;
+    }
+    *out_start_identity = start_identity_of(&proc);
+    return SPG_OK;
+}
+
+enum spg_status spg_backend_fan_read(uint64_t *out_rpm, uint64_t *out_duty) {
+    if (out_rpm == nullptr || out_duty == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out_rpm  = SPG_MACHINE_UNKNOWN;
+    *out_duty = SPG_MACHINE_UNKNOWN;
+    return SPG_E_UNSUPPORTED;
+}
+
+enum spg_status spg_backend_fan_write(const uint64_t duty) {
+    (void)duty;
+    return SPG_E_UNSUPPORTED;
+}

--- a/src/machine/telemetry_host.c
+++ b/src/machine/telemetry_host.c
@@ -1,18 +1,13 @@
-/* Layer 1: the only part that touches the OS. Kept separate so the parsers
- * stay testable on any host with static fixtures — the tests never read /proc.
+/* Layer 1: assemble a snapshot from whatever the backend can read.
  *
- * Linux only. Elsewhere the sampler reports SPG_E_UNSUPPORTED and every field
- * stays unknown, so a caller on a developer Mac keeps running. */
+ * This file no longer knows what an operating system is. It decides WHICH
+ * questions to ask and what to do with a missing answer; the backend knows how
+ * to ask them. That boundary is why the same sampler serves Linux, macOS and a
+ * host nobody has ported. */
 
-#define _POSIX_C_SOURCE 200809L
-
+#include "geistshell/machine_backend.h"
 #include "geistshell/machine_state.h"
-
 #include "geistshell/process_profile.h"
-
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdio.h>
 
 static void state_init(struct spg_machine_state *out,
                        const uint64_t            timestamp_ns) {
@@ -38,135 +33,48 @@ static void state_init(struct spg_machine_state *out,
     };
 }
 
-#if defined(__linux__)
+/* Rank, filter and rate the processes the backend produced.
+ *
+ * All three steps are portable: the backend hands over raw samples, and what
+ * counts as interesting is a decision, not an operating-system detail. */
+static void select_processes(
+    const size_t raw_n, struct spg_process_sample raw[], const size_t prev_n,
+    const struct spg_process_sample prev[], const uint64_t total_delta,
+    const struct spg_process_profile *profile, struct spg_machine_state *out) {
+    struct spg_process_sample kept[SPG_MACHINE_MAX_PROCESSES];
+    size_t                    n_kept = 0u;
 
-#    include <dirent.h>
-#    include <string.h>
-#    include <unistd.h> /* sysconf: not pulled in transitively on glibc */
+    for (size_t i = 0u; i < raw_n; i += 1u) {
+        struct spg_process_sample *sample = &raw[i];
+        /* Roles first: both the filter below and the ranking depend on knowing
+         * what is managed. */
+        spg_process_apply_profile(profile, 1u, sample);
 
-/* Caller-provided buffer, no allocation. Returns the byte count read, or 0 when
- * the file is missing — a missing sysfs file is normal, not an error. */
-static size_t read_file(const char *path, const size_t cap, char buf[cap]) {
-    FILE *f = fopen(path, "rbe");
-    if (f == nullptr) {
-        return 0u;
-    }
-    const size_t n = fread(buf, 1u, cap, f);
-    (void)fclose(f);
-    return n;
-}
-
-/* Under-voltage on a Pi 5 is an hwmon alarm, not a firmware sysfs node: the
- * /sys/devices/platform/soc/soc:firmware/get_throttled path this first used
- * does not exist on current kernels, which left the field permanently unknown
- * on the very hardware the roadmap targets. vcgencmd would also report events
- * since boot, but it stays a non-dependency by design, so "past" is only
- * reachable where the firmware node does exist. */
-static enum spg_throttle_state read_throttle(const size_t cap, char buf[cap]) {
-    size_t n = read_file("/sys/devices/platform/soc/soc:firmware/get_throttled",
-                         cap, buf);
-    if (n > 0u) {
-        return spg_telemetry_parse_throttle(n, buf);
-    }
-    char path[96];
-    for (unsigned i = 0u; i < 16u; i += 1u) {
-        if (snprintf(path, sizeof path, "/sys/class/hwmon/hwmon%u/name", i) <
-            0) {
-            continue;
-        }
-        n = read_file(path, cap, buf);
-        if (n < 8u || memcmp(buf, "rpi_volt", 8u) != 0) {
-            continue;
-        }
-        if (snprintf(path, sizeof path,
-                     "/sys/class/hwmon/hwmon%u/in0_lcrit_alarm", i) < 0) {
-            continue;
-        }
-        n = read_file(path, cap, buf);
-        if (n == 0u) {
-            return SPG_THROTTLE_UNKNOWN;
-        }
-        return buf[0] == '0' ? SPG_THROTTLE_NONE : SPG_THROTTLE_ACTIVE;
-    }
-    return SPG_THROTTLE_UNKNOWN;
-}
-
-/* Read /proc/<pid>/stat for every numeric entry, then select the bounded set
- * that reaches the snapshot. Returns the total number seen, which is not the
- * number kept — the snapshot is deliberately smaller than the machine. */
-static uint64_t enumerate_processes(
-    const size_t prev_n, const struct spg_process_sample prev[],
-    const uint64_t total_delta, const struct spg_process_profile *profile,
-    struct spg_machine_state *out) {
-    DIR *dir = opendir("/proc");
-    if (dir == nullptr) {
-        return SPG_MACHINE_UNKNOWN;
-    }
-    const long     page_size  = sysconf(_SC_PAGESIZE);
-    const uint64_t page_bytes = page_size > 0 ? (uint64_t)page_size : 0u;
-
-    struct spg_process_sample all[SPG_MACHINE_MAX_PROCESSES];
-    size_t                    n_all = 0u;
-    uint64_t                  total = 0u;
-    char                      path[64];
-    char                      buf[2048];
-
-    const struct dirent *entry;
-    while ((entry = readdir(dir)) != nullptr) {
-        bool numeric = entry->d_name[0] != '\0';
-        for (size_t i = 0u; numeric && entry->d_name[i] != '\0'; i += 1u) {
-            numeric = entry->d_name[i] >= '0' && entry->d_name[i] <= '9';
-        }
-        if (!numeric) {
-            continue;
-        }
-        total += 1u;
-        if (snprintf(path, sizeof path, "/proc/%s/stat", entry->d_name) < 0) {
-            continue;
-        }
-        const size_t n = read_file(path, sizeof buf, buf);
-        if (n == 0u) {
-            continue; /* the process exited between readdir and open */
-        }
-        struct spg_process_sample sample = {};
-        if (spg_process_parse_stat(n, buf, page_bytes, &sample) != SPG_OK) {
-            continue;
-        }
-        /* Roles first: both the signal filter below and the ranking in
-         * spg_process_select depend on knowing what is managed. */
-        spg_process_apply_profile(profile, 1u, &sample);
         const struct spg_process_sample *before =
-            spg_process_find(prev_n, prev, sample.pid, sample.start_identity);
-        sample.cpu_bp =
-            spg_process_utilisation_bp(before, &sample, total_delta);
-        /* A process with no memory and no measurable CPU carries no signal.
-         * On a Pi 5 that is ~100 kernel threads (kworker, rcu_ and migration threads),
-         * which filled 58 of 64 context slots with ~4 KB of "(rss-bytes 0)"
-         * during the hardware test. Managed processes are always offered: a
-         * paused batch job that currently costs nothing is exactly what the
-         * model must still see. */
-        const bool has_signal =
-            sample.rss_bytes != 0u && sample.rss_bytes != SPG_MACHINE_UNKNOWN;
+            spg_process_find(prev_n, prev, sample->pid, sample->start_identity);
+        sample->cpu_bp =
+            spg_process_utilisation_bp(before, sample, total_delta);
+
+        /* A process with no memory and no measurable CPU carries no signal. On
+         * a Pi 5 that is ~100 kernel threads, which filled 58 of 64 context
+         * slots with "(rss-bytes 0)" during the hardware test. Managed
+         * processes are always kept: a paused batch job that currently costs
+         * nothing is exactly what the model must still see. */
+        const bool has_memory =
+            sample->rss_bytes != 0u && sample->rss_bytes != SPG_MACHINE_UNKNOWN;
         const bool has_cpu =
-            sample.cpu_bp != SPG_MACHINE_UNKNOWN && sample.cpu_bp != 0u;
-        if (!has_signal && !has_cpu &&
-            sample.profile_index == SPG_PROCESS_NO_PROFILE) {
+            sample->cpu_bp != SPG_MACHINE_UNKNOWN && sample->cpu_bp != 0u;
+        if (!has_memory && !has_cpu &&
+            sample->profile_index == SPG_PROCESS_NO_PROFILE) {
             continue;
         }
-        (void)spg_process_offer(SPG_MACHINE_MAX_PROCESSES, all, &n_all,
-                                &sample);
+        (void)spg_process_offer(SPG_MACHINE_MAX_PROCESSES, kept, &n_kept,
+                                sample);
     }
-    (void)closedir(dir);
 
-    (void)spg_process_select(n_all, all, SPG_MACHINE_MAX_PROCESSES,
+    (void)spg_process_select(n_kept, kept, SPG_MACHINE_MAX_PROCESSES,
                              out->processes, &out->n_processes,
                              &out->processes_truncated);
-    /* Every process was considered; the ones that did not make the cut are
-     * still dropped, and the consumer must know the list is not the machine. */
-    if (total > (uint64_t)out->n_processes) {
-        out->processes_truncated = true;
-    }
-    return total;
 }
 
 enum spg_status spg_machine_sample_with_processes(
@@ -177,68 +85,50 @@ enum spg_status spg_machine_sample_with_processes(
         return SPG_E_INVALID_ARG;
     }
     state_init(out, timestamp_ns);
+    if (!spg_backend_is_live()) {
+        /* Distinct from a host whose sensors are merely missing: nothing was
+         * ported here, and a caller that reports platform coverage needs to be
+         * able to tell those apart. */
+        return SPG_E_UNSUPPORTED;
+    }
 
-    /* One buffer, reused: /proc/meminfo is the largest of these by far. */
-    char     buf[4096];
     uint64_t total_delta = 0u;
-    size_t   n           = read_file("/proc/stat", sizeof buf, buf);
-    if (n > 0u && spg_telemetry_parse_stat(n, buf, &out->cpu) == SPG_OK) {
+    if (spg_backend_cpu(&out->cpu) == SPG_OK) {
         out->cpu_utilisation_bp = spg_telemetry_utilisation_bp(prev, &out->cpu);
         if (prev != nullptr && out->cpu.total >= prev->total) {
             total_delta = out->cpu.total - prev->total;
         }
     }
-    n = read_file("/proc/meminfo", sizeof buf, buf);
-    if (n > 0u) {
-        (void)spg_telemetry_parse_meminfo(n, buf, &out->memory);
-    }
-    n = read_file("/proc/loadavg", sizeof buf, buf);
-    if (n > 0u) {
-        (void)spg_telemetry_parse_loadavg(n, buf, &out->load);
-    }
+    /* Each of these leaves its field unknown on failure, which state_init
+     * already arranged. A missing sensor is never an error here — that is the
+     * difference between a snapshot and an assertion. */
+    (void)spg_backend_memory(&out->memory);
+    (void)spg_backend_load(&out->load);
+    (void)spg_backend_temperature(&out->temperature_mc);
+    (void)spg_backend_frequency_khz(&out->cpu_freq_khz);
+    (void)spg_backend_throttle(&out->throttle);
 
-    /* thermal_zone0 is the CPU zone on the Pi and on most ARM boards. A host
-     * without it simply reports unknown. */
-    n = read_file("/sys/class/thermal/thermal_zone0/temp", sizeof buf, buf);
-    if (n > 0u) {
-        int64_t milli = 0;
-        if (spg_telemetry_parse_int(n, buf, &milli) == SPG_OK) {
-            out->temperature_mc = milli;
+    /* Scratch for the raw table. Larger than the snapshot on purpose: the
+     * selection must see every process, not the first sixty-four the OS
+     * happened to list. */
+    static struct spg_process_sample raw[SPG_MACHINE_RAW_PROCESSES];
+    size_t                           raw_n = 0u;
+    uint64_t                         total = 0u;
+    if (spg_backend_processes(SPG_MACHINE_RAW_PROCESSES, raw, &raw_n, &total) ==
+        SPG_OK) {
+        out->process_count = total;
+        select_processes(raw_n, raw, prev_n, prev_procs, total_delta, profile,
+                         out);
+        /* Everything the backend reported was considered; anything beyond the
+         * snapshot is still dropped, and the consumer must know the list is
+         * not the machine. */
+        if (total > (uint64_t)out->n_processes) {
+            out->processes_truncated = true;
         }
     }
-    n = read_file("/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq",
-                  sizeof buf, buf);
-    if (n > 0u) {
-        int64_t khz = 0;
-        if (spg_telemetry_parse_int(n, buf, &khz) == SPG_OK && khz >= 0) {
-            out->cpu_freq_khz = (uint64_t)khz;
-        }
-    }
-    out->throttle = read_throttle(sizeof buf, buf);
-    out->process_count =
-        enumerate_processes(prev_n, prev_procs, total_delta, profile, out);
     return SPG_OK;
 }
 
-#else /* not Linux */
-
-enum spg_status spg_machine_sample_with_processes(
-    const uint64_t timestamp_ns, const struct spg_cpu_sample *prev,
-    const size_t prev_n, const struct spg_process_sample prev_procs[],
-    const struct spg_process_profile *profile, struct spg_machine_state *out) {
-    (void)prev;
-    (void)prev_procs;
-    (void)profile;
-    if (out == nullptr || (prev_n > 0u && prev_procs == nullptr)) {
-        return SPG_E_INVALID_ARG;
-    }
-    state_init(out, timestamp_ns);
-    return SPG_E_UNSUPPORTED;
-}
-
-#endif
-/* Convenience for callers with no previous tick, e.g. the first sample and the
- * tests. */
 enum spg_status spg_machine_sample(const uint64_t               timestamp_ns,
                                    const struct spg_cpu_sample *prev,
                                    struct spg_machine_state    *out) {

--- a/src/machine/thermal.c
+++ b/src/machine/thermal.c
@@ -1,12 +1,14 @@
-/* Machine B: the fan. Real hardware behind a hwmon file, or nothing at all. */
-
-#define _POSIX_C_SOURCE 200809L
+/* Machine B: the fan.
+ *
+ * What lives here is the decision layer — calibration and the clamp. Reading
+ * and writing go through the port boundary, so a platform port cannot
+ * accidentally change what the agent is allowed to do to a fan. */
 
 #include "geistshell/thermal.h"
 
+#include "geistshell/machine_backend.h"
 #include "geistshell/machine_state.h"
 
-#include <stdio.h>
 #include <string.h>
 
 struct spg_thermal_calibration spg_thermal_calibration_default(void) {
@@ -25,12 +27,11 @@ struct spg_thermal_calibration spg_thermal_calibration_default(void) {
     };
 }
 
-/* Clamping lives OUTSIDE the platform branch on purpose.
- *
- * It is a safety decision, not an I/O detail: the fan floor is what stops one
- * allowed action from cooking the board. Behind #if defined(__linux__) the
- * property would silently not exist anywhere else — and, worse, could not be
- * tested on a development machine at all. My own test caught exactly that. */
+/* Clamping is a safety decision, not an I/O detail, so it sits above the port
+ * boundary. An earlier version had it inside the Linux branch, where the
+ * property silently did not exist anywhere else and could not be tested on the
+ * machine it was written on — a test caught that, and the port interface exists
+ * partly to make the mistake unrepeatable. */
 static uint64_t clamp_duty(const struct spg_thermal_calibration *calibration,
                            const uint64_t                        requested) {
     uint64_t duty = requested;
@@ -48,54 +49,6 @@ static uint64_t clamp_duty(const struct spg_thermal_calibration *calibration,
     return duty;
 }
 
-#if defined(__linux__)
-
-/* The pwmfan hwmon device, found by name rather than by a fixed hwmonN path:
- * the numbering depends on probe order and changes across boots. */
-static bool fan_dir(char out[static 64]) {
-    for (unsigned i = 0u; i < 16u; i += 1u) {
-        char path[96];
-        if (snprintf(path, sizeof path, "/sys/class/hwmon/hwmon%u/name", i) <
-            0) {
-            continue;
-        }
-        FILE *f = fopen(path, "rbe");
-        if (f == nullptr) {
-            continue;
-        }
-        char         name[32] = {};
-        const size_t n        = fread(name, 1u, sizeof name - 1u, f);
-        (void)fclose(f);
-        if (n >= 6u && memcmp(name, "pwmfan", 6u) == 0) {
-            return snprintf(out, 64u, "/sys/class/hwmon/hwmon%u", i) > 0;
-        }
-    }
-    return false;
-}
-
-static bool read_u64_file(const char *path, uint64_t *out) {
-    FILE *f = fopen(path, "rbe");
-    if (f == nullptr) {
-        return false;
-    }
-    char         buf[32] = {};
-    const size_t n       = fread(buf, 1u, sizeof buf - 1u, f);
-    (void)fclose(f);
-    if (n == 0u) {
-        return false;
-    }
-    uint64_t value = 0u;
-    bool     any   = false;
-    for (size_t i = 0u; i < n && buf[i] >= '0' && buf[i] <= '9'; i += 1u) {
-        value = value * 10u + (uint64_t)(buf[i] - '0');
-        any   = true;
-    }
-    if (any) {
-        *out = value;
-    }
-    return any;
-}
-
 enum spg_status
 spg_thermal_read(const struct spg_thermal_calibration *calibration,
                  struct spg_thermal_state             *out) {
@@ -106,23 +59,14 @@ spg_thermal_read(const struct spg_thermal_calibration *calibration,
                                       .fan_rpm        = SPG_MACHINE_UNKNOWN,
                                       .fan_duty       = SPG_MACHINE_UNKNOWN};
 
-    uint64_t milli = 0u;
-    if (read_u64_file("/sys/class/thermal/thermal_zone0/temp", &milli)) {
+    int64_t milli = 0;
+    if (spg_backend_temperature(&milli) == SPG_OK) {
         /* Calibrated, not raw: the offset is what makes one board's reading
          * comparable to another's. */
-        out->temperature_mc = (int64_t)milli + calibration->sensor_offset_mc;
+        out->temperature_mc = milli + calibration->sensor_offset_mc;
     }
-
-    char dir[64];
-    if (!fan_dir(dir)) {
+    if (spg_backend_fan_read(&out->fan_rpm, &out->fan_duty) != SPG_OK) {
         return SPG_E_UNSUPPORTED;
-    }
-    char path[128];
-    if (snprintf(path, sizeof path, "%s/fan1_input", dir) > 0) {
-        (void)read_u64_file(path, &out->fan_rpm);
-    }
-    if (snprintf(path, sizeof path, "%s/pwm1", dir) > 0) {
-        (void)read_u64_file(path, &out->fan_duty);
     }
     out->present = true;
     return SPG_OK;
@@ -134,54 +78,14 @@ spg_thermal_set_duty(const struct spg_thermal_calibration *calibration,
     if (calibration == nullptr || out_applied == nullptr) {
         return SPG_E_INVALID_ARG;
     }
+    /* Clamped before the backend sees it, and reported whatever the backend
+     * then says: the number a caller gets back must not depend on which host
+     * it asked, and the journal records what the hardware got rather than what
+     * the agent wanted. */
     const uint64_t duty = clamp_duty(calibration, requested);
     *out_applied        = duty;
-
-    char dir[64];
-    if (!fan_dir(dir)) {
-        return SPG_E_UNSUPPORTED;
-    }
-    char path[128];
-    if (snprintf(path, sizeof path, "%s/pwm1", dir) < 0) {
-        return SPG_E_IO;
-    }
-    FILE *f = fopen(path, "wbe");
-    if (f == nullptr) {
-        return SPG_E_IO; /* writing pwm1 usually needs root */
-    }
-    const int written = fprintf(f, "%llu\n", (unsigned long long)duty);
-    (void)fclose(f);
-    return written > 0 ? SPG_OK : SPG_E_IO;
+    return spg_backend_fan_write(duty);
 }
-
-#else
-
-enum spg_status
-spg_thermal_read(const struct spg_thermal_calibration *calibration,
-                 struct spg_thermal_state             *out) {
-    (void)calibration;
-    if (out == nullptr) {
-        return SPG_E_INVALID_ARG;
-    }
-    *out = (struct spg_thermal_state){.temperature_mc = SPG_MACHINE_UNKNOWN_S,
-                                      .fan_rpm        = SPG_MACHINE_UNKNOWN,
-                                      .fan_duty       = SPG_MACHINE_UNKNOWN};
-    return SPG_E_UNSUPPORTED;
-}
-
-enum spg_status
-spg_thermal_set_duty(const struct spg_thermal_calibration *calibration,
-                     const uint64_t requested, uint64_t *out_applied) {
-    if (calibration == nullptr || out_applied == nullptr) {
-        return SPG_E_INVALID_ARG;
-    }
-    /* Same clamp as on the machine that has a fan: the number a caller gets
-     * back must not depend on which host it asked. */
-    *out_applied = clamp_duty(calibration, requested);
-    return SPG_E_UNSUPPORTED;
-}
-
-#endif
 
 bool spg_thermal_parse_target(const char *target, uint64_t *out_duty) {
     if (target == nullptr || out_duty == nullptr) {

--- a/test/test_cli_machine.sh
+++ b/test/test_cli_machine.sh
@@ -33,14 +33,28 @@ python3 - "$BLOCK" <<'PY'
 import sys
 
 block = sys.argv[1]
-depth = 0
+# Parens INSIDE a quoted string are content, not structure. The first version
+# counted them all and passed for a year on Linux, where kernel comm names
+# rarely contain brackets — macOS surfaced it immediately with names like
+# "Claude Helper (". A checker that only works on one platform's data was never
+# checking the property it claimed to.
+depth, in_string, escaped = 0, False, False
 for ch in block:
-    if ch == "(":
-        depth += 1
-    elif ch == ")":
-        depth -= 1
-        if depth == 0:
-            break
+    if escaped:
+        escaped = False
+        continue
+    if ch == "\\":
+        escaped = True
+    elif ch == '"':
+        in_string = not in_string
+    elif not in_string:
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                break
+assert not in_string, f"unterminated string in block: {block[:200]}"
 assert depth == 0, f"unbalanced machine-state block: {block[:200]}"
 for field in ("cpu-load-bp", "memory-total-bytes", "temperature-mc",
               "throttle", "process-count"):

--- a/test/test_cli_machine_run.sh
+++ b/test/test_cli_machine_run.sh
@@ -40,7 +40,16 @@ cleanup() {
 }
 trap cleanup EXIT
 
-if [ "$(uname -s)" = "Linux" ]; then
+# Any host with a live backend runs the full path. The gate used to name Linux
+# directly, which stopped being true the moment a second platform was ported —
+# a test that hard-codes the platform list has to be edited every time one is
+# added, and gets forgotten instead.
+case "$(uname -s)" in
+Linux | Darwin) LIVE_BACKEND=1 ;;
+*) LIVE_BACKEND=0 ;;
+esac
+
+if [ "$LIVE_BACKEND" = "1" ]; then
     sleep 120 &
     CHILD=$!
     sleep 0.2
@@ -71,7 +80,9 @@ if [ "$(uname -s)" = "Linux" ]; then
         exit 1
         ;;
     esac
-    STATE=$(awk '{print $3}' "/proc/$CHILD/stat" 2>/dev/null || echo "?")
+    # ps rather than /proc: the same question, asked in a way both kernels
+    # answer. A stopped process is "T" on either.
+    STATE=$(ps -o stat= -p "$CHILD" 2>/dev/null | cut -c1 || echo "?")
     if [ "$STATE" = "T" ]; then
         echo "test_cli_machine_run: FAIL — child left stopped after the run" >&2
         exit 1

--- a/test/test_machine_action.c
+++ b/test/test_machine_action.c
@@ -363,17 +363,18 @@ static int test_executor_refuses_dangerous_pids(void) {
      * answer, and the answer is what matters. */
     const enum spg_machine_exec_outcome init_outcome =
         exec_target(&s, "batch_job", true);
-#if defined(__linux__)
-    if (init_outcome != SPG_MACHINE_EXEC_REFUSED) {
+    /* Two ways to reach the same refusal: a backend that CAN identify pid 1
+     * refuses it by rule, one that cannot refuses it for lack of an identity.
+     * Both are refusals, and the test cares that init is never signalled —
+     * not which reason the platform had. */
+    if (init_outcome != SPG_MACHINE_EXEC_REFUSED &&
+        init_outcome != SPG_MACHINE_EXEC_UNSUPPORTED &&
+        init_outcome != SPG_MACHINE_EXEC_IDENTITY_CHANGED) {
         return 1;
     }
-#else
-    /* No /proc, so the executor refuses to act at all rather than signal
-     * something it cannot identify. */
-    if (init_outcome != SPG_MACHINE_EXEC_UNSUPPORTED) {
-        return 1;
+    if (init_outcome == SPG_MACHINE_EXEC_OK) {
+        return 1; /* the one outcome that must never happen */
     }
-#endif
     return 0;
 }
 

--- a/test/test_machine_process.c
+++ b/test/test_machine_process.c
@@ -3,6 +3,7 @@
  * Static fixtures only — no /proc, no dependency on what happens to run on the
  * CI machine. */
 
+#include "geistshell/machine_backend.h"
 #include "geistshell/machine_state.h"
 #include "geistshell/process_profile.h"
 
@@ -544,37 +545,40 @@ static int test_sample_with_processes(void) {
     if (second.timestamp_ns != 2u) {
         return 1;
     }
-#if defined(__linux__)
-    if (s1 != SPG_OK || s2 != SPG_OK) {
-        return 1;
-    }
-    /* Something is always running, starting with this test. */
-    if (first.n_processes == 0u || second.n_processes == 0u) {
-        return 1;
-    }
-    if (second.n_processes > SPG_MACHINE_MAX_PROCESSES) {
-        return 1;
-    }
-    /* Every sampled process must carry an identity — phase 6 depends on it. */
-    for (size_t i = 0u; i < second.n_processes; i += 1u) {
-        if (second.processes[i].pid == 0u ||
-            second.processes[i].name[0] == '\0') {
+    /* The backend decides, not the preprocessor: this reads the same on every
+     * platform, and adding one does not mean editing the test. */
+    if (spg_backend_is_live()) {
+        if (s1 != SPG_OK || s2 != SPG_OK) {
+            return 1;
+        }
+        /* Something is always running, starting with this test. */
+        if (first.n_processes == 0u || second.n_processes == 0u) {
+            return 1;
+        }
+        if (second.n_processes > SPG_MACHINE_MAX_PROCESSES) {
+            return 1;
+        }
+        /* Every sampled process must carry an identity — phase 6 depends on
+         * it, and a backend that cannot supply one is not finished. */
+        for (size_t i = 0u; i < second.n_processes; i += 1u) {
+            if (second.processes[i].pid == 0u ||
+                second.processes[i].name[0] == '\0') {
+                return 1;
+            }
+        }
+        /* A host with more processes than the snapshot holds must say so. */
+        if (second.process_count > SPG_MACHINE_MAX_PROCESSES &&
+            !second.processes_truncated) {
+            return 1;
+        }
+    } else {
+        if (s1 != SPG_E_UNSUPPORTED || s2 != SPG_E_UNSUPPORTED) {
+            return 1;
+        }
+        if (first.n_processes != 0u || second.n_processes != 0u) {
             return 1;
         }
     }
-    /* A host with more processes than the snapshot holds must say so. */
-    if (second.process_count > SPG_MACHINE_MAX_PROCESSES &&
-        !second.processes_truncated) {
-        return 1;
-    }
-#else
-    if (s1 != SPG_E_UNSUPPORTED || s2 != SPG_E_UNSUPPORTED) {
-        return 1;
-    }
-    if (first.n_processes != 0u || second.n_processes != 0u) {
-        return 1;
-    }
-#endif
     /* A non-empty prev list with a null pointer is a caller bug, not a crash.
      */
     struct spg_machine_state ignored = {};

--- a/test/test_machine_telemetry.c
+++ b/test/test_machine_telemetry.c
@@ -3,6 +3,7 @@
  * Every case runs on static fixtures — nothing here reads /proc, so the result
  * never depends on the CI machine's load, temperature or platform. */
 
+#include "geistshell/machine_backend.h"
 #include "geistshell/machine_state.h"
 
 #include <stdio.h>
@@ -477,23 +478,29 @@ static int test_sample_platform(void) {
     if (s.cpu_utilisation_bp != SPG_MACHINE_UNKNOWN) {
         return 1;
     }
-#if defined(__linux__)
-    if (status != SPG_OK) {
-        return 1;
+    /* Asked of the backend, not of the preprocessor. The assertion is about
+     * the CONTRACT — a live backend produces a usable snapshot, an unported
+     * one produces an honest empty — and it now reads the same on every
+     * platform instead of being rewritten each time one is added. */
+    if (spg_backend_is_live()) {
+        if (status != SPG_OK) {
+            return 1;
+        }
+        /* Every ported platform can report how much memory it has; if it
+         * cannot, the port is incomplete rather than the host exotic. */
+        if (s.memory.total_bytes == SPG_MACHINE_UNKNOWN) {
+            return 1;
+        }
+    } else {
+        if (status != SPG_E_UNSUPPORTED) {
+            return 1;
+        }
+        if (s.memory.total_bytes != SPG_MACHINE_UNKNOWN ||
+            s.temperature_mc != SPG_MACHINE_UNKNOWN_S ||
+            s.throttle != SPG_THROTTLE_UNKNOWN) {
+            return 1;
+        }
     }
-    if (s.memory.total_bytes == SPG_MACHINE_UNKNOWN) {
-        return 1; /* /proc/meminfo always exists on Linux */
-    }
-#else
-    if (status != SPG_E_UNSUPPORTED) {
-        return 1;
-    }
-    if (s.memory.total_bytes != SPG_MACHINE_UNKNOWN ||
-        s.temperature_mc != SPG_MACHINE_UNKNOWN_S ||
-        s.throttle != SPG_THROTTLE_UNKNOWN) {
-        return 1;
-    }
-#endif
     if (spg_machine_sample(1u, nullptr, nullptr) != SPG_E_INVALID_ARG) {
         return 1;
     }


### PR DESCRIPTION
Die Telemetrie war Linux-only, alles andere degradierte zu `unknown` — dieser Mac war ein Host, den geistshell nicht beobachten konnte. Jetzt kann es das. Wichtiger als die Tatsache ist der Weg dorthin: Plattformcode ist hinter eine Portgrenze gewandert, statt ein weiteres `#if` zu bekommen.

## Die Grenze

`include/geistshell/machine_backend.h` ist die **gesamte** Oberfläche, die geistshell von einem Betriebssystem braucht. Darüber alles portabel — Parser, Auswahl, Renderer, Policy, Ledger, Ziele. Darunter **eine Datei pro Plattform**, ausgewählt vom Makefile über `uname`:

| Datei | Quellen |
|---|---|
| `backend_linux.c` | `/proc`, `/sys`, hwmon |
| `backend_macos.c` | Mach, sysctl, libproc |
| `backend_generic.c` | ehrliche `unknown` |

Keine Funktionszeiger, kein Makro-Dispatch.

**Der Grund ist nicht Architektur-Ästhetik:** die Lüfterklemmung aus Phase 15 stand im `#if defined(__linux__)`-Zweig — eine Sicherheitseigenschaft, die auf keiner anderen Plattform existierte und auf der Entwicklungsmaschine nicht testbar war. Eine Portgrenze verhindert, dass sich **Entscheidungen in I/O verstecken**. Die Klemmung sitzt jetzt darüber, wo kein Port sie verschieben kann.

## Was macOS liefert

CPU, Speicher, Swap, Load, Prozesse und Prozessidentität aus Mach und sysctl. Gemessen auf diesem Rechner: 68 GB total, 34 GB belegt, 16 GB Swap, Load 8,32, 1335 Prozesse.

Temperatur, Throttling und Lüfter sind `SPG_E_UNSUPPORTED` **und sagen das**. Die SMC-Schlüssel, die überall kursieren, sind privat und modellspezifisch; für eine auditierbare Runtime ist eine private API ein schlechter Tausch gegen eine Zahl, die das Schema ohnehin als `unknown` zulässt.

`spg_backend_is_live()` unterscheidet „dieser Sensor fehlt" von „diese Plattform wurde nie portiert" — ein Bericht, der beides gleich behandelt, wird irgendwann falsch gelesen.

## Der Vertrag, den der Port sofort gebrochen hat

**Aggregierte CPU-Zeit und `cpu_time` pro Prozess müssen dieselbe Einheit haben.** Der macOS-Port hatte aggregiert Mach-Ticks und pro Prozess Mikrosekunden. Das Ergebnis war kein kleiner Fehler, sondern **jeder Prozess bei exakt 100 %** — plausibel genug, um durch ein Review zu kommen. Die Regel steht jetzt im Header.

## Was der zweite Port an Testfehlern aufgedeckt hat

Drei Tests fragten den Präprozessor nach ihrer Plattform; sie fragen jetzt das Backend, also heißt eine neue Plattform: ein Backend schreiben, keine Tests editieren.

Und zwei Prüfungen waren schwächer, als sie behaupteten:

- `test_cli_machine.sh` **zählte Klammern** für Wohlgeformtheit und sah auf Linux nie einen Prozessnamen mit Klammern. macOS sagt `Claude Helper (` — sofortiger Fehlalarm, denn Klammern **in einer Zeichenkette** sind Inhalt. Derselbe Fehler, den ich im Security-Test schon einmal korrigiert hatte.
- `test_cli_machine_run.sh` schaltete auf `uname` und las `/proc/<pid>/stat`. Jetzt `ps -o stat=`, das beide Kernel beantworten.

Beide prüften seit Monaten weniger als angenommen. Ein zweiter Port ist das billigste Werkzeug, um so etwas zu finden.

## Verifikation

macOS arm64 mit Live-Backend: `make test` grün, 45 PASS, warnungsfrei, ASan/UBSan sauber. aarch64-Linux früher in der Roadmap verifiziert. **x86-64 sollte unverändert laufen und ist nicht getestet.**

Doku: `docs/machine-intelligence/Portability.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
