### PR TITLE
ci: three platforms, and skips that cannot hide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # libomp AND the target it unlocks. detect-target.sh looks for
+      # libomp.dylib under a fixed prefix and silently falls back to the plain
+      # `mac` target when it is absent — a target geistlib's own CI never
+      # builds, and where v0.8.2 has a -Werror unused-function break. Pin both
+      # rather than hope the default prefix matches.
       - name: Install deps (macOS)
         if: runner.os == 'macOS'
-        run: brew install libomp
+        run: |
+          brew install libomp
+          echo "LIBOMP_PREFIX=$(brew --prefix libomp)" >> "$GITHUB_ENV"
+          echo "GEIST_TARGET=mac-omp" >> "$GITHUB_ENV"
 
       - name: Install deps (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,110 @@
+name: CI
+
+# geistshell had no CI at all (#105). Every "make test green" was one person on
+# one machine — and 8 of the 84 test files only execute on Linux (/proc,
+# SIGSTOP, __linux__), so on that machine they step aside and the suite still
+# exits 0. Three platforms, and skipped=0 required where the tests can run.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # The development host. Catches nothing the author would not see, but
+          # pins what people actually run — and it is the leg where the machine
+          # backend's tests legitimately skip.
+          - name: macOS arm64
+            runner: macos-15
+            expect_skips: allowed
+
+          # The deployment target (Raspberry Pi 5 is ARM64 Linux). This is the
+          # only leg where the /proc + signal tests execute at all, so it is the
+          # one that must not skip.
+          - name: Linux arm64
+            runner: ubuntu-24.04-arm
+            expect_skips: none
+
+          # The portable reference. detect-target.sh returns `linux` here, a
+          # target geistshell's Makefile had no link flags for until #105 —
+          # nothing had ever built this repo on x86_64.
+          - name: Linux x86_64
+            runner: ubuntu-latest
+            expect_skips: none
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install deps (macOS)
+        if: runner.os == 'macOS'
+        run: brew install libomp
+
+      - name: Install deps (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            clang libopenblas-dev libomp-dev libfftw3-dev
+
+      # A clean tree, always. #99 found the suite passing on a geistshell-chat
+      # binary left over from an earlier build that no rule promised; an
+      # incremental CI would have reproduced that bug rather than caught it.
+      - name: Build (host-debug = ASan + UBSan)
+        run: make
+
+      # pipefail, or `tee` reports success and every failing test is swallowed —
+      # the same defect this file exists to prevent, one layer up. GitHub's
+      # default shell does not set it.
+      - name: Test
+        shell: bash
+        run: |
+          set -o pipefail
+          make test | tee test.log
+
+      # A run whose Linux-only tests all stepped aside must not look like a run
+      # where they passed. On macOS a skip is expected and fine; on Linux it
+      # means the thing under test did not run.
+      - name: No silent skips
+        run: |
+          summary=$(grep '^test summary:' test.log || true)
+          echo "$summary"
+          [ -n "$summary" ] || { echo "::error::make test printed no summary"; exit 1; }
+          skipped=$(printf '%s' "$summary" | sed 's/.*skipped=//')
+          if [ "${{ matrix.expect_skips }}" = "none" ] && [ "$skipped" != "0" ]; then
+            echo "::error::$skipped test(s) skipped on a platform where they should run"
+            grep ': SKIP' test.log || true
+            exit 1
+          fi
+
+      # The determinism canary, called out separately so a hash drift is
+      # readable in the check list instead of buried in 47 lines of output.
+      - name: Baseline journal hash
+        run: SPG_BIN=build/host-debug/bin/geistshell sh test/test_cli_baseline.sh
+
+  release-build:
+    # host-debug carries ASan/UBSan; -O3 -DNDEBUG is a different compile and has
+    # its own warnings. The Pi runs this one, so it cannot be untested.
+    name: host-release builds
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            clang libopenblas-dev libomp-dev libfftw3-dev
+      - run: make host-release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,17 +48,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # libomp AND the target it unlocks. detect-target.sh looks for
-      # libomp.dylib under a fixed prefix and silently falls back to the plain
-      # `mac` target when it is absent — a target geistlib's own CI never
-      # builds, and where v0.8.2 has a -Werror unused-function break. Pin both
-      # rather than hope the default prefix matches.
+      # LIBOMP_PREFIX, because detection looks for libomp.dylib under a fixed
+      # path and falls back to the plain `mac` target when it is absent — a
+      # target geistlib's own CI never builds, and where v0.8.2 breaks on a
+      # -Werror unused function. The prefix on a runner is not guaranteed to be
+      # the default one, so it is read from brew rather than assumed.
       - name: Install deps (macOS)
         if: runner.os == 'macOS'
         run: |
           brew install libomp
           echo "LIBOMP_PREFIX=$(brew --prefix libomp)" >> "$GITHUB_ENV"
-          echo "GEIST_TARGET=mac-omp" >> "$GITHUB_ENV"
 
       - name: Install deps (Linux)
         if: runner.os == 'Linux'
@@ -79,6 +78,11 @@ jobs:
       # pipefail, or `tee` reports success and every failing test is swallowed —
       # the same defect this file exists to prevent, one layer up. GitHub's
       # default shell does not set it.
+      # The target is printed so a wrong one is visible in the log instead of
+      # surfacing as a confusing error inside libgeist.
+      - name: Show build target
+        run: sh scripts/detect-target.sh
+
       - name: Test
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,16 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            clang libopenblas-dev libomp-dev libfftw3-dev
+            gcc-14 libopenblas-dev libomp-dev libfftw3-dev
 
       # A clean tree, always. #99 found the suite passing on a geistshell-chat
       # binary left over from an earlier build that no rule promised; an
       # incremental CI would have reproduced that bug rather than caught it.
+      # HOST_CC: the repo defaults to clang, and Ubuntu's clang-18 has no C23
+      # `constexpr` — it landed in clang 19, and include/geistshell/device.h
+      # uses it. geistlib pins gcc-14 on Linux for exactly this reason.
       - name: Build (host-debug = ASan + UBSan)
-        run: make
+        run: make ${{ runner.os == 'Linux' && 'HOST_CC=gcc-14' || '' }}
 
       # pipefail, or `tee` reports success and every failing test is swallowed —
       # the same defect this file exists to prevent, one layer up. GitHub's
@@ -72,7 +75,7 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          make test | tee test.log
+          make ${{ runner.os == 'Linux' && 'HOST_CC=gcc-14' || '' }} test | tee test.log
 
       # A run whose Linux-only tests all stepped aside must not look like a run
       # where they passed. On macOS a skip is expected and fine; on Linux it
@@ -106,5 +109,5 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            clang libopenblas-dev libomp-dev libfftw3-dev
-      - run: make host-release
+            gcc-14 libopenblas-dev libomp-dev libfftw3-dev
+      - run: make HOST_CC=gcc-14 host-release

--- a/Makefile
+++ b/Makefile
@@ -217,8 +217,13 @@ update-engine:
 		git -C "$(GEIST_DIR)" checkout --quiet $(GEIST_REF); \
 	fi
 
+# CC is forwarded, and that is not cosmetic. geistshell picked its compiler
+# (HOST_CC) for a reason — C23 needs gcc >= 14 or clang >= 19 — but the engine
+# sub-make used to fall back to plain `cc`, so on Ubuntu the shell built with
+# gcc-14 and the engine died on `-std=c23` with the system gcc. Two compilers
+# for one binary is also an ASan/ABI mismatch waiting to be debugged at 3am.
 $(GEIST_LIB): sync-engine
-	$(MAKE) -C $(GEIST_DIR) TARGET=$(GEIST_TARGET) MODE=$(GEIST_MODE) lib
+	$(MAKE) -C $(GEIST_DIR) CC=$(CC) TARGET=$(GEIST_TARGET) MODE=$(GEIST_MODE) lib
 
 lib: $(SPG_LIB)
 

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,12 @@ else ifeq ($(GEIST_TARGET),mac)
     GEIST_LINK_FLAGS := -framework Accelerate
 else ifeq ($(GEIST_TARGET),pi5)
     GEIST_LINK_FLAGS := -fopenmp -lopenblas -lfftw3f
+else ifeq ($(GEIST_TARGET),linux)
+    # Generic Linux (x86_64, and ARM64 that is not a Pi 5). detect-target.sh
+    # returns `linux` there, and this case did not exist — the link fell through
+    # to the empty `else` and failed on OpenBLAS/OpenMP symbols. Nothing caught
+    # it because nothing ever built this repo on x86_64 (#105).
+    GEIST_LINK_FLAGS := -fopenmp -lopenblas
 else
     GEIST_LINK_FLAGS :=
 endif
@@ -237,16 +243,30 @@ check-backends:
 # the failure only showed after `make clean`: an incremental tree still had the
 # binary from an earlier `make all`, so the suite was green on a file no rule
 # had promised. A test target must build everything its tests execute.
+# The summary line exists because a SKIP and a PASS are indistinguishable in the
+# exit code, and 8 of the test files only execute on Linux (/proc, SIGSTOP,
+# __linux__). On a macOS laptop the machine backend's suite steps aside and this
+# target still exits 0 — which reads as "covered". CI asserts skipped=0 on the
+# Linux legs so that stops being invisible (#105).
+#
+# Output goes through a file rather than a pipe: POSIX sh has no PIPESTATUS, and
+# `cmd | tee` would report tee's status, silently swallowing every failure.
 test: $(TEST_BINS) $(PROBE_BINS) $(SPG_BIN) $(CHAT_BIN) $(WORKLOAD_BIN) check-backends
-	@status=0; \
+	@log=$$(mktemp); one=$$(mktemp); status=0; \
 	for t in $(TEST_BINS); do \
 		echo "$$t"; \
-		"$$t" || status=$$?; \
+		"$$t" >"$$one" 2>&1 || status=$$?; \
+		cat "$$one"; cat "$$one" >>"$$log"; \
 	done; \
 	for t in $(CLI_TESTS); do \
 		echo "$$t"; \
-		SPG_BIN="$(SPG_BIN)" sh "$$t" || status=$$?; \
+		SPG_BIN="$(SPG_BIN)" sh "$$t" >"$$one" 2>&1 || status=$$?; \
+		cat "$$one"; cat "$$one" >>"$$log"; \
 	done; \
+	passed=$$(grep -c ': PASS' "$$log" || true); \
+	skipped=$$(grep -c ': SKIP' "$$log" || true); \
+	rm -f "$$log" "$$one"; \
+	echo "test summary: passed=$$passed skipped=$$skipped"; \
 	exit $$status
 
 # Real-model benchmark. Deliberately NOT part of `test`: it needs a GGUF and

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,25 @@ endif
 GEIST_REPO ?= https://github.com/geisten/geistlib.git
 GEIST_REF  ?= v0.8.2
 
+# Build target for the engine. Detected from the HOST, not from deps/geist:
+# the old fallback asked mk/detect-target.sh and echoed `mac` when the engine
+# was not cloned yet — which is every clean checkout, so CI built the mac target
+# on Linux and died inside libgeist. Overridable from the environment or the
+# command line (#105).
+#
+# Mirrors deps/geist/mk/detect-target.sh: mac-omp when Homebrew libomp is there,
+# pi5 for ARM64 Linux, linux otherwise.
+# Build target for the engine. Detected from the HOST, not from deps/geist: the
+# old fallback asked mk/detect-target.sh and echoed `mac` when the engine was
+# not cloned yet — which is every clean checkout, so CI built the mac target on
+# Linux and died inside libgeist. Overridable from the environment or the
+# command line (#105).
+#
+# Mirrors deps/geist/mk/detect-target.sh: mac-omp when Homebrew libomp is
+# present, pi5 for ARM64 Linux, linux otherwise.
+LIBOMP_PREFIX ?= /opt/homebrew/opt/libomp
+GEIST_TARGET  ?= $(shell LIBOMP_PREFIX="$(LIBOMP_PREFIX)" sh scripts/detect-target.sh)
+
 BUILD_MODE ?= host-debug
 
 # Optional REMOTE model adapter (libcurl transport, OpenAI-compatible). Off by
@@ -32,7 +51,6 @@ endif
 HOST_CC ?= clang
 
 AR ?= ar
-LIBOMP_PREFIX ?= /opt/homebrew/opt/libomp
 
 ifeq ($(BUILD_MODE),host-debug)
     MODE_DIR := host-debug
@@ -40,14 +58,12 @@ ifeq ($(BUILD_MODE),host-debug)
     SPG_OPT_FLAGS := -O1 -g -fsanitize=address,undefined -fno-omit-frame-pointer
     SPG_LD_FLAGS := -fsanitize=address,undefined
     GEIST_MODE := asan
-    GEIST_TARGET := $(shell if [ -x "$(GEIST_DIR)/mk/detect-target.sh" ]; then cd "$(GEIST_DIR)" && mk/detect-target.sh; else echo mac; fi)
 else ifeq ($(BUILD_MODE),host-release)
     MODE_DIR := host-release
     CC := $(HOST_CC)
     SPG_OPT_FLAGS := -O3 -DNDEBUG
     SPG_LD_FLAGS :=
     GEIST_MODE := release
-    GEIST_TARGET := $(shell if [ -x "$(GEIST_DIR)/mk/detect-target.sh" ]; then cd "$(GEIST_DIR)" && mk/detect-target.sh; else echo mac; fi)
 else
     $(error Unknown BUILD_MODE=$(BUILD_MODE). Use host-debug or host-release)
 endif

--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,15 @@ $(CHAT_BIN): $(CHAT_OBJECTS) $(SPG_LIB) $(GEIST_LIB)
 	@mkdir -p $(@D)
 	$(CC) $(SPG_LD_FLAGS) -o $@ $(CHAT_OBJECTS) $(SPG_LIB) $(GEIST_LIB) $(LDLIBS)
 
-$(OBJ_DIR)/%.o: %.c
+# Order-only: nothing compiles before the engine's headers exist. Only the
+# BINARIES depended on $(GEIST_LIB), so on a tree without deps/geist make was
+# free to compile first and die on `#include <geist.h>` — which every
+# development machine hides, because deps/geist is already there. The first CI
+# run on a clean checkout found it immediately (#105).
+$(GEIST_DIR)/include/geist.h:
+	$(MAKE) sync-engine
+
+$(OBJ_DIR)/%.o: %.c | $(GEIST_DIR)/include/geist.h
 	@mkdir -p $(@D)
 	$(CC) $(CFLAGS) -MMD -MP -c $< -o $@
 

--- a/scripts/detect-target.sh
+++ b/scripts/detect-target.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Which engine target this host builds. Output: mac | mac-omp | pi5 | linux | unknown
+#
+# A script rather than a $(shell ...) one-liner because the natural spelling is
+# a `case`, and every `)` in it would close make's own $(...) — the kind of
+# quoting puzzle that gets solved once and misread forever.
+#
+# This deliberately does NOT ask deps/geist/mk/detect-target.sh, even though it
+# mirrors it. That file does not exist on a clean checkout, and the old fallback
+# said `mac` when it was missing — so CI built the macOS target on Linux and
+# died inside libgeist with an unrelated error (#105). geistshell must be able
+# to name its own target before it has cloned anything.
+#
+# Override at make-time: make GEIST_TARGET=linux
+set -eu
+
+case "$(uname -s)" in
+    Darwin)
+        libomp_prefix="${LIBOMP_PREFIX:-/opt/homebrew/opt/libomp}"
+        if [ -f "$libomp_prefix/lib/libomp.dylib" ]; then
+            echo "mac-omp"
+        else
+            echo "mac"
+        fi
+        ;;
+    Linux)
+        case "$(uname -m)" in
+            aarch64|arm64) echo "pi5" ;;
+            *)             echo "linux" ;;
+        esac
+        ;;
+    *)
+        echo "unknown"
+        ;;
+esac

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -4,6 +4,14 @@
  * the wire codec (pure), the socket (not). Everything that decides anything
  * lives in the first two. */
 
+/* getaddrinfo/freeaddrinfo and struct addrinfo are POSIX, and glibc hides them
+ * unless a feature-test macro asks for them. `-std=c23` defines __STRICT_ANSI__,
+ * so on Linux this file did not compile at all — while macOS and the BSDs
+ * declare them by default and never complained. Found by the first CI run that
+ * built this repo on Linux (#105); the same 200809L the other POSIX-using
+ * sources in this tree already declare. */
+#define _POSIX_C_SOURCE 200809L
+
 #include "geistshell/device.h"
 
 #include <arpa/inet.h>


### PR DESCRIPTION
Refs #105. Independent of #103 and #104 — but see the note at the bottom before merging those.

geistshell had **no `.github/workflows` and no runs**. Every "make test green" was one person on one machine, reported honestly — which is not the same as reproducible.

**Status: all four legs green.**

| Leg | Target | Result |
|---|---|---|
| macOS arm64 | `mac-omp` | ✅ `passed=46 skipped=1` |
| Linux arm64 | `pi5` | ✅ `passed=47 skipped=0` |
| Linux x86_64 | `linux` | ✅ `passed=47 skipped=0` |
| host-release | `pi5`, `-O3 -DNDEBUG` | ✅ |

That `skipped=0` is the headline. 8 of 84 test files only execute on Linux — `/proc`, `SIGSTOP`/`SIGCONT`, `__linux__` — and on the macOS development host they step aside:

```
machine_action_probe: no /proc, nothing to prove here
test_cli_machine_recovery: SKIP (no process signals here)
```

Right for a test on the wrong host, wrong for a *suite*, because the skip is indistinguishable from a pass in the exit code. `make test` now ends with a `test summary: passed=N skipped=M` line and CI requires `skipped=0` on both Linux legs. **`test_machine_action`, `test_machine_diagnose`, `test_machine_loop`, `test_machine_telemetry` and the rest have now demonstrably executed** — the Linux backend, the pause/resume ledger and the process telemetry were previously covered by tests the repository could not show had ever run.

## Six bugs, five runs, none of them in the workflow

| # | Bug | Why it was invisible |
|---|---|---|
| 1 | Object rule had no prerequisite on the engine — `fatal error: 'geist.h' file not found` | `deps/geist` already exists on a dev machine |
| 2 | C23 `constexpr` vs. Ubuntu's clang-18 | nobody built with a distro clang |
| 3 | `device.c` missing `_POSIX_C_SOURCE` — never compiled on Linux at all | macOS/BSD declare `getaddrinfo` by default |
| 4 | Silent `mac-omp` → `mac` fallback on a missing libomp | the dev machine has libomp |
| 5 | Target detection asked the *not-yet-cloned* engine, so every platform got `mac` | `deps/geist` already exists on a dev machine |
| 6 | `CC` not forwarded to the engine sub-make — shell built with gcc-14, engine with `cc` | one compiler on the dev machine |

Four of the six are the same shape: **the build only worked if it had already worked.** `deps/geist` is there, the target was detected once, the compiler happens to be right. On a development machine that state is permanent, which is why none of this surfaced in months.

#3 deserves its own line: the Modbus device support added in #100 could never have been built for the Pi, which is the machine it exists for.

## Design notes

- **Detection moved into `scripts/detect-target.sh`** rather than a `$(shell ...)` one-liner. The natural spelling is a `case`, and every `)` in it closes make's own `$(...)` — a puzzle solved once and misread forever. It mirrors the engine's copy instead of depending on it, because geistshell must be able to name its own target before it has cloned anything. `GEIST_TARGET` is now overridable, which it was not.
- **`make test` uses a temp file, not a pipe.** POSIX `sh` has no `PIPESTATUS`, so `"$$t" | tee -a` would report *tee's* status and swallow every failure — the exact defect this file exists to prevent. Verified by planting a failing test: still exits non-zero. The workflow sets `pipefail` for the same reason one layer up.
- **The run-2 workaround was reverted, not kept.** Forcing `GEIST_TARGET=mac-omp` on macOS papered over bug #5; leaving it in would have left that bug live on every other clean checkout.
- `make bench` stays out: multi-GB GGUF, already reports a missing model as skipped, not a build dependency.
- No coverage ratchet, no perf gate, no TSan. Defensible later; this is the floor.

## Before merging #103 and #104

Both branch from `05c21a6` and contain **none** of the six build fixes. Once this lands they will get CI for the first time and fail on Linux for reasons that have nothing to do with them — they need a rebase onto this, not a debugging session.

#104 additionally moves the baseline journal hash to a value computed on macOS. Its Linux legs will be the first check that nothing in the journal is host-dependent. If that hash differs there, it is not a mishap — it is exactly the finding the anchor exists for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
