### PR TITLE
ci: separate "wrong host" from "optional artefact missing"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
           # The deployment target (Raspberry Pi 5 is ARM64 Linux). This is the
           # only leg where the /proc + signal tests execute at all, so it is the
-          # one that must not skip.
+          # one where a SKIP(host) is a failure.
           - name: Linux arm64
             runner: ubuntu-24.04-arm
             expect_skips: none
@@ -89,18 +89,20 @@ jobs:
           set -o pipefail
           make ${{ runner.os == 'Linux' && 'HOST_CC=gcc-14' || '' }} test | tee test.log
 
-      # A run whose Linux-only tests all stepped aside must not look like a run
-      # where they passed. On macOS a skip is expected and fine; on Linux it
-      # means the thing under test did not run.
-      - name: No silent skips
+      # A run whose HOST-GATED tests stepped aside must not look like a run where
+      # they passed. Only that class is checked: a test that skips because an
+      # optional artefact is missing — a GGUF, python3, a built gym env, a
+      # REMOTE=1 binary — is legitimate on every platform, and counting those
+      # too is what turned main red the first time this ran there.
+      - name: No silent host skips
         run: |
           summary=$(grep '^test summary:' test.log || true)
           echo "$summary"
           [ -n "$summary" ] || { echo "::error::make test printed no summary"; exit 1; }
-          skipped=$(printf '%s' "$summary" | sed 's/.*skipped=//')
-          if [ "${{ matrix.expect_skips }}" = "none" ] && [ "$skipped" != "0" ]; then
-            echo "::error::$skipped test(s) skipped on a platform where they should run"
-            grep ': SKIP' test.log || true
+          host_skipped=$(printf '%s' "$summary" | sed 's/.*host_skipped=//')
+          if [ "${{ matrix.expect_skips }}" = "none" ] && [ "$host_skipped" != "0" ]; then
+            echo "::error::$host_skipped host-gated test(s) skipped on a platform that can run them"
+            grep ': SKIP(host)' test.log || true
             exit 1
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -276,8 +276,18 @@ check-backends:
 # The summary line exists because a SKIP and a PASS are indistinguishable in the
 # exit code, and 8 of the test files only execute on Linux (/proc, SIGSTOP,
 # __linux__). On a macOS laptop the machine backend's suite steps aside and this
-# target still exits 0 — which reads as "covered". CI asserts skipped=0 on the
-# Linux legs so that stops being invisible (#105).
+# target still exits 0 — which reads as "covered" (#105).
+#
+# TWO CLASSES, counted separately, because conflating them made main red:
+#
+#   SKIP(host)  the host cannot run this — /proc, process signals. On a platform
+#               that HAS those, a skip means the thing under test did not run,
+#               and CI fails on it.
+#   SKIP        an optional artefact is absent — a GGUF, python3, a built gym
+#               env, a REMOTE=1 binary. Legitimate on every platform, including
+#               the ones where the host-gated tests must run.
+#
+# A test declares its own class, because the test is what knows which it is.
 #
 # Output goes through a file rather than a pipe: POSIX sh has no PIPESTATUS, and
 # `cmd | tee` would report tee's status, silently swallowing every failure.
@@ -295,8 +305,9 @@ test: $(TEST_BINS) $(PROBE_BINS) $(SPG_BIN) $(CHAT_BIN) $(WORKLOAD_BIN) check-ba
 	done; \
 	passed=$$(grep -c ': PASS' "$$log" || true); \
 	skipped=$$(grep -c ': SKIP' "$$log" || true); \
+	host_skipped=$$(grep -c ': SKIP(host)' "$$log" || true); \
 	rm -f "$$log" "$$one"; \
-	echo "test summary: passed=$$passed skipped=$$skipped"; \
+	echo "test summary: passed=$$passed skipped=$$skipped host_skipped=$$host_skipped"; \
 	exit $$status
 
 # Real-model benchmark. Deliberately NOT part of `test`: it needs a GGUF and

--- a/test/test_cli_machine_action.sh
+++ b/test/test_cli_machine_action.sh
@@ -12,7 +12,7 @@ set -eu
 BIN=${SPG_MACHINE_PROBE:-${TEST_DIR:-build/host-debug/test}/machine_action_probe}
 
 if [ ! -x "$BIN" ]; then
-    echo "test_cli_machine_action: SKIP (probe not built)"
+    echo "test_cli_machine_action: SKIP(host) (probe not built)"
     exit 0
 fi
 

--- a/test/test_cli_machine_recovery.sh
+++ b/test/test_cli_machine_recovery.sh
@@ -17,7 +17,7 @@ SCRIPT=build/machine-recovery-fake.txt
 RUNCFG=build/machine-recovery-run.spg
 
 if [ "$(uname -s)" != "Linux" ]; then
-    echo "test_cli_machine_recovery: SKIP (no process signals here)"
+    echo "test_cli_machine_recovery: SKIP(host) (no process signals here)"
     exit 0
 fi
 


### PR DESCRIPTION
**`main` is red, and this fixes it.** Refs #105.

```
test_cli_gym: SKIP (no build/gymenv; see docs/machine-intelligence/Devices.md)
##[error]1 test(s) skipped on a platform where they should run
```

The rule I added in #106 counted **every** skip and demanded zero on Linux. This tree has two unrelated reasons to skip, and only one of them is a defect:

| Class | Examples | On a platform that can run it |
|---|---|---|
| `SKIP(host)` | `/proc`, process signals | **failure** — the thing under test did not run |
| `SKIP` | missing GGUF, no `python3`, no built gym env, no `REMOTE=1` binary | fine, everywhere |

Seven test files already skip for the second reason. Conflating the two did not just produce a false failure — it made the strictness *self-defeating*: a rule that fires on a missing `python3` gets switched off, and then nothing notices the day the machine backend stops being tested.

A test now declares its own class, because the test is what knows which it is. Two files changed — the two that gate on the host. `make test` reports both counts:

```
test summary: passed=49 skipped=2 host_skipped=1
```

and CI checks only `host_skipped`.

**An allowlist of permitted skips was the obvious alternative and is worse.** It has to be maintained from outside, by someone who did not write the test, and it grows silently every time a new optional dependency appears.

## How this got in

#101 and #103 were merged without checks — not a deliberate skip, but because `pull_request` workflows are read from the **PR head**, and both branches predate the workflow file. They were not the cause: `main` would have gone red on the next push regardless. The run immediately after #106 merged was cancelled by the following push, so nobody saw it.

#104 is blocked by the same rule and goes green once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
