### PR TITLE
chore(engine): pin libgeist v0.9.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ else
 endif
 
 GEIST_REPO ?= https://github.com/geisten/geistlib.git
-GEIST_REF  ?= v0.8.2
+GEIST_REF  ?= v0.9.0
 
 # Build target for the engine. Detected from the HOST, not from deps/geist:
 # the old fallback asked mk/detect-target.sh and echoed `mac` when the engine

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ the same governed loop** rather than compete on local‑model capability.
 | `src/eval/`, `src/improve/`             | evaluation harness + self‑improvement loop             |
 | `src/journal/`, `src/core/`, `src/dsl/` | hash‑chained journal, primitives, s‑expression DSL     |
 | `src/cli/`, `src/chat/`                 | CLI and chat REPL surfaces                             |
-| `deps/geist/`                           | the external inference engine (pinned `v0.8.2`)        |
+| `deps/geist/`                           | the external inference engine (pinned `v0.9.0`)        |
 
 ## Constraints
 


### PR DESCRIPTION
`geist_model_arch` is **STABLE** as of that tag, and it is the key geistshell's chat-template selection is built on ([docs/MODEL-ADAPTATION.md](../blob/main/docs/MODEL-ADAPTATION.md), decision 2). Until now the promise lived in geistlib's `main` and in no release — the pinned `v0.8.2` was a library that did not carry it.

Two lines: `GEIST_REF` and the pin in the README layout table.

## Verified against the tag, not assumed

```
deps/geist @ v0.9.0   (GEIST_VERSION_STRING "0.9.0")
make clean && make && make test
  test summary: passed=50 skipped=2 host_skipped=1
  exit=0
test_cli_baseline: PASS
```

The one `host_skipped` is the `/proc` suite on macOS; the Linux legs cover it and require `host_skipped=0` there.

## On the risk

The last bump — `v0.2.1` → `v0.8.2` — surfaced six portability bugs (#105), every one of them something that only worked because the machine had already built once. This one is a minor over two weeks against a contract that is now CI-enforced upstream, so the risk is different in kind rather than merely smaller.

It goes through the three-platform CI regardless. That is the first time an engine change in this repo does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
