### PR TITLE
fix: der grüne Build war grün auf einer Datei, die keine Regel versprochen hat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,23 @@ $(OBJ_DIR)/%.o: %.c
 $(WORKLOAD_BIN): examples/machine/workloads/workload.c | $(BIN_DIR)
 	$(CC) $(CFLAGS) -o $@ $<
 
-test: $(TEST_BINS) $(PROBE_BINS) $(SPG_BIN) $(WORKLOAD_BIN)
+# Link-time backend selection means a build compiles exactly ONE of the three
+# backends — the other two rot unseen. A deletion orphaned a helper in
+# backend_linux.c and macOS could not notice, because macOS never compiles that
+# file. Both of these are pure POSIX, so any host can syntax-check them;
+# backend_macos.c needs Darwin headers and is covered where it actually builds.
+PORTABLE_BACKENDS := src/machine/backend_linux.c src/machine/backend_generic.c
+
+check-backends:
+	@for f in $(PORTABLE_BACKENDS); do \
+		$(CC) $(CFLAGS) -Werror -fsyntax-only $$f || exit 1; \
+	done
+
+# CHAT_BIN belongs here because test_cli_chat.sh runs it. It was missing, and
+# the failure only showed after `make clean`: an incremental tree still had the
+# binary from an earlier `make all`, so the suite was green on a file no rule
+# had promised. A test target must build everything its tests execute.
+test: $(TEST_BINS) $(PROBE_BINS) $(SPG_BIN) $(CHAT_BIN) $(WORKLOAD_BIN) check-backends
 	@status=0; \
 	for t in $(TEST_BINS); do \
 		echo "$$t"; \

--- a/src/machine/backend_linux.c
+++ b/src/machine/backend_linux.c
@@ -216,20 +216,3 @@ enum spg_status spg_backend_process_identity(const uint64_t pid,
     return SPG_OK;
 }
 
-static bool read_u64_file(const char *path, uint64_t *out) {
-    char         buf[32] = {};
-    const size_t n       = read_file(path, sizeof buf - 1u, buf);
-    if (n == 0u) {
-        return false;
-    }
-    uint64_t value = 0u;
-    bool     any   = false;
-    for (size_t i = 0u; i < n && buf[i] >= '0' && buf[i] <= '9'; i += 1u) {
-        value = value * 10u + (uint64_t)(buf[i] - '0');
-        any   = true;
-    }
-    if (any) {
-        *out = value;
-    }
-    return any;
-}


### PR DESCRIPTION
Drei Befunde aus einem OS- und architekturunabhängigen Testlauf auf macOS. Alle drei haben dieselbe Form: **eine Prüfung, die weniger geprüft hat, als sie behauptet.**

### 1. `make test` baut `geistshell-chat` nicht

`test_cli_chat.sh` führt die Binary aus, aber sie stand nicht in den Prerequisites. Inkrementell lag sie von einem früheren `make all` herum — die Suite war grün auf einer Datei, die keine Regel versprochen hatte. Nach `make clean`: 43 statt 44, exit 2.

Das galt auch für den „44 PASS"-Nachweis, mit dem #98 gemerged wurde. Der Lauf war echt, die Reproduzierbarkeit nicht.

### 2. `read_u64_file` in `backend_linux.c` verwaist

Rückstand aus der Fan-Entfernung in #98. Auf Linux eine `-Wunused-function`-Warnung; macOS kompiliert die Datei nie und konnte es nicht sehen.

### 3. `check-backends` — damit das nicht wieder passiert

Die Link-Zeit-Auswahl kompiliert genau **einen** von drei Backends; die anderen beiden verrotten unbeobachtet. `backend_linux.c` und `backend_generic.c` sind reines POSIX, also kann sie jeder Host syntaktisch prüfen. Neuer Prerequisite von `test`, mit `-Werror`. `backend_macos.c` braucht Darwin-Header und wird dort geprüft, wo er ohnehin gebaut wird.

### Was der Testlauf sonst belegt hat

- **x86-64:** `Portability.md` sagte „sollte laufen, nicht getestet". Der portable Kern (36 Test-Binaries: Parser, Fixed-Point, Policy, Journal, Hash, Auswahl) baut und läuft als x86-64 — 36/36, null Warnungen aus eigenem Code. Die vollständige Suite geht dort nicht, weil `deps/geist` als arm64-Static-Lib vorliegt; das ist eine Eigenschaft der Abhängigkeit, nicht unseres Codes.
- **arm64:** clean, 44 PASS, null Warnungen.
- **ASan + UBSan** laufen im Debug-Build ohnehin mit — Alignment, OOB und Integer-UB sind über beide Architekturen abgedeckt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)