### PR TITLE
Profil: finish_on_no_progress — die Schleife hält, wo der Satz es nicht tat

### DIFF
--- a/include/geistshell/model_profile.h
+++ b/include/geistshell/model_profile.h
@@ -63,6 +63,15 @@ struct spg_model_profile {
      * why this is a decoding aid and not a security control (see cmd_menu.h).
      * Off keeps the slot free, which is the arm a baseline compares against. */
     bool                   command_mask;
+    /* #40's convergence stop, per model. Absent (has_ false) keeps the
+     * default `true`: an executed action that makes no progress ends the run
+     * FINISHED — right for diagnosis, where one answer is the job. `false`
+     * keeps the loop asking until the model itself finishes or the step cap
+     * hits. MachineBench is the consumer that finally earned this field: a
+     * controller that must STAY on a plant cannot be one the loop sends home
+     * early, and whether the model then stays is exactly the measurement. */
+    bool                   has_finish_on_no_progress;
+    bool                   finish_on_no_progress;
     bool                   present;
 };
 

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -2678,8 +2678,13 @@ static int agent_command(int argc, char **argv) {
         .max_repairs = max_repairs,
         /* #40: a model that acts validly but never emits (kind finish) would
          * run to the step cap; treat a converged (no-progress) run as done so
-         * it terminates FINISHED and an expect verdict can pass. */
-        .finish_on_no_progress = true,
+         * it terminates FINISHED and an expect verdict can pass. The model
+         * profile may override: a controller that must stay on a plant cannot
+         * be one the loop sends home early (see model_profile.h). */
+        .finish_on_no_progress =
+            model_profile.present && model_profile.has_finish_on_no_progress
+                ? model_profile.finish_on_no_progress
+                : true,
         .directive_slug        = directive_slug,
         .execution_enabled     = allow_exec,
         .exec_timeout_ms       = 5000u,

--- a/src/model/model_profile.c
+++ b/src/model/model_profile.c
@@ -125,6 +125,18 @@ spg_model_profile_load(const size_t input_n, const char input[],
             return SPG_E_SCHEMA;
         }
     }
+    node = field_value(input_n, input, nodes, root, "finish_on_no_progress");
+    if (node != SPG_SEXPR_INVALID_INDEX) {
+        if (spg_sexpr_span_eq_cstr(input_n, input, nodes[node].span, "true")) {
+            out->finish_on_no_progress = true;
+        } else if (spg_sexpr_span_eq_cstr(input_n, input, nodes[node].span,
+                                          "false")) {
+            out->finish_on_no_progress = false;
+        } else {
+            return SPG_E_SCHEMA;
+        }
+        out->has_finish_on_no_progress = true;
+    }
     out->present = true;
     return SPG_OK;
 }

--- a/test/test_model_profile.c
+++ b/test/test_model_profile.c
@@ -42,6 +42,28 @@ static int test_parse(void) {
     if (strcmp(p.name, "x") != 0 || !p.present) {
         return 1;
     }
+    /* finish_on_no_progress is tri-state: absent means "the default", which
+     * must stay distinguishable from an explicit true — otherwise a profile
+     * could never say "hold the loop open" without also rewriting every
+     * profile that never mentioned the field. */
+    if (p.has_finish_on_no_progress) {
+        return 1; /* the fixture above never named the field */
+    }
+    if (load(LIT("(model_profile (name \"hold\")"
+                 " (finish_on_no_progress false))"),
+             &p) != SPG_OK ||
+        !p.has_finish_on_no_progress || p.finish_on_no_progress) {
+        return 1;
+    }
+    if (load(LIT("(model_profile (finish_on_no_progress true))"), &p) !=
+            SPG_OK ||
+        !p.has_finish_on_no_progress || !p.finish_on_no_progress) {
+        return 1;
+    }
+    if (load(LIT("(model_profile (finish_on_no_progress maybe))"), &p) !=
+        SPG_E_SCHEMA) {
+        return 1;
+    }
     return 0;
 }
 


### PR DESCRIPTION
Die in MODEL-ADAPTATION.md entworfene Profil-Achse `finish_on_no_progress`, jetzt gebaut — weil sie ihren Konsumenten hat: MachineBench hat gemessen, dass Gemma4-E2B aus dem Goal-Text die *Wahl der nächsten Aktion* übernimmt, aber keine *Verpflichtung über die Zeit* (reports/, gemma+stay 0/3, zwölf Vorschläge, alle value 0, Ausstieg vor dem Relapse). Der nächste Messarm ist eine Schleife, die den Regler hält, statt eines Satzes, der ihn bittet.

- Tri-state im Profil (`has_` + Wert): absent = Default `true`, das heutige Verhalten jeder existierenden Profildatei bleibt byte-gleich.
- Konsumiert nur vom `agent`-Pfad (`--model-profile`); eval unverändert.
- Parse-Tests für alle drei Zustände plus Schema-Ablehnung.

`make test` komplett grün (macOS/ASan). Der Messwert, den die Achse ermöglicht, folgt als MachineBench-Report-Spalte `gemma+hold`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)