### PR TITLE
test(machine): a fake backend, and a make test that survives a fresh clone

### DIFF
--- a/src/machine/backend_fake.c
+++ b/src/machine/backend_fake.c
@@ -1,0 +1,174 @@
+/* The backend for a machine that does not exist.
+ *
+ * Same contract as Linux and macOS, but every value comes from a struct a test
+ * sets. That is the point of the port boundary: the sampler above it — delta
+ * arithmetic, selection, truncation, the "unknown is not zero" rule — can be
+ * driven through cases no developer machine will produce on demand. A CPU
+ * counter that goes backwards across a reboot, a host with 900 processes, a
+ * sensor that reports SPG_E_IO: all of those are one assignment here.
+ *
+ * NOT built into libgeistshell. A test includes this file directly:
+ *
+ *     #include "../src/machine/backend_fake.c"
+ *
+ * which defines spg_backend_* in the test's own translation unit. The real
+ * backend then stays inside the static library and is never pulled in — the
+ * linker only takes an archive member that resolves something still missing.
+ * No Makefile entry, no link-order rule to remember, and the test file itself
+ * says which machine it runs against.
+ *
+ * Defaults are what a zeroed struct gives: SPG_OK everywhere, all counters 0,
+ * no processes. A test overrides the fields its case is about and leaves the
+ * rest alone.
+ *
+ * A getter given a failing status writes the sentinel and ignores the value
+ * beside it — same as every real backend, because the sampler passes its own
+ * field by pointer and does not look at the status. A fake that left a 0 there
+ * instead would make "unknown is never zero" pass in the test suite and fail
+ * on a host. */
+
+#include "geistshell/machine_backend.h"
+
+#include <string.h>
+
+#define SPG_FAKE_MAX_PROCESSES 1024u
+
+struct spg_backend_fake {
+    bool not_live; /* inverted so the zero value is a live machine */
+
+    enum spg_status         cpu_status;
+    struct spg_cpu_sample   cpu;
+    enum spg_status         memory_status;
+    struct spg_memory_sample memory;
+    enum spg_status         load_status;
+    uint64_t                load_1_cbp;
+    enum spg_status         temperature_status;
+    int64_t                 temperature_mc;
+    enum spg_status         frequency_status;
+    uint64_t                frequency_khz;
+    enum spg_status         throttle_status;
+    enum spg_throttle_state throttle;
+
+    enum spg_status           processes_status;
+    struct spg_process_sample processes[SPG_FAKE_MAX_PROCESSES];
+    size_t                    n_processes;
+    /* How many the machine has, which is not how many are in the array above:
+     * a backend reports a total larger than the snapshot it can fill, and the
+     * truncation path only runs when a test can say so. 0 means "same as
+     * n_processes". */
+    uint64_t total_processes;
+
+    /* spg_backend_process_identity answers from `processes` by default. Set
+     * identity_status to make the pid vanish (SPG_E_NOT_FOUND) or the lookup
+     * fail — the re-validation before signalling is the one caller, and it
+     * must be testable without a real process to race against. */
+    enum spg_status identity_status;
+};
+
+struct spg_backend_fake spg_fake = {};
+
+const char *spg_backend_name(void) { return "fake"; }
+bool        spg_backend_is_live(void) { return !spg_fake.not_live; }
+
+enum spg_status spg_backend_cpu(struct spg_cpu_sample *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = spg_fake.cpu_status == SPG_OK ? spg_fake.cpu
+                                         : (struct spg_cpu_sample){};
+    return spg_fake.cpu_status;
+}
+
+enum spg_status spg_backend_memory(struct spg_memory_sample *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = spg_fake.memory_status == SPG_OK
+               ? spg_fake.memory
+               : (struct spg_memory_sample){
+                     .total_bytes     = SPG_MACHINE_UNKNOWN,
+                     .used_bytes      = SPG_MACHINE_UNKNOWN,
+                     .swap_used_bytes = SPG_MACHINE_UNKNOWN};
+    return spg_fake.memory_status;
+}
+
+enum spg_status spg_backend_load(uint64_t *out_1_cbp) {
+    if (out_1_cbp == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out_1_cbp = spg_fake.load_status == SPG_OK ? spg_fake.load_1_cbp
+                                                : SPG_MACHINE_UNKNOWN;
+    return spg_fake.load_status;
+}
+
+enum spg_status spg_backend_temperature(int64_t *out_mc) {
+    if (out_mc == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out_mc = spg_fake.temperature_status == SPG_OK ? spg_fake.temperature_mc
+                                                    : SPG_MACHINE_UNKNOWN_S;
+    return spg_fake.temperature_status;
+}
+
+enum spg_status spg_backend_frequency_khz(uint64_t *out_khz) {
+    if (out_khz == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out_khz = spg_fake.frequency_status == SPG_OK ? spg_fake.frequency_khz
+                                                   : SPG_MACHINE_UNKNOWN;
+    return spg_fake.frequency_status;
+}
+
+enum spg_status spg_backend_throttle(enum spg_throttle_state *out) {
+    if (out == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out = spg_fake.throttle_status == SPG_OK ? spg_fake.throttle
+                                              : SPG_THROTTLE_UNKNOWN;
+    return spg_fake.throttle_status;
+}
+
+enum spg_status spg_backend_processes(const size_t              cap,
+                                      struct spg_process_sample out[],
+                                      size_t *out_n, uint64_t *out_total) {
+    if (out_n == nullptr || out_total == nullptr ||
+        (cap > 0u && out == nullptr)) {
+        return SPG_E_INVALID_ARG;
+    }
+    if (spg_fake.processes_status != SPG_OK) {
+        *out_n     = 0u;
+        *out_total = 0u;
+        return spg_fake.processes_status;
+    }
+    size_t n = spg_fake.n_processes;
+    if (n > cap) {
+        n = cap;
+    }
+    if (n > 0u) {
+        memcpy(out, spg_fake.processes, n * sizeof out[0]);
+    }
+    *out_n     = n;
+    *out_total = spg_fake.total_processes > 0u ? spg_fake.total_processes
+                                               : (uint64_t)spg_fake.n_processes;
+    return spg_fake.processes_status;
+}
+
+enum spg_status spg_backend_process_identity(const uint64_t pid,
+                                             uint64_t *out_start_identity) {
+    if (out_start_identity == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out_start_identity = 0u;
+    if (spg_fake.identity_status != SPG_OK) {
+        return spg_fake.identity_status;
+    }
+    for (size_t i = 0u; i < spg_fake.n_processes; i += 1u) {
+        if (spg_fake.processes[i].pid == pid) {
+            *out_start_identity = spg_fake.processes[i].start_identity;
+            return SPG_OK;
+        }
+    }
+    /* A pid the fake machine does not have is gone, not unsupported. The
+     * executor treats those differently and must never signal the first. */
+    return SPG_E_NOT_FOUND;
+}

--- a/test/test_machine_backend_fake.c
+++ b/test/test_machine_backend_fake.c
@@ -1,0 +1,239 @@
+/* The sampler against a machine that does not exist.
+ *
+ * Everything here was previously reachable only on a real host, where the
+ * numbers are whatever the CI runner happened to be doing. The cases below are
+ * the ones a developer machine will not produce on request: a counter that
+ * runs backwards, a host with more processes than the snapshot holds, a sensor
+ * that fails while its neighbours succeed.
+ *
+ * Including the fake backend replaces the platform one for this binary — see
+ * the note at the top of backend_fake.c. */
+
+#include "../src/machine/backend_fake.c"
+
+#include "geistshell/machine_state.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static void reset(void) { spg_fake = (struct spg_backend_fake){}; }
+
+static void put_process(const uint64_t pid, const char *name,
+                        const uint64_t cpu_time, const uint64_t rss) {
+    struct spg_process_sample *p = &spg_fake.processes[spg_fake.n_processes];
+    *p                           = (struct spg_process_sample){
+                                  .pid             = pid,
+                                  .start_identity  = pid * 10u,
+                                  .state           = 'S',
+                                  .cpu_time        = cpu_time,
+                                  .cpu_bp          = SPG_MACHINE_UNKNOWN,
+                                  .rss_bytes       = rss,
+                                  .profile_index   = SPG_PROCESS_NO_PROFILE,
+    };
+    (void)snprintf(p->name, sizeof p->name, "%s", name);
+    spg_fake.n_processes += 1u;
+}
+
+/* An unported platform is not a broken one: the call fails, the snapshot stays
+ * honest, and nothing above the boundary invents a number. */
+static int test_not_live(void) {
+    reset();
+    spg_fake.not_live = true;
+    spg_fake.cpu      = (struct spg_cpu_sample){.idle = 1u, .total = 2u};
+
+    struct spg_machine_state s = {};
+    if (spg_machine_sample(1000u, nullptr, &s) != SPG_E_UNSUPPORTED) {
+        return 1;
+    }
+    if (s.timestamp_ns != 1000u || s.cpu_utilisation_bp != SPG_MACHINE_UNKNOWN ||
+        s.memory.total_bytes != SPG_MACHINE_UNKNOWN || s.n_processes != 0u) {
+        return 1;
+    }
+    return 0;
+}
+
+/* Two samples, a known delta: 30% busy. On a live host this number is whatever
+ * the machine was doing between the two calls. */
+static int test_utilisation_from_delta(void) {
+    reset();
+    spg_fake.cpu = (struct spg_cpu_sample){.idle = 700u, .total = 1000u};
+    const struct spg_cpu_sample prev = {.idle = 0u, .total = 0u};
+
+    struct spg_machine_state s = {};
+    if (spg_machine_sample(1u, &prev, &s) != SPG_OK) {
+        return 1;
+    }
+    if (s.cpu_utilisation_bp != 3000u) {
+        return 1;
+    }
+    return 0;
+}
+
+/* Suspend/resume resets the kernel counters. The rule is unknown, not a
+ * fabricated spike — untestable on a host without actually suspending it. */
+static int test_counter_reset(void) {
+    reset();
+    spg_fake.cpu = (struct spg_cpu_sample){.idle = 5u, .total = 10u};
+    const struct spg_cpu_sample prev = {.idle = 700u, .total = 1000u};
+
+    struct spg_machine_state s = {};
+    if (spg_machine_sample(1u, &prev, &s) != SPG_OK) {
+        return 1;
+    }
+    if (s.cpu_utilisation_bp != SPG_MACHINE_UNKNOWN) {
+        return 1;
+    }
+    return 0;
+}
+
+/* One sensor missing must not cost the others. The failing field is unknown,
+ * never zero: a 0°C reading and a missing thermal zone are different machines.
+ */
+static int test_partial_sensors(void) {
+    reset();
+    spg_fake.memory = (struct spg_memory_sample){.total_bytes     = 16u << 20,
+                                                 .used_bytes      = 8u << 20,
+                                                 .swap_used_bytes = 0u};
+    spg_fake.temperature_status = SPG_E_UNSUPPORTED;
+    spg_fake.frequency_status   = SPG_E_IO;
+    spg_fake.load_1_cbp         = 250u;
+
+    struct spg_machine_state s = {};
+    if (spg_machine_sample(1u, nullptr, &s) != SPG_OK) {
+        return 1;
+    }
+    if (s.memory.total_bytes != (16u << 20) || s.load_1_cbp != 250u) {
+        return 1;
+    }
+    if (s.temperature_mc != SPG_MACHINE_UNKNOWN_S ||
+        s.cpu_freq_khz != SPG_MACHINE_UNKNOWN) {
+        return 1;
+    }
+    return 0;
+}
+
+/* Kernel threads: no memory, no measurable CPU, no profile. They are dropped
+ * before selection — the case that filled 58 of 64 context slots on a Pi. */
+static int test_idle_processes_dropped(void) {
+    reset();
+    put_process(1u, "init", 0u, 4096u);
+    for (uint64_t pid = 100u; pid < 140u; pid += 1u) {
+        put_process(pid, "kworker", 0u, 0u);
+    }
+
+    struct spg_machine_state s = {};
+    if (spg_machine_sample(1u, nullptr, &s) != SPG_OK) {
+        return 1;
+    }
+    if (s.n_processes != 1u || strcmp(s.processes[0].name, "init") != 0) {
+        return 1;
+    }
+    return 0;
+}
+
+/* A machine with more processes than the snapshot holds. The consumer must be
+ * told the list is not the machine. */
+static int test_truncation_reported(void) {
+    reset();
+    for (uint64_t i = 0u; i < SPG_MACHINE_MAX_PROCESSES + 10u; i += 1u) {
+        put_process(1000u + i, "worker", 0u, (i + 1u) * 4096u);
+    }
+    spg_fake.total_processes = 900u; /* far beyond what was sampled */
+
+    struct spg_machine_state s = {};
+    if (spg_machine_sample(1u, nullptr, &s) != SPG_OK) {
+        return 1;
+    }
+    if (s.n_processes != SPG_MACHINE_MAX_PROCESSES || !s.processes_truncated) {
+        return 1;
+    }
+    if (s.process_count != 900u) {
+        return 1;
+    }
+    return 0;
+}
+
+/* Per-process utilisation is a ratio against the machine's own delta, and a
+ * recycled pid must not inherit the counter of the process it replaced. */
+static int test_process_utilisation(void) {
+    reset();
+    spg_fake.cpu = (struct spg_cpu_sample){.idle = 0u, .total = 1000u};
+    put_process(42u, "busy", 250u, 4096u);
+    put_process(43u, "recycled", 900u, 4096u);
+
+    struct spg_process_sample prev[2] = {
+        {.pid            = 42u,
+         .start_identity = 420u,
+         .cpu_time       = 0u},
+        /* same pid, different start: a different process wearing its number */
+        {.pid            = 43u,
+         .start_identity = 999u,
+         .cpu_time       = 0u},
+    };
+
+    const struct spg_cpu_sample prev_cpu = {.idle = 0u, .total = 0u};
+    struct spg_machine_state    s        = {};
+    if (spg_machine_sample_with_processes(1u, &prev_cpu, 2u, prev, nullptr,
+                                          &s) != SPG_OK) {
+        return 1;
+    }
+    const struct spg_process_sample *busy =
+        spg_process_find(s.n_processes, s.processes, 42u, 420u);
+    const struct spg_process_sample *recycled =
+        spg_process_find(s.n_processes, s.processes, 43u, 430u);
+    if (busy == nullptr || recycled == nullptr) {
+        return 1;
+    }
+    if (busy->cpu_bp != 2500u) { /* 250 of 1000 ticks */
+        return 1;
+    }
+    if (recycled->cpu_bp != SPG_MACHINE_UNKNOWN) {
+        return 1;
+    }
+    return 0;
+}
+
+/* The re-validation the executor does immediately before signalling. A pid the
+ * machine no longer has must read as gone, never as an error to ignore. */
+static int test_process_identity(void) {
+    reset();
+    put_process(42u, "busy", 10u, 4096u);
+
+    uint64_t identity = 0u;
+    if (spg_backend_process_identity(42u, &identity) != SPG_OK ||
+        identity != 420u) {
+        return 1;
+    }
+    if (spg_backend_process_identity(43u, &identity) != SPG_E_NOT_FOUND ||
+        identity != 0u) {
+        return 1;
+    }
+    return 0;
+}
+
+int main(void) {
+    const struct {
+        const char *name;
+        int (*fn)(void);
+    } cases[] = {
+        {"not_live", test_not_live},
+        {"utilisation_from_delta", test_utilisation_from_delta},
+        {"counter_reset", test_counter_reset},
+        {"partial_sensors", test_partial_sensors},
+        {"idle_processes_dropped", test_idle_processes_dropped},
+        {"truncation_reported", test_truncation_reported},
+        {"process_utilisation", test_process_utilisation},
+        {"process_identity", test_process_identity},
+    };
+    int failures = 0;
+    for (size_t i = 0u; i < sizeof cases / sizeof cases[0]; i += 1u) {
+        if (cases[i].fn() != 0) {
+            printf("test_machine_backend_fake: FAIL %s\n", cases[i].name);
+            failures += 1;
+        }
+    }
+    if (failures == 0) {
+        printf("test_machine_backend_fake: PASS\n");
+    }
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## backend_fake.c

The port boundary made the sampler testable in principle and nothing took it up: every test above it either ran against the real host or skipped on `spg_backend_is_live()`. The cases that matter are the ones no developer machine produces on request.

`src/machine/backend_fake.c` is the fourth backend — same contract, values from a struct the test sets. It is **not** in the library. A test includes the `.c`:

```c
#include "../src/machine/backend_fake.c"
```

which defines `spg_backend_*` in its own translation unit, so the linker never pulls the platform member out of the archive. No Makefile entry, no link-order rule to remember, and the test file itself says which machine it runs against.

A failing getter writes the sentinel rather than the value beside it. That is not decoration: `telemetry_host.c` hands its own field to the backend by pointer and ignores the status, so a fake that left a `0` there would make "unknown is never zero" pass in the suite and fail on a host.

New in `test/test_machine_backend_fake.c`, none of it reachable before:

- unported platform → `SPG_E_UNSUPPORTED`, snapshot stays unknown
- counter reset after suspend → unknown, not a fabricated spike
- one sensor fails, its neighbours still answer
- ~40 kernel threads with no RSS and no CPU → filtered (the Pi case)
- 900 processes against a 64-slot snapshot → `processes_truncated`
- recycled pid, same number and a different `start_identity` → `cpu_bp` unknown instead of inherited

## make test on a fresh clone

Three things stood between `git clone` and a passing suite, none of them in the tests:

1. **geist's headers were needed before the rule that fetches them ran.** Nothing said an object depends on the engine, so the first compile died on `geist.h`. Now an order-only prerequisite — a relinked `libgeist.a` is not a reason to recompile the world.
2. **`GEIST_TARGET` guessed wrong.** It is detected by a script inside the engine and expanded before any rule can fetch it; the fallback said `mac`, so a fresh clone built every object without OpenMP and threw the tree away on the next `make`. It now asks the same three questions itself.
3. **`test` never built `geistshell-chat`**, which two of the cli tests run.

Two make 3.81 traps on the way (Xcode still ships 3.81): it does not fold a backslash-newline inside `$(shell ...)`, and it ends the function at the first unbalanced `)` — which a `case` pattern is. Both noted at the line.

## Verification

Run twice from nothing, both exit 0 with 45 PASS and one deliberate SKIP (`test_cli_machine_recovery`, no process signals in this sandbox):

- a real `git clone` into an empty directory — 1:02
- this branch with `build/` removed and no `deps/geist` at all, so `sync-engine` cloned libgeist v0.8.2 from GitHub as the first step of `make test` — 1:42

Warm tree green too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)