### PR TITLE
fix(make): workload binary fails on clean checkout — bin dir never created

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,8 @@ $(OBJ_DIR)/%.o: %.c | $(GEIST_DIR)/include/geist.h
 
 # Phase 8 (#68): reproducible load for machine experiments. Same flags as
 # everything else, so a sanitiser build covers it too.
-$(WORKLOAD_BIN): examples/machine/workloads/workload.c | $(BIN_DIR)
+$(WORKLOAD_BIN): examples/machine/workloads/workload.c
+	@mkdir -p $(@D)
 	$(CC) $(CFLAGS) -o $@ $<
 
 # Link-time backend selection means a build compiles exactly ONE of the three


### PR DESCRIPTION
## Problem

Fresh `make host-release -j8` (and host-debug) in a clean checkout/worktree reproducibly fails:

```
No rule to make target 'build/host-release/bin', needed by 'build/host-release/bin/workload'
```

The `$(WORKLOAD_BIN)` rule declared `| $(BIN_DIR)` as an order-only prerequisite, but no rule ever creates `$(BIN_DIR)` — every other binary creates its directory via `mkdir -p $(@D)` in its own recipe. On a developer tree the directory already exists from earlier builds, which hid the bug.

## Fix

Drop the phantom order-only prerequisite and use the same `@mkdir -p $(@D)` idiom as `$(SPG_BIN)` / `$(CHAT_BIN)`.

## Verification

`rm -rf build && make host-release -j8` and `rm -rf build && make host-debug -j8` both build all three binaries (geistshell, geistshell-chat, workload) with no manual mkdir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)