### PR TITLE
Docs: Masken-Lektion (zweite Instanz) und --model-profile im Agenten

### DIFF
--- a/docs/MODEL-ADAPTATION.md
+++ b/docs/MODEL-ADAPTATION.md
@@ -188,10 +188,11 @@ not as failure.
   (finish_on_no_progress false))
 ```
 
-Referenced from `run.spg` alongside `(policy …)` and `(scenario …)`.
-Precedence: **CLI > profile file > auto-detect** (auto-detect via
-`geist_model_arch()` + special-token probe, so a user with nothing but a GGUF
-needs no profile).
+Passed as `--model-profile <file>` — to `eval` since #54, to the live
+`agent` since #110 (before that, every live run spoke auto-detect, which for
+a base model means `none`). Precedence: **CLI > profile file > auto-detect**
+(auto-detect via `geist_model_arch()` + special-token probe, so a user with
+nothing but a GGUF needs no profile).
 
 Data, not code — the same call as the command menu in decision 7. The decisive
 property is that a profile file is **versionable and journalable**: when

--- a/docs/machine-intelligence/Machine-B.md
+++ b/docs/machine-intelligence/Machine-B.md
@@ -73,6 +73,21 @@ dritten Fall hinzufügte.
 Ein geschlossenes Enum ist nur geschlossen, wenn jedes `switch` darüber
 vollständig ist. Hier war es das nicht, und niemand hat es bemerkt.
 
+**Nachtrag (#110): dieselbe Lektion, zweite Instanz, anderer Finder.** Was
+`-Wswitch` in `kinds_for_cap` fand, konnte es in `ALL_KINDS` nicht finden —
+eine Array-Initialisierung ist kein `switch`. Dort fehlten
+`machine_pause_process`, `machine_resume_process` und `device_write` bis
+zuletzt: parsebar, gescaffoldet, aber im Kind-Slot des Decoders **nicht
+tippbar**. Gefunden hat es kein Compiler, sondern MachineBench — zwei
+Modelle, denen der Goal-Text das Verb wörtlich nannte, schlugen 0/3 fehl,
+und die Journale zeigten einen Decoder, der die Antwort verbot, kein Modell,
+das sie verfehlte.
+
+Konsequenz für Messungen: jeder `--constrained`-Lauf vor #110, dessen
+richtige Antwort ein Maschinen- oder Anlagen-Verb gewesen wäre, hat ein
+verkürztes Menü gemessen. Die Diagnose-Zahlen (Phase 12, Go/No-Go) bleiben
+gültig — Diagnose endet in `finish`, das immer tippbar war.
+
 ### Der Parameter im String
 
 `(kind machine_set_fan) (target "fan:60")` — die Lüfterstufe reitet in der


### PR DESCRIPTION
Zwei Doku-Nachträge zu #110:

- **Machine-B.md**: Der Abschnitt „Was der Compiler dabei gefunden hat" bekommt den Nachtrag, dass dieselbe Lücke ein zweites Mal existierte — in `ALL_KINDS`, wo `-Wswitch` nicht hinsieht — und diesmal von MachineBench gefunden wurde statt vom Compiler. Mit der ehrlichen Konsequenz für ältere Messungen: `--constrained`-Läufe vor #110 mit Maschinen-/Anlagen-Verben maßen ein verkürztes Menü; die Diagnose-Zahlen (Phase 12, Go/No-Go) bleiben gültig, weil Diagnose in `finish` endet.
- **MODEL-ADAPTATION.md**: Profil-Mechanik präzisiert — `--model-profile` gilt seit #110 auch für den Live-Agenten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)