### PR TITLE
Mask: jedes Verb tippbar — und agent --model-profile

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -2100,6 +2100,7 @@ static int agent_command(int argc, char **argv) {
      * counters to reflect its own action. */
     uint64_t    settle_ms    = 0u;
     const char *profile_path = nullptr; /* (process-profile ...) file */
+    const char *model_profile_path = nullptr; /* (model_profile ...) file */
     /* Attached machine (device_write). Declared per run: a channel table is
      * the operator saying what this agent may move, which is not something a
      * model or a runtime-discovered config should be able to widen. */
@@ -2255,6 +2256,11 @@ static int agent_command(int argc, char **argv) {
             i += 1;
             continue;
         }
+        if (strcmp(argv[i], "--model-profile") == 0 && i + 1 < argc) {
+            model_profile_path = argv[i + 1];
+            i += 1;
+            continue;
+        }
         if (strcmp(argv[i], "--best-of") == 0 && i + 1 < argc) {
             best_of = (size_t)strtoull(argv[i + 1], nullptr, 10);
             if (best_of == 0u) {
@@ -2271,6 +2277,7 @@ static int agent_command(int argc, char **argv) {
                 "usage: %s agent --config <run> [--fake-script <file>] "
                 "[--process-profile <file>] "
                 "[--command-menu <menu.spg>] [--command-mask] "
+                "[--model-profile <file>] "
                 "[--max-steps N] [--max-repairs N] [--allow-exec] "
                 "[--memory-dir <d>]\n"
                 "  without --fake-script the real model at the config's "
@@ -2525,6 +2532,29 @@ static int agent_command(int argc, char **argv) {
      * it needs an action to observe first. The timestamp is the run's, from the
      * same injected counter the journal uses — no clock is read here either. */
     struct spg_machine_state   machine = {};
+    /* #54 for the live agent: eval could describe HOW to speak to a model,
+     * the agent could not — so every agent run spoke auto-detect, which for
+     * a base model like BitNet means `none` (phase 12: 1/9 parses). Same
+     * file format, same loader, same field the eval path fills. */
+    static struct spg_model_profile model_profile;
+    model_profile = (struct spg_model_profile){};
+    if (model_profile_path != nullptr) {
+        struct file_buffer mtext = {};
+        if (read_file(model_profile_path, &mtext) != SPG_OK) {
+            fprintf(stderr, "agent: cannot read model profile: %s\n",
+                    model_profile_path);
+            return 2;
+        }
+        const enum spg_status ms = spg_model_profile_load(
+            mtext.n, mtext.data, CLI_TOKEN_CAPACITY, rec_tokens,
+            CLI_NODE_CAPACITY, rec_nodes, &model_profile);
+        free_file_buffer(&mtext);
+        if (ms != SPG_OK) {
+            fprintf(stderr, "agent: invalid model profile %s: %s\n",
+                    model_profile_path, spg_status_to_string(ms));
+            return 2;
+        }
+    }
     struct spg_process_profile profile = {};
     if (profile_path != nullptr) {
         struct file_buffer profile_text = {};
@@ -2638,7 +2668,8 @@ static int agent_command(int argc, char **argv) {
          * machine action as unmanaged. That is the right default: a run that
          * never declared what it may touch may not touch anything. */
         .profile      = profile_path != nullptr ? &profile : nullptr,
-        .pause_ledger = &pause_ledger,
+        .pause_ledger  = &pause_ledger,
+        .profile_model = model_profile.present ? &model_profile : nullptr,
         .device       = device.n_channels > 0u ? &device : nullptr,
         .device_state = device.n_channels > 0u ? &device_state : nullptr,
     };

--- a/src/model/grammar_mask.c
+++ b/src/model/grammar_mask.c
@@ -6,11 +6,20 @@
 
 /* Every action kind that parse_action_kind accepts. Their canonical names come
  * from spg_action_kind_to_string, so this list is the enum, not a second copy
- * of the strings. */
+ * of the strings.
+ *
+ * It IS a second copy of the enum's MEMBERSHIP though, and it drifted: the
+ * machine kinds and device_write were parseable and scaffolded but missing
+ * here, so the constrained decoder could not TYPE them — a model told to
+ * pause a process or drive a heater was railroaded into the other seven
+ * verbs. MachineBench surfaced it: 0/3 with the action named in the goal
+ * text is a decoder that forbids the answer, not a model that missed it. */
 static const enum spg_action_kind ALL_KINDS[] = {
-    SPG_ACTION_LOCAL_SHELL, SPG_ACTION_SSH_AUTH_PROBE, SPG_ACTION_SIMULATOR,
-    SPG_ACTION_MEMORY_SAVE, SPG_ACTION_MEMORY_DELETE,  SPG_ACTION_MEMORY_READ,
-    SPG_ACTION_FINISH,
+    SPG_ACTION_LOCAL_SHELL,   SPG_ACTION_SSH_AUTH_PROBE,
+    SPG_ACTION_SIMULATOR,     SPG_ACTION_MEMORY_SAVE,
+    SPG_ACTION_MEMORY_DELETE, SPG_ACTION_MEMORY_READ,
+    SPG_ACTION_MACHINE_PAUSE, SPG_ACTION_MACHINE_RESUME,
+    SPG_ACTION_DEVICE_WRITE,  SPG_ACTION_FINISH,
 };
 static const size_t KIND_COUNT = sizeof ALL_KINDS / sizeof ALL_KINDS[0];
 

--- a/src/model/model_adapter.c
+++ b/src/model/model_adapter.c
@@ -464,7 +464,11 @@ static enum spg_status generate_geist(
 
         /* 2. kind-slot mask: constrain the slot to a valid kind enum name. */
         char        kindbuf[64];
-        const char *kn[8];
+        /* Room for every kind in ALL_KINDS. This was 8 when there were 7
+         * kinds; growing the enum would have silently truncated the menu,
+         * and the dropped names would have been device_write and finish —
+         * the actuator and the exit. */
+        const char *kn[16];
         const size_t  knn = spg_kind_names(kn, sizeof kn / sizeof kn[0]);
         const enum spg_status ks =
             decode_choice_slot(adapter, result, kn, knn, kindbuf, sizeof kindbuf);

--- a/test/test_grammar_mask.c
+++ b/test/test_grammar_mask.c
@@ -161,6 +161,26 @@ int main(void) {
         return fail("leading-space name completes");
     }
 
+    /* The verbs that were missing from ALL_KINDS while being parseable and
+     * scaffolded: the constrained decoder could not TYPE them, so every
+     * --constrained run looked like a model that never reached the actuator.
+     * These lines are the regression guard against the list drifting again. */
+    if (!spg_kind_prefix_ok("", "device") ||
+        !spg_kind_prefix_ok("device", "_write") ||
+        !spg_kind_complete("device_write")) {
+        return fail("device_write must be typable under the mask");
+    }
+    if (!spg_kind_prefix_ok("", "machine") ||
+        !spg_kind_complete("machine_pause_process") ||
+        !spg_kind_complete("machine_resume_process")) {
+        return fail("machine kinds must be typable under the mask");
+    }
+    enum spg_action_kind parsed_kind;
+    if (!spg_kind_from_text("device_write", &parsed_kind) ||
+        parsed_kind != SPG_ACTION_DEVICE_WRITE) {
+        return fail("device_write must round-trip through the mask");
+    }
+
     /* Rejections: unknown text and overshoot past a complete name. */
     if (spg_kind_prefix_ok("", "xyz")) {
         return fail("'xyz' is not any kind prefix");


### PR DESCRIPTION
## Zwei Funde aus dem ersten echten MachineBench-Lauf

**1. Der constrained Decoder konnte `device_write`, `machine_pause_process` und `machine_resume_process` nicht tippen.** `ALL_KINDS` in grammar_mask.c behauptet, die Enum zu sein — es war eine gedriftete Kopie ihrer Mitgliedschaft: die drei Verben waren parsebar (`recommendation.c`) und gescaffoldet (`SEG_DEVICE`, `SEG_MACHINE`), aber im Kind-Slot verboten. Konsequenz: **jeder bisherige `--constrained`-Lauf mit Maschinen- oder Anlagenzielen war railroaded** — Gemma und BitNet sahen im MachineBench wie Modelle aus, die den Aktuator nie erreichen (0/3), auch als der Goal-Text das Verb wörtlich nannte. Ein Decoder, der die Antwort verbietet, ist kein Modell, das sie verfehlt. Dazu: `kn[8] → kn[16]` im Adapter — beim nächsten Wachsen der Liste wären sonst still `device_write` und `finish` aus dem Menü gefallen. Regression-Guard in `test_grammar_mask.c`.

**2. `agent --model-profile <file>`** — #54 für den Live-Agenten: eval konnte beschreiben, wie man mit einem Modell spricht (Template, Constrained), der Agent nicht — BitNet lief live immer mit Auto-Detect = `none` (Phase 12: 1/9 Parses). Gleicher Loader, gleiches `profile_model`-Feld wie im eval-Pfad.

## Tests
`make test` komplett grün (48 PASS, macOS/ASan), inkl. neuer Mask-Guards (device_write/machine_* tippbar, Roundtrip durch `spg_kind_from_text`).

Gefunden von MachineBench (Experiment „Verb im Goal-Text", reports/2026-08-14) — der Benchmark tut, wofür er da ist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)