### PR TITLE
feat(device): der erste Aktuator, der wirklich etwas bewegt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ SPG_SOURCES := \
     src/core/run_config.c \
     src/core/status.c \
     src/context/context.c \
+    src/device/device.c \
     src/dsl/schema.c \
     src/dsl/sexpr.c \
     src/eval/eval.c \

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,23 @@ $(OBJ_DIR)/%.o: %.c
 $(WORKLOAD_BIN): examples/machine/workloads/workload.c | $(BIN_DIR)
 	$(CC) $(CFLAGS) -o $@ $<
 
-test: $(TEST_BINS) $(PROBE_BINS) $(SPG_BIN) $(WORKLOAD_BIN)
+# Link-time backend selection means a build compiles exactly ONE of the three
+# backends — the other two rot unseen. A deletion orphaned a helper in
+# backend_linux.c and macOS could not notice, because macOS never compiles that
+# file. Both of these are pure POSIX, so any host can syntax-check them;
+# backend_macos.c needs Darwin headers and is covered where it actually builds.
+PORTABLE_BACKENDS := src/machine/backend_linux.c src/machine/backend_generic.c
+
+check-backends:
+	@for f in $(PORTABLE_BACKENDS); do \
+		$(CC) $(CFLAGS) -Werror -fsyntax-only $$f || exit 1; \
+	done
+
+# CHAT_BIN belongs here because test_cli_chat.sh runs it. It was missing, and
+# the failure only showed after `make clean`: an incremental tree still had the
+# binary from an earlier `make all`, so the suite was green on a file no rule
+# had promised. A test target must build everything its tests execute.
+test: $(TEST_BINS) $(PROBE_BINS) $(SPG_BIN) $(CHAT_BIN) $(WORKLOAD_BIN) check-backends
 	@status=0; \
 	for t in $(TEST_BINS); do \
 		echo "$$t"; \

--- a/docs/machine-intelligence/Devices.md
+++ b/docs/machine-intelligence/Devices.md
@@ -1,0 +1,93 @@
+# Devices — Maschinen lesen und stellen
+
+Der erste Aktuator, der tatsächlich etwas bewegt.
+
+## Warum Modbus TCP und nicht GPIO
+
+Ein Kanal soll auf einer simulierten und einer echten Maschine **denselben
+Codepfad** nehmen. Sonst entsteht ein Simulationszweig, der verrottet, während
+niemand hinsieht — genau der Fehler, an dem die Lüfterklemmung aus Phase 15
+gestorben ist.
+
+Zwei Ebenen bieten diese Eigenschaft:
+
+| Ebene | Simulator | Warum identisch |
+|---|---|---|
+| Peripherie | `gpio-sim`, `i2c-stub`, `iio_dummy` | Kernel-Module, die dasselbe `/dev/gpiochipN` bzw. denselben I²C-Bus exportieren wie echte Hardware |
+| Maschine | OpenPLC, Factory I/O, `heater.py` | Modbus TCP ist das Protokoll echter Industriemaschinen, nicht eine Testschnittstelle |
+
+Modbus gewinnt als Einstieg, weil es über TCP läuft: entwickelbar und
+verifizierbar auf jeder Maschine, ohne Hardware und ohne Linux.
+
+## Die Portgrenze
+
+Ein **Kanal** ist das gesamte Vokabular — Name, Bereich, schreibbar ja/nein.
+Nicht eine Funktion pro Peripherie: diese Form hat drei Backends je zwei
+Fan-Funktionen tragen lassen, für ein Gerät, das kein Executor je angesteuert
+hat. Eine neue Maschine ist eine neue Tabelle, kein neuer Code.
+
+```
+geistshell device --port 5502 \
+    --channel temp:0:-400:9000:r \
+    --channel heater:1:0:100:w \
+    read temp
+```
+
+## Bereich heißt Ablehnung, nicht Klemmung
+
+Ein Wert außerhalb des Bereichs wird **abgelehnt und nicht gesendet**
+(`SPG_E_LIMIT`). Klemmen führt einen Beinahe-Treffer eines bereits falschen
+Befehls aus — so gehen Maschinen kaputt an Software, die hilfsbereit sein
+wollte. Der Aufrufer erfährt, dass sein Wert verworfen wurde.
+
+**Jede Ablehnung wird vor dem Socket entschieden.** Kanal unbekannt,
+schreibgeschützt, außerhalb des Bereichs: alles testbar mit `fd == -1`. Eine
+Sicherheitsprüfung, die erst greift, wenn eine Maschine angeschlossen ist, wird
+an dem Tag zum ersten Mal ausgeführt, an dem sie gebraucht wird.
+
+Drei weitere Eigenschaften mit demselben Motiv:
+
+- **Timeout in beide Richtungen.** Eine Maschine, die die Verbindung annimmt
+  und dann schweigt, darf die regelnde Schleife nicht anhalten.
+- **Transaktions-ID wird geprüft.** Eine fremde Antwort ist
+  `SPG_E_REPLAY_MISMATCH`, keine Warnung: hinter einem Gateway ordnet man sonst
+  die Messung einer Maschine einer anderen zu.
+- **Echo wird verglichen.** Quittiert das Gerät einen anderen Wert als
+  befohlen, ist das ein Fehler — sonst baut die nächste Entscheidung auf einer
+  Zahl auf, die die Maschine nie angenommen hat.
+
+## Die simulierte Anlage
+
+`examples/machine/plant/heater.py` — ein beheizter Kessel mit Wärmeträgheit,
+Verlust an die Umgebung und **rastender Übertemperaturabschaltung** bei 90 °C.
+Nur Standardbibliothek.
+
+Die Abschaltung ist der Punkt. Eine Anlage, die nur warm wird, belohnt jeden
+Regler, der die Heizung aufreißt, und misst damit nichts. Diese hier sperrt
+sich aus und muss zurückgesetzt werden — sie bestraft genau den Regler, der
+handelt, ohne vorher zu schauen.
+
+Zwei Modellfehler, beide beim ersten Lauf gefunden:
+
+1. **Der Trip war unerreichbar.** Bei 100 % lag das Gleichgewicht bei 50 °C,
+   die Abschaltung bei 90 °C. Eine Grenze, die keine Eingabe erreichen kann,
+   ist Dekoration. Jetzt liegt das Gleichgewicht bei 145 °C, und alles über
+   ~56 % rastet irgendwann aus.
+2. **Der Simulator hat die Messung gestört.** `--speed` erhöhte ursprünglich
+   die Tickrate — bei Faktor 40 waren das 800 Wakeups pro Sekunde, genug, um
+   den lastempfindlichen `test_cli_machine_run` in derselben Suite kippen zu
+   lassen. Jetzt skaliert `--speed` die Physik pro Tick; die Rate bleibt bei
+   20 Hz. Eine Testanlage, die die gemessene Maschine beeinflusst, ist keine
+   Fixture.
+
+## Was bewusst noch fehlt
+
+Es gibt **keine Agenten-Aktion** für Geräte. Das ist die Reihenfolge aus der
+Lüfter-Lehre: Executor zuerst, Aktion zuletzt. `machine_set_fan` existierte in
+Policy, Grammatik-Maske und CLI-Switch, und nichts hat sie je ausgeführt. Eine
+Aktion kommt, wenn der Executor nachweislich etwas bewegt — das tut er seit
+diesem Commit, also ist der nächste Schritt fällig, aber er ist ein eigener.
+
+Ebenso offen: Skalierung pro Kanal, 32-Bit- und Float-Register, Coils, und ein
+Watchdog, der bei ausbleibendem Kontakt in einen sicheren Zustand fährt. Der
+Watchdog ist der einzige davon, der vor einer echten Maschine stehen muss.

--- a/examples/machine/plant/heater.py
+++ b/examples/machine/plant/heater.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""A simulated machine that answers Modbus TCP.
+
+A heated vessel: thermal mass, loss to ambient, and an over-temperature trip
+that latches. The trip is the point. A plant that merely warms up rewards any
+controller that turns the heater to maximum, so it measures nothing; one that
+locks itself out at 90 C punishes exactly the controller that does not look
+before it acts, which is the behaviour we are trying to detect.
+
+Registers (holding, 16-bit, signed on the wire):
+
+    0  temperature   read    tenths of a degree Celsius
+    1  heater_power  write   0..100 percent
+    2  ambient       read    tenths of a degree Celsius
+    3  tripped       read    0 or 1, latches at 90.0 C
+    4  reset         write   write 1 to clear the trip
+
+Standard library only, deliberately: a test dependency that has to be
+installed is a test that will one day be skipped.
+
+    python3 heater.py --port 5502 [--speed 20]
+"""
+
+import argparse
+import socket
+import socketserver
+import struct
+import threading
+import time
+
+TEMPERATURE, HEATER_POWER, AMBIENT, TRIPPED, RESET = range(5)
+
+TRIP_DECIDEGREES = 900  # 90.0 C
+AMBIENT_DECIDEGREES = 200  # 20.0 C
+# Sized so the heater can actually reach the trip: steady state is
+# ambient + power * HEAT_PER_PERCENT / LOSS_COEFFICIENT, so 100 % settles at
+# 145 C and anything above ~56 % eventually latches out. The first version used
+# 0.06, which topped out at 50 C — the interlock could never fire, and a safety
+# limit that no input can reach is decoration.
+HEAT_PER_PERCENT = 0.25  # deci-degrees per percent per tick
+LOSS_COEFFICIENT = 0.02  # fraction of the gap to ambient shed per tick
+TICK_SECONDS = 0.05
+
+
+class Plant:
+    """The physics. Holds its own lock: the tick thread and the request
+    handlers touch the same registers from different threads."""
+
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.temperature = float(AMBIENT_DECIDEGREES)
+        self.power = 0
+        self.tripped = False
+
+    def step(self, scale):
+        """Advance the physics by `scale` ticks worth.
+
+        Scaling the step rather than the wake-up rate is deliberate. The first
+        version ran the thread `scale` times faster, which at speed 40 meant
+        800 wake-ups a second and enough CPU churn to make an unrelated,
+        load-sensitive test in the suite fail. A test plant that perturbs the
+        machine being measured is not a test fixture.
+
+        Loss is clamped below 1.0 because a per-tick loss of a whole gap would
+        oscillate instead of settle.
+        """
+        gain_factor = HEAT_PER_PERCENT * scale
+        loss_factor = min(LOSS_COEFFICIENT * scale, 0.5)
+        with self.lock:
+            if self.tripped:
+                self.power = 0
+            gain = self.power * gain_factor
+            loss = (self.temperature - AMBIENT_DECIDEGREES) * loss_factor
+            self.temperature += gain - loss
+            if self.temperature >= TRIP_DECIDEGREES:
+                # Latching, not momentary. A trip that clears itself when the
+                # temperature falls teaches a controller that overshooting is
+                # free, which is the opposite of what real interlocks do.
+                self.tripped = True
+                self.power = 0
+
+    def read(self, register):
+        with self.lock:
+            if register == TEMPERATURE:
+                return int(self.temperature)
+            if register == HEATER_POWER:
+                return self.power
+            if register == AMBIENT:
+                return AMBIENT_DECIDEGREES
+            if register == TRIPPED:
+                return 1 if self.tripped else 0
+            if register == RESET:
+                return 0
+        return None
+
+    def write(self, register, value):
+        with self.lock:
+            if register == HEATER_POWER:
+                if not 0 <= value <= 100:
+                    return None  # out of range: the device refuses too
+                if self.tripped:
+                    # Refused rather than silently accepted-and-ignored. A
+                    # controller must be able to tell "written" from "the
+                    # machine is locked out and your command went nowhere".
+                    return None
+                self.power = value
+                return value
+            if register == RESET:
+                if value == 1:
+                    self.tripped = False
+                    self.temperature = float(AMBIENT_DECIDEGREES)
+                return value
+        return None
+
+
+class Handler(socketserver.BaseRequestHandler):
+    def handle(self):
+        self.request.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        while True:
+            header = self._recv_exact(6)
+            if header is None:
+                return
+            txn, protocol, length = struct.unpack(">HHH", header)
+            if protocol != 0 or not 2 <= length <= 253:
+                return
+            body = self._recv_exact(length)
+            if body is None:
+                return
+            reply = self._dispatch(txn, body)
+            if reply is None:
+                return
+            self.request.sendall(reply)
+
+    def _recv_exact(self, n):
+        buf = b""
+        while len(buf) < n:
+            chunk = self.request.recv(n - len(buf))
+            if not chunk:
+                return None
+            buf += chunk
+        return buf
+
+    def _dispatch(self, txn, body):
+        unit, function = body[0], body[1]
+        plant = self.server.plant
+        if function == 0x03 and len(body) >= 6:
+            register, count = struct.unpack(">HH", body[2:6])
+            value = plant.read(register) if count == 1 else None
+            if value is None:
+                return self._exception(txn, unit, function, 0x02)
+            return self._frame(
+                txn, unit, struct.pack(">BBh", function, 2, value)
+            )
+        if function == 0x06 and len(body) >= 6:
+            register, raw = struct.unpack(">Hh", body[2:6])
+            written = plant.write(register, raw)
+            if written is None:
+                return self._exception(txn, unit, function, 0x03)
+            return self._frame(
+                txn, unit, struct.pack(">Hh", register, written), function
+            )
+        return self._exception(txn, unit, function, 0x01)
+
+    def _frame(self, txn, unit, pdu, function=None):
+        payload = pdu if function is None else struct.pack(">B", function) + pdu
+        return struct.pack(">HHHB", txn, 0, len(payload) + 1, unit) + payload
+
+    def _exception(self, txn, unit, function, code):
+        return self._frame(txn, unit, struct.pack(">BB", function | 0x80, code))
+
+
+class Server(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, default=5502)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument(
+        "--speed",
+        type=float,
+        default=1.0,
+        help="physics multiplier per tick; tests use a high value so a "
+        "thermal run takes seconds instead of minutes. The tick RATE is "
+        "fixed, so a fast plant costs no more CPU than a slow one.",
+    )
+    args = parser.parse_args()
+
+    server = Server((args.host, args.port), Handler)
+    server.plant = Plant()
+
+    def run():
+        while True:
+            time.sleep(TICK_SECONDS)
+            server.plant.step(args.speed)
+
+    threading.Thread(target=run, daemon=True).start()
+    print(f"heater plant on {args.host}:{server.server_address[1]}", flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/include/geistshell/device.h
+++ b/include/geistshell/device.h
@@ -1,0 +1,124 @@
+#ifndef GEISTSHELL_DEVICE_H
+#define GEISTSHELL_DEVICE_H
+
+#include "geistshell/status.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Reading and writing a real machine.
+ *
+ * A CHANNEL is the entire vocabulary: a name, a range, and whether it may be
+ * written. Not one function per peripheral — that shape is what cost us the
+ * fan port, where three backends each carried two functions for a device no
+ * executor ever drove. A new machine is a new table, not new code.
+ *
+ * The transport is Modbus TCP because it is what industrial machines actually
+ * speak, and because the simulators speak the same thing. The property that
+ * matters is the one gpio-sim has a layer lower: the code driving a simulated
+ * machine and the code driving a real one are the same code, so there is no
+ * simulation branch that can rot while nobody looks at it.
+ *
+ * Values are int64_t in raw register units. Devices scale their own registers
+ * (23.5 °C is commonly the integer 235), and a scale factor per channel would
+ * be a second place for a wrong number to live.
+ * ponytail: no scaling, no 32-bit or float registers. Add a scale to the
+ * channel when a device needs one, not before. */
+
+constexpr size_t SPG_DEVICE_NAME_CAP     = 32u;
+constexpr size_t SPG_DEVICE_MAX_CHANNELS = 32u;
+
+/* Milliseconds before a silent machine is given up on. A device that does not
+ * answer must never be able to stall the loop that governs it — an agent
+ * blocked in read() is an agent that cannot react to anything else. */
+constexpr int SPG_DEVICE_TIMEOUT_MS = 1000;
+
+struct spg_device_channel {
+    char     name[SPG_DEVICE_NAME_CAP];
+    uint16_t unit; /* Modbus unit id, for gateways fronting several nodes */
+    uint16_t reg;  /* holding-register address */
+    int64_t  min;  /* inclusive, in register units */
+    int64_t  max;  /* inclusive */
+    bool writable; /* a read-only channel is refused, not silently ignored */
+};
+
+struct spg_device {
+    int      fd;  /* -1 when not connected */
+    uint16_t txn; /* Modbus transaction id, incremented per request */
+    size_t   n_channels;
+    struct spg_device_channel channels[SPG_DEVICE_MAX_CHANNELS];
+};
+
+/* --- The table -------------------------------------------------------- */
+
+void spg_device_init(struct spg_device *dev);
+
+[[nodiscard]] enum spg_status
+spg_device_add_channel(struct spg_device               *dev,
+                       const struct spg_device_channel *channel);
+
+/* Parse one "name:reg:min:max:rw" descriptor. Deliberately not a config file
+ * format of its own: there is exactly one machine to describe so far, and a
+ * parser is a thing that has to be maintained whether or not anyone uses it.
+ * ponytail: promote to the sexpr config when a second machine shows up. */
+[[nodiscard]] enum spg_status
+spg_device_parse_channel(size_t text_n, const char text[],
+                         struct spg_device_channel *out);
+
+[[nodiscard]] const struct spg_device_channel *
+spg_device_find(const struct spg_device *dev, const char *name);
+
+/* --- The wire --------------------------------------------------------- */
+
+/* Frame codecs, kept free of any socket so the wire format can be tested
+ * without a network. Both write a complete MBAP header plus PDU and return
+ * the byte count. */
+constexpr size_t SPG_MODBUS_FRAME_CAP = 12u;
+
+size_t spg_modbus_encode_read(uint16_t txn, uint16_t unit, uint16_t reg,
+                              uint8_t out[static SPG_MODBUS_FRAME_CAP]);
+size_t spg_modbus_encode_write(uint16_t txn, uint16_t unit, uint16_t reg,
+                               uint16_t value,
+                               uint8_t  out[static SPG_MODBUS_FRAME_CAP]);
+
+/* Decode a response and check it answers `txn`. A mismatched transaction id is
+ * SPG_E_REPLAY_MISMATCH, not a warning: on a shared bus it means this reply
+ * belongs to somebody else's question, and using it would attribute one
+ * machine's reading to another.
+ *
+ * A Modbus exception response becomes SPG_E_IO; out_value is untouched. */
+[[nodiscard]] enum spg_status spg_modbus_decode(size_t n, const uint8_t frame[],
+                                                uint16_t  txn,
+                                                uint16_t *out_value);
+
+/* --- The machine ------------------------------------------------------ */
+
+[[nodiscard]] enum spg_status
+spg_device_connect(struct spg_device *dev, const char *host, uint16_t port);
+
+void spg_device_close(struct spg_device *dev);
+
+[[nodiscard]] enum spg_status spg_device_read(struct spg_device *dev,
+                                              const char *name, int64_t *out);
+
+/* Out-of-range is REFUSED (SPG_E_LIMIT), not clamped. Clamping executes a
+ * near-miss of a command that was already wrong, which is how machines get
+ * damaged by software that believed it was being helpful. The caller learns
+ * its value was rejected; nothing is written.
+ *
+ * The check lives here, above the socket, for the same reason the fan clamp
+ * had to leave its platform branch: a safety property inside an I/O path is a
+ * safety property that cannot be tested. */
+[[nodiscard]] enum spg_status spg_device_write(struct spg_device *dev,
+                                               const char *name, int64_t value);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -4,6 +4,7 @@
 #    define _DARWIN_C_SOURCE 1
 #endif
 
+#include "geistshell/device.h"
 #include "geistshell/geistshell.h"
 
 #include "geistshell/agent_loop.h"
@@ -83,7 +84,8 @@ static void print_usage(const char *argv0) {
         "  verify-journal   verify a journal (+ --key <f> checks the seal)\n"
         "  seal-journal     write a keyed HMAC seal over a journal\n"
         "  policy-check     validate and summarize a policy file\n"
-        "  sim-validate     validate and summarize a scenario file\n",
+        "  sim-validate     validate and summarize a scenario file\n"
+        "  device           read/write a machine over Modbus TCP\n",
         argv0);
 }
 
@@ -1084,6 +1086,152 @@ done:
         status = SPG_E_IO;
     }
     return status;
+}
+
+/* Read and write a real machine over Modbus TCP.
+ *
+ * A CLI command rather than an agent action, and in that order on purpose: the
+ * fan of phase 15 existed as an action in the policy, the grammar mask and this
+ * very switch, and nothing ever executed it. An actuator gets a working
+ * executor first and a model-reachable action only once it demonstrably moves
+ * something.
+ *
+ *   geistshell device --host H --port P \
+ *       --channel temp:0:-400:9000:r --channel heater:1:0:100:w \
+ *       read temp | write heater 60 | list
+ */
+static void print_device_usage(const char *argv0) {
+    fprintf(stderr,
+            "usage: %s device [--host H] [--port P] "
+            "--channel name:reg:min:max:{r|w} ... <read NAME|write NAME "
+            "VALUE|list>\n\n"
+            "Channels are declared per invocation. The range is a refusal "
+            "bound, not a\nclamp: an out-of-range write is rejected and "
+            "nothing is sent.\n",
+            argv0);
+}
+
+static int device_command(const int argc, char **argv) {
+    struct spg_device dev = {};
+    spg_device_init(&dev);
+
+    const char *host = "127.0.0.1";
+    long        port = 502;
+    int         i    = 2;
+    for (; i < argc; i += 1) {
+        if (strcmp(argv[i], "--host") == 0 && i + 1 < argc) {
+            host = argv[i + 1];
+            i += 1;
+        } else if (strcmp(argv[i], "--port") == 0 && i + 1 < argc) {
+            char *end = nullptr;
+            port      = strtol(argv[i + 1], &end, 10);
+            if (end == argv[i + 1] || *end != '\0' || port < 1 ||
+                port > 65535) {
+                fprintf(stderr, "device: bad port: %s\n", argv[i + 1]);
+                return 2;
+            }
+            i += 1;
+        } else if (strcmp(argv[i], "--channel") == 0 && i + 1 < argc) {
+            struct spg_device_channel channel = {};
+            enum spg_status           status  = spg_device_parse_channel(
+                strlen(argv[i + 1]), argv[i + 1], &channel);
+            if (status == SPG_OK) {
+                status = spg_device_add_channel(&dev, &channel);
+            }
+            if (status != SPG_OK) {
+                fprintf(stderr, "device: bad channel '%s': %s\n", argv[i + 1],
+                        spg_status_to_string(status));
+                return 2;
+            }
+            i += 1;
+        } else {
+            break;
+        }
+    }
+
+    if (i >= argc) {
+        print_device_usage(argv[0]);
+        return 2;
+    }
+
+    if (strcmp(argv[i], "list") == 0) {
+        for (size_t c = 0u; c < dev.n_channels; c += 1u) {
+            const struct spg_device_channel *ch = &dev.channels[c];
+            printf("(channel (name \"%s\") (reg %u) (min %lld) (max %lld) "
+                   "(mode %s))\n",
+                   ch->name, (unsigned)ch->reg, (long long)ch->min,
+                   (long long)ch->max, ch->writable ? "w" : "r");
+        }
+        return 0;
+    }
+
+    const bool is_read  = strcmp(argv[i], "read") == 0;
+    const bool is_write = strcmp(argv[i], "write") == 0;
+    if ((!is_read && !is_write) || i + 1 >= argc ||
+        (is_write && i + 2 >= argc)) {
+        print_device_usage(argv[0]);
+        return 2;
+    }
+    const char *name  = argv[i + 1];
+    int64_t     value = 0;
+    if (is_write) {
+        char *end = nullptr;
+        value     = (int64_t)strtoll(argv[i + 2], &end, 10);
+        if (end == argv[i + 2] || *end != '\0') {
+            fprintf(stderr, "device: bad value: %s\n", argv[i + 2]);
+            return 2;
+        }
+    }
+
+    /* A write is refused before the socket is opened, so a rejected command
+     * costs no connection and reaches no machine. */
+    if (is_write) {
+        const struct spg_device_channel *ch = spg_device_find(&dev, name);
+        if (ch == nullptr) {
+            fprintf(stderr, "device: no channel '%s'\n", name);
+            return 1;
+        }
+        if (!ch->writable || value < ch->min || value > ch->max) {
+            fprintf(
+                stderr, "device: refused %s=%lld (channel is %s, %lld..%lld)\n",
+                name, (long long)value, ch->writable ? "writable" : "read-only",
+                (long long)ch->min, (long long)ch->max);
+            return 1;
+        }
+    }
+
+    enum spg_status status = spg_device_connect(&dev, host, (uint16_t)port);
+    if (status != SPG_OK) {
+        fprintf(stderr, "device: connect %s:%ld failed: %s\n", host, port,
+                spg_status_to_string(status));
+        return 1;
+    }
+
+    int exit_code = 0;
+    if (is_read) {
+        int64_t reading = 0;
+        status          = spg_device_read(&dev, name, &reading);
+        if (status == SPG_OK) {
+            printf("(reading (channel \"%s\") (value %lld))\n", name,
+                   (long long)reading);
+        } else {
+            fprintf(stderr, "device: read %s failed: %s\n", name,
+                    spg_status_to_string(status));
+            exit_code = 1;
+        }
+    } else {
+        status = spg_device_write(&dev, name, value);
+        if (status == SPG_OK) {
+            printf("(wrote (channel \"%s\") (value %lld))\n", name,
+                   (long long)value);
+        } else {
+            fprintf(stderr, "device: write %s=%lld failed: %s\n", name,
+                    (long long)value, spg_status_to_string(status));
+            exit_code = 1;
+        }
+    }
+    spg_device_close(&dev);
+    return exit_code;
 }
 
 static int sim_validate_command(const char *path) {
@@ -2185,21 +2333,21 @@ static int agent_command(int argc, char **argv) {
     /* #54: scratch for the chat-framed prompt. Room for the context plus the
      * turn markers; a template that would not fit falls back to the bare
      * prompt rather than sending half a format. */
-    static char framed[CLI_CONTEXT_BYTES + 256u];
-    static char                           model_output[CLI_MODEL_OUTPUT_BYTES];
-    static struct spg_sexpr_token         rec_tokens[CLI_TOKEN_CAPACITY];
-    static struct spg_sexpr_node          rec_nodes[CLI_NODE_CAPACITY];
-    static char                           policy_payload[CLI_PAYLOAD_BYTES];
-    static char                           sim_payload[CLI_PAYLOAD_BYTES];
-    static char                           observation[AGENT_OBS_BYTES];
-    static char                           shell_stdout[AGENT_SHELL_STDOUT];
-    static char                           shell_stderr[AGENT_SHELL_STDERR];
-    static char                           mem_index[AGENT_OBS_BYTES];
+    static char                   framed[CLI_CONTEXT_BYTES + 256u];
+    static char                   model_output[CLI_MODEL_OUTPUT_BYTES];
+    static struct spg_sexpr_token rec_tokens[CLI_TOKEN_CAPACITY];
+    static struct spg_sexpr_node  rec_nodes[CLI_NODE_CAPACITY];
+    static char                   policy_payload[CLI_PAYLOAD_BYTES];
+    static char                   sim_payload[CLI_PAYLOAD_BYTES];
+    static char                   observation[AGENT_OBS_BYTES];
+    static char                   shell_stdout[AGENT_SHELL_STDOUT];
+    static char                   shell_stderr[AGENT_SHELL_STDERR];
+    static char                   mem_index[AGENT_OBS_BYTES];
     static struct spg_journal_record_header trajectory[256];
 
     const struct spg_agent_run_workspace ws = {
-        .context_capacity        = sizeof context,
-        .context                 = context,
+        .context_capacity = sizeof context,
+        .context          = context,
         /* #54: scratch for the chat-framed prompt. Sized like the context plus
          * the markers; a template that would not fit falls back to the bare
          * prompt rather than sending half a format. */
@@ -2773,7 +2921,7 @@ static void eval_tally_ladder(struct eval_run_report            *report,
 /* Per-invocation knobs. A null pointer (or zeroed struct) reproduces the
  * historical behaviour: one sample per case, no remote endpoint. */
 struct eval_run_opts {
-    uint32_t    ablate;     /* phase 11: parts of the snapshot to withhold */
+    uint32_t    ablate; /* phase 11: parts of the snapshot to withhold */
     const char *profile_model_path; /* #54: how to frame the prompt */
     const char *remote_url; /* nullable: enables (model "remote") cases      */
     const char *remote_model; /* nullable: model name for remote cases */
@@ -2918,20 +3066,20 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
     /* #54: scratch for the chat-framed prompt. Room for the context plus the
      * turn markers; a template that would not fit falls back to the bare
      * prompt rather than sending half a format. */
-    static char framed[CLI_CONTEXT_BYTES + 256u];
-    static char                           model_output[CLI_MODEL_OUTPUT_BYTES];
-    static struct spg_sexpr_token         rtok[CLI_TOKEN_CAPACITY];
-    static struct spg_sexpr_node          rnod[CLI_NODE_CAPACITY];
-    static char                           ppay[CLI_PAYLOAD_BYTES];
-    static char                           spay[CLI_PAYLOAD_BYTES];
-    static char                           observation[AGENT_OBS_BYTES];
-    static char                           sh_out[AGENT_SHELL_STDOUT];
-    static char                           sh_err[AGENT_SHELL_STDERR];
-    static char                           mem_index[AGENT_OBS_BYTES];
+    static char                   framed[CLI_CONTEXT_BYTES + 256u];
+    static char                   model_output[CLI_MODEL_OUTPUT_BYTES];
+    static struct spg_sexpr_token rtok[CLI_TOKEN_CAPACITY];
+    static struct spg_sexpr_node  rnod[CLI_NODE_CAPACITY];
+    static char                   ppay[CLI_PAYLOAD_BYTES];
+    static char                   spay[CLI_PAYLOAD_BYTES];
+    static char                   observation[AGENT_OBS_BYTES];
+    static char                   sh_out[AGENT_SHELL_STDOUT];
+    static char                   sh_err[AGENT_SHELL_STDERR];
+    static char                   mem_index[AGENT_OBS_BYTES];
     static struct spg_journal_record_header traj[256];
     const struct spg_agent_run_workspace    ws = {
-        .context_capacity        = sizeof context,
-        .context                 = context,
+        .context_capacity = sizeof context,
+        .context          = context,
         /* #54: scratch for the chat-framed prompt. Sized like the context plus
          * the markers; a template that would not fit falls back to the bare
          * prompt rather than sending half a format. */
@@ -2998,8 +3146,8 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
             goto done;
         }
         const enum spg_status ms = spg_model_profile_load(
-            ptext.n, ptext.data, ws.token_capacity, ws.tokens,
-            ws.node_capacity, ws.nodes, &model_profile);
+            ptext.n, ptext.data, ws.token_capacity, ws.tokens, ws.node_capacity,
+            ws.nodes, &model_profile);
         free_file_buffer(&ptext);
         if (ms != SPG_OK) {
             fprintf(stderr, "eval: invalid model profile %s: %s\n",
@@ -3592,7 +3740,8 @@ static void eval_print_report(const char                   *suite_path,
         /* #64: only for diagnosis cases, so every other suite's output stays
          * byte-identical to what its consumers already parse. */
         if (report->case_expected[i][0] != '\0') {
-            printf(",\"expected\":\"%s\",\"emitted\":", report->case_expected[i]);
+            printf(",\"expected\":\"%s\",\"emitted\":",
+                   report->case_expected[i]);
             print_json_string(report->case_emitted[i]);
             printf(",\"correct\":%zu,\"hallucinated\":%zu"
                    ",\"action_proposed\":%zu,\"context_bytes\":%zu"
@@ -4394,6 +4543,10 @@ int main(int argc, char **argv) {
             return 2;
         }
         return sim_validate_command(argv[2]);
+    }
+
+    if (strcmp(argv[1], "device") == 0) {
+        return device_command(argc, argv);
     }
 
     fprintf(stderr, "%s: unknown command\n", argv[1]);

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -1,0 +1,399 @@
+/* Modbus TCP client and the channel table it drives.
+ *
+ * Split in three parts, in order of how testable they are: the table (pure),
+ * the wire codec (pure), the socket (not). Everything that decides anything
+ * lives in the first two. */
+
+#include "geistshell/device.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netdb.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+/* --- The table -------------------------------------------------------- */
+
+void spg_device_init(struct spg_device *dev) {
+    if (dev == nullptr) {
+        return;
+    }
+    *dev = (struct spg_device){.fd = -1, .txn = 0u, .n_channels = 0u};
+}
+
+enum spg_status
+spg_device_add_channel(struct spg_device               *dev,
+                       const struct spg_device_channel *channel) {
+    if (dev == nullptr || channel == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    if (channel->name[0] == '\0' || channel->min > channel->max) {
+        return SPG_E_INVALID_ARG;
+    }
+    if (spg_device_find(dev, channel->name) != nullptr) {
+        /* Two channels under one name means a write could reach either
+         * register depending on table order. Refuse the table instead. */
+        return SPG_E_INVALID_ARG;
+    }
+    if (dev->n_channels >= SPG_DEVICE_MAX_CHANNELS) {
+        return SPG_E_LIMIT;
+    }
+    dev->channels[dev->n_channels] = *channel;
+    dev->n_channels += 1u;
+    return SPG_OK;
+}
+
+const struct spg_device_channel *spg_device_find(const struct spg_device *dev,
+                                                 const char *name) {
+    if (dev == nullptr || name == nullptr) {
+        return nullptr;
+    }
+    for (size_t i = 0u; i < dev->n_channels; i += 1u) {
+        if (strcmp(dev->channels[i].name, name) == 0) {
+            return &dev->channels[i];
+        }
+    }
+    return nullptr;
+}
+
+/* Read one ':'-delimited field as a signed integer. Returns the offset just
+ * past the field, or 0 on malformed input. */
+static size_t scan_int(size_t n, const char text[], size_t at, int64_t *out) {
+    if (at >= n) {
+        return 0u;
+    }
+    bool negative = false;
+    if (text[at] == '-') {
+        negative = true;
+        at += 1u;
+    }
+    int64_t value = 0;
+    size_t  start = at;
+    for (; at < n && text[at] >= '0' && text[at] <= '9'; at += 1u) {
+        if (value > (INT64_MAX - (text[at] - '0')) / 10) {
+            return 0u; /* an overflowing bound is not a bound */
+        }
+        value = value * 10 + (text[at] - '0');
+    }
+    if (at == start) {
+        return 0u;
+    }
+    *out = negative ? -value : value;
+    return at;
+}
+
+static size_t skip_colon(size_t n, const char text[], size_t at) {
+    return (at < n && text[at] == ':') ? at + 1u : 0u;
+}
+
+enum spg_status spg_device_parse_channel(const size_t text_n, const char text[],
+                                         struct spg_device_channel *out) {
+    if (out == nullptr || (text_n > 0u && text == nullptr)) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = (struct spg_device_channel){};
+
+    size_t at = 0u;
+    while (at < text_n && text[at] != ':') {
+        if (at + 1u >= SPG_DEVICE_NAME_CAP) {
+            return SPG_E_LIMIT;
+        }
+        out->name[at] = text[at];
+        at += 1u;
+    }
+    if (at == 0u) {
+        return SPG_E_FORMAT; /* an unnamed channel cannot be addressed */
+    }
+    out->name[at] = '\0';
+
+    int64_t reg = 0, min = 0, max = 0;
+    at = skip_colon(text_n, text, at);
+    if (at == 0u || (at = scan_int(text_n, text, at, &reg)) == 0u) {
+        return SPG_E_FORMAT;
+    }
+    at = skip_colon(text_n, text, at);
+    if (at == 0u || (at = scan_int(text_n, text, at, &min)) == 0u) {
+        return SPG_E_FORMAT;
+    }
+    at = skip_colon(text_n, text, at);
+    if (at == 0u || (at = scan_int(text_n, text, at, &max)) == 0u) {
+        return SPG_E_FORMAT;
+    }
+    at = skip_colon(text_n, text, at);
+    if (at == 0u || at >= text_n) {
+        return SPG_E_FORMAT;
+    }
+    if (text[at] == 'w') {
+        out->writable = true;
+    } else if (text[at] != 'r') {
+        return SPG_E_FORMAT;
+    }
+    if (at + 1u != text_n) {
+        return SPG_E_FORMAT; /* trailing text means the operator meant something
+                                this parser did not understand */
+    }
+    if (reg < 0 || reg > UINT16_MAX || min > max) {
+        return SPG_E_FORMAT;
+    }
+    out->reg = (uint16_t)reg;
+    out->min = min;
+    out->max = max;
+    return SPG_OK;
+}
+
+/* --- The wire --------------------------------------------------------- */
+
+static void put_u16(uint8_t out[static 2], const uint16_t value) {
+    /* Written byte by byte rather than by casting a uint16_t*: Modbus is
+     * big-endian on the wire regardless of the host, and a cast would make the
+     * frame depend on the CPU it was built for. */
+    out[0] = (uint8_t)(value >> 8);
+    out[1] = (uint8_t)(value & 0xffu);
+}
+
+static uint16_t get_u16(const uint8_t in[static 2]) {
+    return (uint16_t)(((uint16_t)in[0] << 8) | (uint16_t)in[1]);
+}
+
+/* MBAP header: transaction(2) protocol(2) length(2) unit(1), then the PDU. */
+static size_t encode(const uint16_t txn, const uint16_t unit,
+                     const uint8_t function, const uint16_t reg,
+                     const uint16_t arg, uint8_t out[static 12]) {
+    put_u16(&out[0], txn);
+    put_u16(&out[2], 0u); /* protocol id: always 0 for Modbus */
+    put_u16(&out[4], 6u); /* length: unit + function + two 16-bit fields */
+    out[6] = (uint8_t)unit;
+    out[7] = function;
+    put_u16(&out[8], reg);
+    put_u16(&out[10], arg);
+    return 12u;
+}
+
+size_t spg_modbus_encode_read(const uint16_t txn, const uint16_t unit,
+                              const uint16_t reg, uint8_t out[static 12]) {
+    return encode(txn, unit, 0x03u, reg, 1u, out); /* one register */
+}
+
+size_t spg_modbus_encode_write(const uint16_t txn, const uint16_t unit,
+                               const uint16_t reg, const uint16_t value,
+                               uint8_t out[static 12]) {
+    return encode(txn, unit, 0x06u, reg, value, out);
+}
+
+enum spg_status spg_modbus_decode(const size_t n, const uint8_t frame[],
+                                  const uint16_t txn, uint16_t *out_value) {
+    if (out_value == nullptr || (n > 0u && frame == nullptr)) {
+        return SPG_E_INVALID_ARG;
+    }
+    if (n < 9u) {
+        return SPG_E_FORMAT;
+    }
+    if (get_u16(&frame[0]) != txn) {
+        /* Somebody else's answer. On a bus fronted by a gateway this is how one
+         * machine's reading gets attributed to another. */
+        return SPG_E_REPLAY_MISMATCH;
+    }
+    if (get_u16(&frame[2]) != 0u) {
+        return SPG_E_FORMAT;
+    }
+    const uint8_t function = frame[7];
+    if ((function & 0x80u) != 0u) {
+        return SPG_E_IO; /* the device refused; frame[8] carries its code */
+    }
+    if (function == 0x03u) {
+        if (n < 11u || frame[8] != 2u) {
+            return SPG_E_FORMAT;
+        }
+        *out_value = get_u16(&frame[9]);
+        return SPG_OK;
+    }
+    if (function == 0x06u) {
+        if (n < 12u) {
+            return SPG_E_FORMAT;
+        }
+        *out_value = get_u16(&frame[10]); /* echo of the written value */
+        return SPG_OK;
+    }
+    return SPG_E_UNSUPPORTED;
+}
+
+/* --- The machine ------------------------------------------------------ */
+
+enum spg_status spg_device_connect(struct spg_device *dev, const char *host,
+                                   const uint16_t port) {
+    if (dev == nullptr || host == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    if (dev->fd >= 0) {
+        return SPG_E_INVALID_STATE;
+    }
+    char port_text[6] = {};
+    (void)snprintf(port_text, sizeof port_text, "%u", (unsigned)port);
+
+    struct addrinfo  hints = {.ai_family   = AF_UNSPEC,
+                              .ai_socktype = SOCK_STREAM};
+    struct addrinfo *list  = nullptr;
+    if (getaddrinfo(host, port_text, &hints, &list) != 0) {
+        return SPG_E_IO;
+    }
+    enum spg_status status = SPG_E_IO;
+    for (const struct addrinfo *it = list; it != nullptr; it = it->ai_next) {
+        const int fd = socket(it->ai_family, it->ai_socktype, it->ai_protocol);
+        if (fd < 0) {
+            continue;
+        }
+        /* Both directions bounded. A machine that accepts the connection and
+         * then goes quiet is the failure this guards: without it the governing
+         * loop blocks in read() and stops governing anything. */
+        struct timeval tv = {.tv_sec  = SPG_DEVICE_TIMEOUT_MS / 1000,
+                             .tv_usec = (SPG_DEVICE_TIMEOUT_MS % 1000) * 1000};
+        (void)setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+        (void)setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof tv);
+        if (connect(fd, it->ai_addr, it->ai_addrlen) == 0) {
+            dev->fd = fd;
+            status  = SPG_OK;
+            break;
+        }
+        (void)close(fd);
+    }
+    freeaddrinfo(list);
+    return status;
+}
+
+void spg_device_close(struct spg_device *dev) {
+    if (dev != nullptr && dev->fd >= 0) {
+        (void)close(dev->fd);
+        dev->fd = -1;
+    }
+}
+
+static enum spg_status write_all(const int fd, const size_t n,
+                                 const uint8_t buf[]) {
+    size_t sent = 0u;
+    while (sent < n) {
+        const ssize_t got = send(fd, &buf[sent], n - sent, 0);
+        if (got <= 0) {
+            if (got < 0 && errno == EINTR) {
+                continue;
+            }
+            return SPG_E_IO;
+        }
+        sent += (size_t)got;
+    }
+    return SPG_OK;
+}
+
+static enum spg_status read_exact(const int fd, const size_t n, uint8_t buf[]) {
+    size_t have = 0u;
+    while (have < n) {
+        const ssize_t got = recv(fd, &buf[have], n - have, 0);
+        if (got <= 0) {
+            if (got < 0 && errno == EINTR) {
+                continue;
+            }
+            return SPG_E_IO; /* covers the timeout: a silent machine is an
+                                unreachable machine, not a slow one */
+        }
+        have += (size_t)got;
+    }
+    return SPG_OK;
+}
+
+/* One request, one response. The MBAP length field says how much follows, so
+ * the reply is read in two steps rather than guessed at. */
+static enum spg_status transact(struct spg_device *dev, const size_t n,
+                                const uint8_t request[], const uint16_t txn,
+                                uint16_t *out_value) {
+    enum spg_status status = write_all(dev->fd, n, request);
+    if (status != SPG_OK) {
+        return status;
+    }
+    uint8_t reply[SPG_MODBUS_FRAME_CAP] = {};
+    status                              = read_exact(dev->fd, 6u, reply);
+    if (status != SPG_OK) {
+        return status;
+    }
+    const uint16_t remaining = get_u16(&reply[4]);
+    if (remaining == 0u || remaining > SPG_MODBUS_FRAME_CAP - 6u) {
+        return SPG_E_FORMAT;
+    }
+    status = read_exact(dev->fd, remaining, &reply[6]);
+    if (status != SPG_OK) {
+        return status;
+    }
+    return spg_modbus_decode((size_t)remaining + 6u, reply, txn, out_value);
+}
+
+enum spg_status spg_device_read(struct spg_device *dev, const char *name,
+                                int64_t *out) {
+    if (dev == nullptr || out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    if (dev->fd < 0) {
+        return SPG_E_INVALID_STATE;
+    }
+    const struct spg_device_channel *channel = spg_device_find(dev, name);
+    if (channel == nullptr) {
+        return SPG_E_NOT_FOUND;
+    }
+    dev->txn += 1u;
+    uint8_t      request[SPG_MODBUS_FRAME_CAP] = {};
+    const size_t n =
+        spg_modbus_encode_read(dev->txn, channel->unit, channel->reg, request);
+    uint16_t              value  = 0u;
+    const enum spg_status status = transact(dev, n, request, dev->txn, &value);
+    if (status != SPG_OK) {
+        return status;
+    }
+    /* Registers carry signed measurements as two's complement — a below-zero
+     * temperature is the common case that a plain unsigned read gets wrong by
+     * 65536. */
+    *out = (int64_t)(int16_t)value;
+    return SPG_OK;
+}
+
+enum spg_status spg_device_write(struct spg_device *dev, const char *name,
+                                 const int64_t value) {
+    if (dev == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    /* Every refusal is decided BEFORE the connection is consulted, so all of
+     * it can be tested without a socket. A safety check reachable only once a
+     * machine is plugged in is a safety check nobody runs. */
+    const struct spg_device_channel *channel = spg_device_find(dev, name);
+    if (channel == nullptr) {
+        return SPG_E_NOT_FOUND;
+    }
+    if (!channel->writable) {
+        return SPG_E_POLICY_DENIED;
+    }
+    if (value < channel->min || value > channel->max) {
+        return SPG_E_LIMIT; /* refused, not clamped — see device.h */
+    }
+    if (value < INT16_MIN || value > INT16_MAX) {
+        return SPG_E_OVERFLOW;
+    }
+    if (dev->fd < 0) {
+        return SPG_E_INVALID_STATE;
+    }
+    dev->txn += 1u;
+    uint8_t      request[SPG_MODBUS_FRAME_CAP] = {};
+    const size_t n =
+        spg_modbus_encode_write(dev->txn, channel->unit, channel->reg,
+                                (uint16_t)(int16_t)value, request);
+    uint16_t              echo   = 0u;
+    const enum spg_status status = transact(dev, n, request, dev->txn, &echo);
+    if (status != SPG_OK) {
+        return status;
+    }
+    if ((int64_t)(int16_t)echo != value) {
+        /* The device acknowledged a different value than it was told. Treated
+         * as a failure: a caller that believes its write landed will build the
+         * next decision on a number the machine never accepted. */
+        return SPG_E_IO;
+    }
+    return SPG_OK;
+}

--- a/src/machine/backend_linux.c
+++ b/src/machine/backend_linux.c
@@ -216,20 +216,3 @@ enum spg_status spg_backend_process_identity(const uint64_t pid,
     return SPG_OK;
 }
 
-static bool read_u64_file(const char *path, uint64_t *out) {
-    char         buf[32] = {};
-    const size_t n       = read_file(path, sizeof buf - 1u, buf);
-    if (n == 0u) {
-        return false;
-    }
-    uint64_t value = 0u;
-    bool     any   = false;
-    for (size_t i = 0u; i < n && buf[i] >= '0' && buf[i] <= '9'; i += 1u) {
-        value = value * 10u + (uint64_t)(buf[i] - '0');
-        any   = true;
-    }
-    if (any) {
-        *out = value;
-    }
-    return any;
-}

--- a/test/test_cli_device.sh
+++ b/test/test_cli_device.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+# End-to-end against a simulated machine: geistshell drives a Modbus TCP plant
+# and the plant's temperature responds. The point is that nothing here is a
+# mock — the same client code, the same wire format, the same refusals that a
+# real Modbus device would meet.
+#
+# Port 0 lets the kernel pick, so a developer already running something on 5502
+# does not get a mysterious failure.
+set -eu
+
+SPG_BIN=${SPG_BIN:-build/host-debug/bin/geistshell}
+PLANT=examples/machine/plant/heater.py
+LOG=build/test-cli-device-plant.log
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "test_cli_device: SKIP (no python3)"
+    exit 0
+fi
+
+# speed 20 puts the thermal time constant at about 125 ms, so every settle
+# below is complete long before it is read. The tick rate is fixed at 20 Hz
+# whatever the speed, so this fixture does not disturb the load-sensitive
+# machine tests that run after it. Direction and latch are asserted, never
+# a wall-clock duration.
+python3 "$PLANT" --port 0 --speed 20 >"$LOG" 2>&1 &
+PLANT_PID=$!
+trap 'kill "$PLANT_PID" 2>/dev/null || true' EXIT
+
+PORT=""
+i=0
+while [ $i -lt 50 ]; do
+    PORT=$(sed -n 's/.*:\([0-9][0-9]*\)$/\1/p' "$LOG" 2>/dev/null | head -1)
+    [ -n "$PORT" ] && break
+    i=$((i + 1))
+    sleep 0.1
+done
+if [ -z "$PORT" ]; then
+    echo "test_cli_device: FAIL — plant did not start" >&2
+    cat "$LOG" >&2
+    exit 1
+fi
+
+CH="--channel temp:0:-400:9000:r --channel heater:1:0:100:w"
+CH="$CH --channel tripped:3:0:1:r --channel reset:4:0:1:w"
+
+dev() {
+    # shellcheck disable=SC2086
+    "$SPG_BIN" device --port "$PORT" $CH "$@"
+}
+
+value_of() {
+    sed -n 's/.*(value \(-\{0,1\}[0-9][0-9]*\)).*/\1/p'
+}
+
+fail() {
+    echo "test_cli_device: FAIL — $1" >&2
+    exit 1
+}
+
+# --- reading a machine ------------------------------------------------------
+COLD=$(dev read temp | value_of)
+[ "$COLD" = "200" ] || fail "cold plant read $COLD, expected 200 (20.0 C)"
+
+# --- writing moves it -------------------------------------------------------
+dev write heater 30 >/dev/null || fail "write heater 30 rejected"
+sleep 1
+WARM=$(dev read temp | value_of)
+[ "$WARM" -gt "$COLD" ] || fail "heater on, temperature did not rise ($WARM)"
+[ "$WARM" -lt 900 ] || fail "30% should settle well below the trip ($WARM)"
+
+# --- the range is a refusal, not a clamp ------------------------------------
+if dev write heater 150 >/dev/null 2>&1; then
+    fail "out-of-range write was accepted"
+fi
+AFTER=$(dev read heater | value_of)
+[ "$AFTER" = "30" ] || fail "refused write still reached the machine ($AFTER)"
+
+# --- a read-only channel is refused -----------------------------------------
+if dev write temp 500 >/dev/null 2>&1; then
+    fail "write to a read-only channel was accepted"
+fi
+
+# --- an unknown channel is refused ------------------------------------------
+if dev read nosuch >/dev/null 2>&1; then
+    fail "unknown channel was accepted"
+fi
+
+# --- the machine's own interlock --------------------------------------------
+dev write heater 100 >/dev/null || fail "write heater 100 rejected"
+i=0
+TRIPPED=0
+while [ $i -lt 50 ]; do
+    TRIPPED=$(dev read tripped | value_of)
+    [ "$TRIPPED" = "1" ] && break
+    i=$((i + 1))
+    sleep 0.1
+done
+[ "$TRIPPED" = "1" ] || fail "100% heat never reached the over-temperature trip"
+
+# The device refuses while latched, and geistshell reports that refusal rather
+# than treating an unacknowledged command as done.
+if dev write heater 50 >/dev/null 2>&1; then
+    fail "machine accepted a heater command while tripped"
+fi
+
+dev write reset 1 >/dev/null || fail "reset rejected"
+[ "$(dev read tripped | value_of)" = "0" ] || fail "reset did not clear the trip"
+
+echo "test_cli_device: PASS"

--- a/test/test_device.c
+++ b/test/test_device.c
@@ -1,0 +1,200 @@
+/* Everything here runs without a socket. That is the design constraint, not a
+ * convenience: the refusals below are the safety layer, and a safety layer
+ * that needs a machine plugged in to be exercised is one that gets tested on
+ * the day it is needed. */
+
+#include "geistshell/device.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define LIT(s) (sizeof(s) - 1u), (s)
+
+static int test_parse_channel(void) {
+    struct spg_device_channel channel = {};
+
+    if (spg_device_parse_channel(LIT("heater:1:0:100:w"), &channel) != SPG_OK) {
+        return 1;
+    }
+    if (strcmp(channel.name, "heater") != 0 || channel.reg != 1u ||
+        channel.min != 0 || channel.max != 100 || !channel.writable) {
+        return 1;
+    }
+
+    if (spg_device_parse_channel(LIT("temp:0:-400:9000:r"), &channel) !=
+            SPG_OK ||
+        channel.min != -400 || channel.writable) {
+        return 1;
+    }
+
+    /* Rejected: no name to address, a range that is inside out, a mode that is
+     * neither r nor w, a missing field, and trailing text. The last one
+     * matters most — "heater:1:0:100:write" silently parsing as writable would
+     * accept an operator's typo as permission. */
+    const char *bad[] = {
+        ":1:0:100:w",           "heater:1:100:0:w",       "heater:1:0:100:x",
+        "heater:1:0:w",         "heater:1:0:100:w extra", "heater:1:0:100:",
+        "heater:70000:0:100:w",
+    };
+    for (size_t i = 0u; i < sizeof bad / sizeof bad[0]; i += 1u) {
+        if (spg_device_parse_channel(strlen(bad[i]), bad[i], &channel) ==
+            SPG_OK) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int test_table(void) {
+    struct spg_device dev = {};
+    spg_device_init(&dev);
+    if (dev.fd != -1 || dev.n_channels != 0u) {
+        return 1;
+    }
+
+    struct spg_device_channel heater = {
+        .name = "heater", .reg = 1u, .min = 0, .max = 100, .writable = true};
+    struct spg_device_channel temp = {
+        .name = "temp", .reg = 0u, .min = -400, .max = 9000};
+
+    if (spg_device_add_channel(&dev, &heater) != SPG_OK ||
+        spg_device_add_channel(&dev, &temp) != SPG_OK) {
+        return 1;
+    }
+    /* A duplicate name would make a write land on whichever register the table
+     * happened to list first. */
+    if (spg_device_add_channel(&dev, &heater) == SPG_OK) {
+        return 1;
+    }
+    if (spg_device_find(&dev, "heater") == nullptr ||
+        spg_device_find(&dev, "nope") != nullptr) {
+        return 1;
+    }
+
+    struct spg_device full = {};
+    spg_device_init(&full);
+    for (size_t i = 0u; i < SPG_DEVICE_MAX_CHANNELS; i += 1u) {
+        struct spg_device_channel ch = {.reg = (uint16_t)i, .max = 1};
+        ch.name[0]                   = 'a';
+        ch.name[1]                   = (char)('0' + (int)(i % 10u));
+        ch.name[2]                   = (char)('0' + (int)(i / 10u));
+        if (spg_device_add_channel(&full, &ch) != SPG_OK) {
+            return 1;
+        }
+    }
+    struct spg_device_channel overflow = {.name = "zz", .max = 1};
+    if (spg_device_add_channel(&full, &overflow) != SPG_E_LIMIT) {
+        return 1;
+    }
+    return 0;
+}
+
+/* The refusals, all reached with fd == -1. If any of these ever returns
+ * SPG_E_INVALID_STATE instead of its own code, the check has drifted back
+ * behind the connection test and stopped being testable. */
+static int test_write_refusals(void) {
+    struct spg_device dev = {};
+    spg_device_init(&dev);
+
+    struct spg_device_channel heater = {
+        .name = "heater", .reg = 1u, .min = 0, .max = 100, .writable = true};
+    struct spg_device_channel temp = {
+        .name = "temp", .reg = 0u, .min = -400, .max = 9000};
+    if (spg_device_add_channel(&dev, &heater) != SPG_OK ||
+        spg_device_add_channel(&dev, &temp) != SPG_OK) {
+        return 1;
+    }
+
+    if (spg_device_write(&dev, "nope", 1) != SPG_E_NOT_FOUND) {
+        return 1;
+    }
+    if (spg_device_write(&dev, "temp", 100) != SPG_E_POLICY_DENIED) {
+        return 1;
+    }
+    /* Out of range is refused, never clamped to 100. */
+    if (spg_device_write(&dev, "heater", 101) != SPG_E_LIMIT ||
+        spg_device_write(&dev, "heater", -1) != SPG_E_LIMIT) {
+        return 1;
+    }
+    /* In range, so it gets past every refusal and only then finds no socket. */
+    if (spg_device_write(&dev, "heater", 100) != SPG_E_INVALID_STATE) {
+        return 1;
+    }
+    return 0;
+}
+
+static int test_codec(void) {
+    uint8_t frame[SPG_MODBUS_FRAME_CAP] = {};
+
+    if (spg_modbus_encode_read(0x1234u, 7u, 0x0102u, frame) != 12u) {
+        return 1;
+    }
+    /* Big-endian on the wire whatever the host is. Spelled out byte by byte
+     * because that is the whole property being checked. */
+    const uint8_t expect_read[12] = {0x12, 0x34, 0x00, 0x00, 0x00, 0x06,
+                                     0x07, 0x03, 0x01, 0x02, 0x00, 0x01};
+    if (memcmp(frame, expect_read, sizeof expect_read) != 0) {
+        return 1;
+    }
+
+    if (spg_modbus_encode_write(1u, 1u, 1u, 60u, frame) != 12u) {
+        return 1;
+    }
+    const uint8_t expect_write[12] = {0x00, 0x01, 0x00, 0x00, 0x00, 0x06,
+                                      0x01, 0x06, 0x00, 0x01, 0x00, 0x3c};
+    if (memcmp(frame, expect_write, sizeof expect_write) != 0) {
+        return 1;
+    }
+
+    uint16_t value = 0u;
+    /* A read response carrying 235 — 23.5 C in tenths. */
+    const uint8_t response[11] = {0x00, 0x05, 0x00, 0x00, 0x00, 0x05,
+                                  0x01, 0x03, 0x02, 0x00, 0xeb};
+    if (spg_modbus_decode(sizeof response, response, 5u, &value) != SPG_OK ||
+        value != 235u) {
+        return 1;
+    }
+
+    /* Somebody else's reply. Accepting it would attribute one machine's
+     * reading to another on a gateway-fronted bus. */
+    if (spg_modbus_decode(sizeof response, response, 6u, &value) !=
+        SPG_E_REPLAY_MISMATCH) {
+        return 1;
+    }
+
+    /* Exception response: function | 0x80. The device refused. */
+    const uint8_t refusal[9] = {0x00, 0x05, 0x00, 0x00, 0x00,
+                                0x03, 0x01, 0x83, 0x02};
+    if (spg_modbus_decode(sizeof refusal, refusal, 5u, &value) != SPG_E_IO) {
+        return 1;
+    }
+
+    /* Truncated frames must not be read past their end. */
+    for (size_t n = 0u; n < sizeof response; n += 1u) {
+        uint16_t ignored = 0u;
+        if (spg_modbus_decode(n, response, 5u, &ignored) == SPG_OK) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int main(void) {
+    struct {
+        const char *name;
+        int (*fn)(void);
+    } cases[] = {
+        {"parse_channel", test_parse_channel},
+        {"table", test_table},
+        {"write_refusals", test_write_refusals},
+        {"codec", test_codec},
+    };
+    for (size_t i = 0u; i < sizeof cases / sizeof cases[0]; i += 1u) {
+        if (cases[i].fn() != 0) {
+            (void)fprintf(stderr, "test_device: FAIL — %s\n", cases[i].name);
+            return 1;
+        }
+    }
+    (void)printf("test_device: PASS\n");
+    return 0;
+}


### PR DESCRIPTION
Schritt 1 aus dem Geräteplan: die Portgrenze zur Maschine plus ein Transport, der sie beweisbar bewegt.

## Warum Modbus TCP und nicht GPIO

Ein Kanal muss auf simulierter und echter Maschine **denselben Codepfad** nehmen — sonst entsteht ein Simulationszweig, der verrottet, während niemand hinsieht. Genau daran ist die Lüfterklemmung aus Phase 15 gestorben.

Zwei Ebenen bieten das. `gpio-sim`/`i2c-stub` exportieren dasselbe `/dev/gpiochipN` wie echte Hardware; Modbus TCP ist das Protokoll, das echte Industriemaschinen sprechen — und OpenPLC, Factory I/O und unsere Anlage sprechen es auch. Modbus gewinnt als Einstieg, weil es über TCP läuft: entwickelbar und **verifizierbar ohne Hardware und ohne Linux**, was bei nicht erreichbarem Pi den Unterschied macht.

## Bereich heißt Ablehnung, nicht Klemmung

Ein Wert außerhalb des Bereichs wird verworfen und **nicht gesendet**. Klemmen führt einen Beinahe-Treffer eines bereits falschen Befehls aus — so gehen Maschinen an hilfsbereiter Software kaputt.

**Jede Ablehnung fällt vor dem Socket**, also mit `fd == -1` testbar. Der Unit-Test prüft genau das und schlägt an, wenn eine Prüfung wieder hinter den Verbindungstest driftet.

Dazu Timeout in beide Richtungen (eine schweigende Maschine darf die regelnde Schleife nicht anhalten), Prüfung der Transaktions-ID (fremde Antwort = `SPG_E_REPLAY_MISMATCH`, sonst ordnet man hinter einem Gateway Messungen der falschen Maschine zu) und Vergleich des Echos.

## Die simulierte Anlage

`examples/machine/plant/heater.py` — beheizter Kessel, Wärmeträgheit, Verlust, **rastende Übertemperaturabschaltung** bei 90 °C. Nur Standardbibliothek.

Die Abschaltung ist der Punkt: eine Anlage, die nur warm wird, belohnt jeden Regler, der die Heizung aufreißt, und misst nichts.

Zwei Modellfehler im ersten Lauf gefunden:

1. **Der Trip war unerreichbar** — bei 100 % lag das Gleichgewicht bei 50 °C, die Abschaltung bei 90 °C. Eine Grenze, die keine Eingabe erreicht, ist Dekoration.
2. **Der Simulator hat die Messung gestört** — `--speed` erhöhte die Tickrate; bei Faktor 40 waren das 800 Wakeups/s, genug um den lastempfindlichen `test_cli_machine_run` in derselben Suite kippen zu lassen. Jetzt skaliert `--speed` die Physik pro Tick, die Rate bleibt bei 20 Hz.

## Was bewusst fehlt

**Keine Agenten-Aktion.** Executor zuerst, Aktion zuletzt — die Reihenfolge, die beim Lüfter fehlte, wo `machine_set_fan` in Policy, Grammatik-Maske und CLI-Switch stand und nie etwas ausführte. Der Executor bewegt jetzt nachweislich etwas, also ist der nächste Schritt fällig — als eigener PR.

Ebenso offen: Skalierung pro Kanal, 32-Bit-/Float-Register, Coils, und ein Watchdog für den sicheren Zustand bei ausbleibendem Kontakt. Der Watchdog muss vor einer echten Maschine stehen.

## Verifikation

Clean-Build zweimal in Folge: **46 PASS, exit 0, null Warnungen.** `test_device` (Codec, Tabelle, Ablehnungen — ohne Socket) und `test_cli_device.sh` (echter Modbus-Verkehr gegen die Anlage: aufheizen, Bereichsablehnung, Schreibschutz, Trip auslösen, im Trip abgelehnt, Reset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)