### PR TITLE
cli: drop dead safe_free (#122); README: device section reflects shipped state (#123)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,10 @@ instead — geistshell never learns JSON-RPC.
 See [docs/machine-intelligence/Devices.md](docs/machine-intelligence/Devices.md)
 for the full contract, the s-expression channel config, and the migration order.
 Current state: the channel table, range/safe/watchdog and
-`SPG_ACTION_DEVICE_WRITE` ship; the transport is still hard-wired Modbus TCP and
-the `(device-state …)` context block is not built yet.
+`SPG_ACTION_DEVICE_WRITE` ship; channels speak the POSIX exec transport,
+`spg_device_sample()` delivers sensor readings, and the actor renders the
+`(device-state …)` context block (re-sampling after a write is covered by
+`test_cli_device.sh`).
 
 ### Evaluation (`geistshell eval` / `improve`)
 

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -40,14 +40,6 @@
 #include <time.h>
 #include <unistd.h> /* mkstemp/write/close/unlink: the guard-gate temp suite */
 
-/* free-and-null; formerly from the engine's heap.h, internalised in geist v0.9 */
-static void safe_free(void **ptr) {
-    if (ptr != nullptr) {
-        free(*ptr);
-        *ptr = nullptr;
-    }
-}
-
 #define CLI_TOKEN_CAPACITY 1024u
 #define CLI_NODE_CAPACITY 1024u
 #define CLI_CONTEXT_BYTES 32768u


### PR DESCRIPTION
Two small closes:

**#122** — the reported test failures no longer reproduce on current main (verified on macOS arm64: full suite 50 pass / 2 skip / 1 host-skip). What remained was the one build warning: the `safe_free` helper in `src/cli/main.c` that nothing calls since the engine internalised it. Removed; the build is warning-free.

**#123** — the README device paragraph still described the pre-exec-transport state. Now matches the code, `Devices.md` and `test_cli_device.sh`: POSIX exec transport, `spg_device_sample()`, actor-rendered `(device-state …)`.

Closes #122. Closes #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)