### PR TITLE
Adapter: break nach dem NUM-Slot — Gemmas richtige Aktion scheiterte an einer Klammer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ endif
 # private headers like src/base/heap.h) was dropped with the arena wrapper in
 # v0.3.1 — geistshell must not depend on libgeist internals.
 CPPFLAGS := -Iinclude -Iinclude/geistshell -I$(GEIST_DIR)/include -I$(DEPS_DIR)/jsmn
-WARNINGS := -Wall -Wextra -Wpedantic -Wconversion -Wshadow -Wstrict-prototypes
+WARNINGS := -Wall -Wextra -Wpedantic -Wconversion -Wshadow -Wstrict-prototypes -Wimplicit-fallthrough
 CFLAGS := -std=c23 $(WARNINGS) $(SPG_OPT_FLAGS) $(CPPFLAGS) $(REMOTE_DEFS)
 LDLIBS := $(GEIST_LINK_FLAGS) -lm -lpthread $(REMOTE_LIBS)
 

--- a/deps/geist
+++ b/deps/geist
@@ -1,0 +1,1 @@
+/Users/germar/workspace/geistshell/deps/geist

--- a/src/model/model_adapter.c
+++ b/src/model/model_adapter.c
@@ -494,7 +494,13 @@ static enum spg_status generate_geist(
                     ss = decode_capability_slot(adapter, result, kind);
                     break;
                 case SPG_SCAFFOLD_NUMBER:
+                    /* The missing break here survived exactly as long as no
+                     * scaffold could reach a NUM slot: after the number, the
+                     * command-slot decoder ran too and wrote garbage where
+                     * SEG_DEVICE's closing literal belonged. -Wimplicit-
+                     * fallthrough now guards the whole class. */
                     ss = decode_number_slot(adapter, result);
+                    break;
                 case SPG_SCAFFOLD_COMMAND:
                     ss = decode_command_slot(adapter, result);
                     break;


### PR DESCRIPTION
## Der dritte Fund aus derselben MachineBench-Session

Nach #110 (device_write tippbar) schlug Gemma4-E2B im ersten gültigen Lauf **die richtige Aktion** vor:

```
(recommend (kind device_write) ... (target "batch_enable") (value 0 (reason ) (reason ""))
```

Kind, Capability, Target, Wert — alles richtig. Die Form ist trotzdem unparsebar: nach der Zahl fehlt die schließende Klammer. Ursache: `case SPG_SCAFFOLD_NUMBER` in model_adapter.c hatte **kein `break`** und fiel in den Command-Slot-Decoder durch. Der NUM-Slot ist der einzige freie Zahlen-Slot der ganzen Grammatik und war bis #110 von keinem Scaffold erreichbar — der Fallthrough konnte nie feuern.

Fix: `break;` plus `-Wimplicit-fallthrough` in WARNINGS (kompiliert warnungsfrei), damit diese Klasse künftig dem Compiler gehört statt dem nächsten Benchmark.

## Tests
`make test` komplett grün (macOS/ASan). Der eigentliche Beweis folgt als MachineBench-Report: derselbe Lauf, der den Bug fand, läuft nach dem Merge erneut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)