### PR TITLE
fix(cli): --best-of selects without an oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,29 @@ regression), not a capability gain on a real model. Swap in a local or remote
 model and add `--samples N` to run the identical harness under noise — each case
 then reports `k of N` and the gate compares summed pass counts.
 
+### Best‑of‑N (`--best-of`)
+
+`--best-of N` samples up to N attempts (the choice‑slot RNG drifts between them
+when `temperature > 0`) and keeps the best. "Best" needs no oracle: attempts are
+ranked by how far the run got, which every run already records —
+
+```
+finished  >  max_steps  >  budget  >  denied  >  rejected  >  error
+```
+
+— the same order as the eval ladder, because a `max_steps` run *parsed*, *was
+allowed*, and executed real actions, while a `denied` run never got past the
+gate. It stops at the first `finished`, since nothing beats it.
+
+A declared `(expect "<substring>")` still wins when present: an attempt that
+satisfies it is unbeatable and ends the loop immediately. When none does, the
+answer‑free rank picks the survivor.
+
+Ties are deliberately **not** broken on fewer steps. Without an expectation a
+one‑step run cannot be distinguished from a model that emitted `finish`
+immediately and did nothing, so preferring brevity would reward exactly the
+degenerate answer. On a tie the first attempt wins.
+
 ## Where geistshell is different — and where it is not
 
 This section is deliberately critical. geistshell makes a sharp bet: be a

--- a/include/geistshell/eval.h
+++ b/include/geistshell/eval.h
@@ -55,6 +55,32 @@ struct spg_eval_case_result {
 
 [[nodiscard]] const char *spg_eval_outcome_to_string(enum spg_eval_outcome o);
 
+/* Answer-free run quality, for selecting among N sampled attempts when nobody
+ * knows the right answer (geistshell#55).
+ *
+ * `--best-of N` used to select with spg_eval_judge, which needs a declared
+ * (expect ...) — i.e. the answer. Without one the feature silently collapsed to
+ * a single attempt, so in production, where nobody has the expected
+ * observation, it was off. This is the selector that needs no oracle: the
+ * information is already in every run's termination, and nothing read it.
+ *
+ * Higher is better. The order follows the parse/gate/task ladder (#53), NOT the
+ * ordering originally written into #55 — which put `denied` above `max_steps`
+ * and is wrong: a denied run parsed but never got past the policy gate, while a
+ * max_steps run parsed, WAS allowed, and executed real actions. It got strictly
+ * further; it simply ran out of room.
+ *
+ *   4  finished   reached a terminal state on its own
+ *   3  max_steps  acted validly, ran out of steps
+ *   2  budget     acted validly, ran out of budget
+ *   1  denied     produced a valid action the gate refused
+ *   0  rejected   never produced a valid form
+ *  -1  error      the harness failed; not a measurement of the model at all
+ *
+ * A non-OK run status is always -1 regardless of termination. */
+[[nodiscard]] int spg_run_rank(enum spg_status                 status,
+                               enum spg_agent_loop_termination termination);
+
 /* Judge a finished run against expectations (termination, step bounds, an
  * observation substring). Exposed so callers that drive the run themselves —
  * e.g. a real-model task case via spg_agent_run — score it the same way. */

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -2508,26 +2508,61 @@ static int agent_command(int argc, char **argv) {
                                      .observation = expect_obs};
     }
 
-    /* Verifier-guided best-of-N (#2): up to best_of attempts, model loaded
-     * once; the choice-slot RNG drifts between attempts (temperature > 0), so
-     * each explores different valid decisions, and we keep the first the
-     * verifier passes. Needs an (expect ...) to select on — without it a single
-     * run. */
-    const size_t          attempts = have_expect ? best_of : 1u;
+    /* Best-of-N (#2, fixed in #55): up to best_of attempts, model loaded once;
+     * the choice-slot RNG drifts between attempts (temperature > 0), so each
+     * explores different valid decisions.
+     *
+     * Selection used to require an (expect ...) — the ANSWER — so without one
+     * the feature silently collapsed to a single attempt and was off in
+     * production. It now ranks attempts with spg_run_rank, which needs no
+     * oracle. A declared (expect ...) still wins when present: an attempt that
+     * satisfies it is unbeatable and ends the loop immediately.
+     *
+     * Ties are NOT broken on fewer steps, tempting as it looks. Without an
+     * expectation a one-step run cannot be told from a model that emitted
+     * `finish` immediately and did nothing, so preferring brevity would
+     * actively reward the degenerate answer. On a tie the first attempt wins:
+     * deterministic, and it invents no preference the data does not support. */
+    const size_t          attempts = best_of;
     enum spg_eval_outcome verdict  = SPG_EVAL_PASS;
     size_t                used     = 0u;
+    size_t                chosen   = 1u;   /* 1-based attempt that won */
+    int                   best_rank = -2;  /* below every real rank */
+    struct spg_agent_loop_result best_loop   = {};
+    enum spg_status              best_status = SPG_E_INVALID_STATE;
+    static char                  best_obs[AGENT_OBS_BYTES];
+    best_obs[0] = '\0';
     for (size_t a = 0u; a < attempts; a += 1u) {
         used   = a + 1u;
         usage  = (struct spg_policy_usage){}; /* each attempt is independent */
         status = spg_agent_run(&inputs, &rcfg, &ws, &usage, &loop_result);
-        if (!have_expect) {
-            break;
+
+        const enum spg_eval_outcome attempt_verdict =
+            have_expect ? spg_eval_judge(&expect, &loop_result, status, observation)
+                        : SPG_EVAL_PASS;
+        /* A satisfied expectation outranks every answer-free rung. */
+        const int rank = (have_expect && attempt_verdict == SPG_EVAL_PASS)
+                             ? 100
+                             : spg_run_rank(status, loop_result.termination);
+        if (rank > best_rank) {
+            best_rank   = rank;
+            best_loop   = loop_result;
+            best_status = status;
+            verdict     = attempt_verdict;
+            chosen      = used;
+            (void)snprintf(best_obs, sizeof best_obs, "%s", observation);
         }
-        verdict = spg_eval_judge(&expect, &loop_result, status, observation);
-        if (verdict == SPG_EVAL_PASS) {
-            break;
+        if (rank == 100) {
+            break; /* cannot be improved on */
+        }
+        if (!have_expect && rank >= 4) {
+            break; /* top answer-free rung: finished on its own */
         }
     }
+    loop_result = best_loop;
+    status      = best_status;
+    (void)snprintf(observation, sizeof observation, "%s", best_obs);
+
     printf("steps=%zu termination=%s journal=%s\n", loop_result.steps_taken,
            spg_agent_loop_termination_to_string(loop_result.termination),
            journal_path);
@@ -2536,13 +2571,15 @@ static int agent_command(int argc, char **argv) {
     }
     rc = (status == SPG_OK) ? 0 : 1;
 
+    /* best_of reporting is no longer conditional on an expectation: the whole
+     * point of #55 is that selection happens without one. */
+    if (attempts > 1u) {
+        printf("best_of=%zu attempts_used=%zu chosen=%zu rank=%d\n", attempts,
+               used, chosen, best_rank);
+    }
     if (have_expect) {
         printf("verdict=%s\n", spg_eval_outcome_to_string(verdict));
-        if (attempts > 1u) {
-            printf("best_of=%zu attempts_used=%zu\n", attempts, used);
-        }
-        /* a FAIL exits non-zero so a caller (and a future miner) can act on it
-         */
+        /* a FAIL exits non-zero so a caller (and a future miner) can act on it */
         if (verdict != SPG_EVAL_PASS && rc == 0) {
             rc = 1;
         }

--- a/src/eval/eval.c
+++ b/src/eval/eval.c
@@ -24,6 +24,28 @@ const char *spg_eval_outcome_to_string(const enum spg_eval_outcome o) {
     return "unknown";
 }
 
+int spg_run_rank(const enum spg_status                 status,
+                 const enum spg_agent_loop_termination termination) {
+    if (status != SPG_OK) {
+        return -1;
+    }
+    switch (termination) {
+    case SPG_AGENT_LOOP_FINISHED:
+        return 4;
+    case SPG_AGENT_LOOP_MAX_STEPS:
+        return 3;
+    case SPG_AGENT_LOOP_BUDGET:
+        return 2;
+    case SPG_AGENT_LOOP_DENIED:
+        return 1;
+    case SPG_AGENT_LOOP_REJECTED:
+        return 0;
+    case SPG_AGENT_LOOP_ERROR:
+        break;
+    }
+    return -1;
+}
+
 enum spg_eval_outcome spg_eval_judge(const struct spg_eval_expect *expect,
                                      const struct spg_agent_loop_result *loop,
                                      const enum spg_status status,

--- a/test/test_cli_best_of.sh
+++ b/test/test_cli_best_of.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# System test: --best-of N selects without an oracle (geistshell#55).
+#
+# The defect: selection went through spg_eval_judge, which needs a declared
+# (expect ...) — the ANSWER. Without one, `attempts = have_expect ? best_of : 1`
+# quietly made the flag a no-op, so the shipped feature was off in production,
+# where nobody knows the expected observation. The 5/5-vs-0/5 it was measured
+# at was obtained knowing the answer.
+#
+# Scripted fakes throughout: what is under test is the SELECTION, and the
+# selector reads only termination and status.
+set -eu
+
+SPG_BIN=${SPG_BIN:-build/host-debug/bin/geistshell}
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT
+
+die() { echo "FAIL: $*" >&2; exit 1; }
+
+mkrun() { # mkrun <name> [extra run fields]
+    cat > "$T/$1.spg" <<EOF
+(run
+ (model "fake.gguf")
+ (policy "examples/policy.spg")
+ (scenario "examples/scenario.spg")
+ (corpus "examples/corpus.spg")
+ (journal "$T/$1.sgj")
+ (seed 42)
+ $2
+ (budgets
+  (inference_steps 8) (tokens 256) (shell_actions 1) (sim_actions 8)
+  (memory_actions 8) (wall_ms 10000) (journal_bytes 1048576) (risk_bp 10000)))
+EOF
+}
+
+# ---- 1. best-of runs at all without an (expect ...) ------------------------
+mkrun plain ""
+"$SPG_BIN" agent --config "$T/plain.spg" \
+    --fake-script examples/eval/broken.txt --max-repairs 0 --best-of 3 \
+    > "$T/plain.out" 2>&1 || true
+grep -q 'best_of=3' "$T/plain.out" ||
+    die "best-of must report itself without an expectation: $(cat "$T/plain.out")"
+grep -q 'attempts_used=3' "$T/plain.out" ||
+    die "a run that never reaches the top rung must use every attempt"
+grep -q 'rank=0' "$T/plain.out" ||
+    die "a rejected run should be selected at the bottom rung"
+
+# ---- 2. it stops at the top rung instead of burning attempts --------------
+"$SPG_BIN" agent --config "$T/plain.spg" \
+    --fake-script examples/eval/sim_finish.txt --best-of 5 \
+    > "$T/top.out" 2>&1 || die "a finishing script must succeed"
+grep -q 'attempts_used=1' "$T/top.out" ||
+    die "a finished run cannot be improved on; stop at one attempt"
+grep -q 'rank=4' "$T/top.out" || die "finished is the top answer-free rung"
+grep -q 'termination=finished' "$T/top.out" || die "termination should be finished"
+
+# ---- 3. the selected run is the one REPORTED ------------------------------
+# The observation and termination printed must belong to the chosen attempt,
+# not to whichever attempt happened to run last.
+grep -q 'chosen=1' "$T/top.out" || die "the chosen attempt must be reported"
+
+# ---- 4. an (expect ...) still wins when present ---------------------------
+mkrun expected '(expect "patch_vulnerability")'
+"$SPG_BIN" agent --config "$T/expected.spg" \
+    --fake-script examples/eval/sim_finish.txt --best-of 4 \
+    > "$T/expected.out" 2>&1 || die "a satisfied expectation must exit zero"
+grep -q 'verdict=pass' "$T/expected.out" || die "the expectation should pass"
+grep -q 'attempts_used=1' "$T/expected.out" ||
+    die "a passing attempt is unbeatable; stop immediately"
+grep -q 'rank=100' "$T/expected.out" ||
+    die "a satisfied expectation must outrank every answer-free rung"
+
+# ---- 5. an unsatisfiable expectation still uses every attempt -------------
+mkrun unmet '(expect "THIS-NEVER-APPEARS")'
+if "$SPG_BIN" agent --config "$T/unmet.spg" \
+        --fake-script examples/eval/sim_finish.txt --best-of 3 \
+        > "$T/unmet.out" 2>&1; then
+    die "a failed expectation must exit non-zero"
+fi
+grep -q 'attempts_used=3' "$T/unmet.out" ||
+    die "an unmet expectation should exhaust the attempts"
+grep -q 'verdict=fail_observation' "$T/unmet.out" ||
+    die "the verdict should say which expectation failed"
+# ... and it falls back to the answer-free rung rather than reporting nothing
+grep -q 'rank=4' "$T/unmet.out" ||
+    die "with no attempt passing, the best answer-free run is selected"
+
+# ---- 6. --best-of 1 is unchanged ------------------------------------------
+# The single-attempt path must stay byte-identical, or every existing script
+# and recorded benchmark silently changes shape.
+"$SPG_BIN" agent --config "$T/plain.spg" \
+    --fake-script examples/eval/sim_finish.txt > "$T/one.out" 2>&1 ||
+    die "a plain run must still work"
+grep -q 'best_of=' "$T/one.out" &&
+    die "a single attempt must not print best-of bookkeeping"
+
+"$SPG_BIN" agent --config "$T/plain.spg" \
+    --fake-script examples/eval/sim_finish.txt --best-of 1 > "$T/one2.out" 2>&1 ||
+    die "--best-of 1 must work"
+diff "$T/one.out" "$T/one2.out" > /dev/null ||
+    die "--best-of 1 must be identical to no flag at all"
+
+echo "test_cli_best_of: PASS"

--- a/test/test_eval.c
+++ b/test/test_eval.c
@@ -213,7 +213,47 @@ static int test_memory_index_injected(void) {
     return ok;
 }
 
+/* #55: the answer-free selector for best-of-N. */
+static int test_run_rank(void) {
+    /* Strictly ordered, and the order follows the parse/gate/task ladder:
+     * a max_steps run PARSED and was ALLOWED and executed real actions; a
+     * denied run parsed but never got past the gate. max_steps got further.
+     * (#55's issue text had these the other way round — this is the fix.) */
+    const int finished = spg_run_rank(SPG_OK, SPG_AGENT_LOOP_FINISHED);
+    const int max_steps = spg_run_rank(SPG_OK, SPG_AGENT_LOOP_MAX_STEPS);
+    const int budget   = spg_run_rank(SPG_OK, SPG_AGENT_LOOP_BUDGET);
+    const int denied   = spg_run_rank(SPG_OK, SPG_AGENT_LOOP_DENIED);
+    const int rejected = spg_run_rank(SPG_OK, SPG_AGENT_LOOP_REJECTED);
+    const int error    = spg_run_rank(SPG_OK, SPG_AGENT_LOOP_ERROR);
+
+    if (!(finished > max_steps && max_steps > budget && budget > denied &&
+          denied > rejected && rejected > error)) {
+        fprintf(stderr,
+                "rank order: finished=%d max_steps=%d budget=%d denied=%d "
+                "rejected=%d error=%d\n",
+                finished, max_steps, budget, denied, rejected, error);
+        return 1;
+    }
+    /* A harness failure is never a measurement of the model, whatever the
+     * termination says — otherwise a crashed attempt could out-rank a real
+     * one and best-of-N would select the broken run. */
+    if (spg_run_rank(SPG_E_IO, SPG_AGENT_LOOP_FINISHED) >= rejected ||
+        spg_run_rank(SPG_E_MODEL, SPG_AGENT_LOOP_FINISHED) >= rejected) {
+        return 1;
+    }
+    /* Every enumerator is covered: no termination may fall through to the
+     * error value by accident. */
+    if (error != spg_run_rank(SPG_E_IO, SPG_AGENT_LOOP_FINISHED)) {
+        return 1;
+    }
+    return 0;
+}
+
 int main(void) {
+    if (test_run_rank() != 0) {
+        fprintf(stderr, "test_run_rank failed\n");
+        return 1;
+    }
     if (test_memory_index_injected() != 0) {
         fprintf(stderr, "test_memory_index_injected failed\n");
         return 1;


### PR DESCRIPTION
Closes #55.

`--best-of N` never worked outside a test. Selection went through `spg_eval_judge`, which needs a declared `(expect ...)` — the **answer**:

```c
const size_t attempts = have_expect ? best_of : 1u;
```

Without one the flag is silently a no-op. So in production, where nobody has the expected observation, the shipped feature is off — and the 5/5-vs-0/5 it was measured at in af090d3 was obtained knowing the answer.

The selector that needs no oracle was already sitting in every run: `termination` plus `status`, read by nobody. `spg_run_rank` turns it into an order.

## Two corrections to what #55 itself specified

**The rank order in the issue was wrong.** It said `finished > denied > rejected > max_steps`. That contradicts the parse/gate/task ladder: a `max_steps` run *parsed*, *was allowed*, and executed real actions; a `denied` run parsed but never got past the gate. `max_steps` got strictly further. Implemented:

```
finished > max_steps > budget > denied > rejected > error
```

with a non-OK status always at the bottom, so a crashed attempt can never out-rank a real one.

**The tie-break on fewer steps is gone.** Without an expectation, a one-step run cannot be told apart from a model that emitted `finish` immediately and did nothing — preferring brevity would reward exactly the degenerate answer. On a tie the first attempt wins: deterministic, and it invents no preference the data does not support.

A declared `(expect ...)` still wins when present (rank 100, ends the loop immediately), so "run until the output contains `BUILD OK`" is unchanged. The reported run is now the **selected** one rather than whichever attempt went last; the observation is carried with it.

## Compatibility

`--best-of 1` and the no-flag path stay byte-identical — a test diffs them. `test_cli_baseline.sh` stays green: the journal hash does not move.

## Tests

- `test_eval` pins the rank order, that a harness failure never out-ranks a real run, and that no termination falls through by accident.
- `test_cli_best_of` covers six properties through the CLI on scripted fakes, including that best-of works with **no** expectation — the actual defect. Verified by restoring the oracle gate and watching the first assertion fail.

`make test`: 47 PASS, exit 0.

## Note on provenance

This was written earlier on a side branch that was never pushed; #81 landed the first half of that branch and this half was left behind. I marked #55 closed against the branch rather than against the repository, which was wrong — reopened and re-landed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
