### PR TITLE
fix(device): validate sensor reads against the channel range

### DIFF
--- a/include/geistshell/device.h
+++ b/include/geistshell/device.h
@@ -221,7 +221,14 @@ spg_device_watchdog_check(struct spg_device *dev, uint64_t now);
  * stdout. Exit != 0, unparsable output or the timeout are SPG_E_IO — and the
  * reading stays untouched, never 0. There is no connect step: the first read
  * IS the connectivity probe, and a plant that cannot be read is something the
- * caller is told about per channel, not a session that failed to open. */
+ * caller is told about per channel, not a session that failed to open.
+ *
+ * The channel's range bounds readings as well as writes: a parsed value
+ * outside min..max is SPG_E_LIMIT, the reading stays untouched, and it does
+ * NOT count as watchdog contact. A defective or mis-scaled sensor must not
+ * inject an impossible number into the context/journal, and it must not keep
+ * a watchdog alive. The range is inclusive on both ends, same as the write
+ * check. */
 [[nodiscard]] enum spg_status spg_device_read(struct spg_device *dev,
                                               const char *name, int64_t *out);
 

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -334,6 +334,13 @@ enum spg_status spg_device_read(struct spg_device *dev, const char *name,
     if (!parse_output(output, &value)) {
         return SPG_E_FORMAT;
     }
+    if (value < channel->min || value > channel->max) {
+        /* The operator's range is also the plausibility bound for readings: a
+         * physically impossible number must not become a known measurement,
+         * and it must not feed the watchdog — a sensor that answers garbage
+         * is not a machine in contact. `out` stays untouched. */
+        return SPG_E_LIMIT;
+    }
     *out = value;
     /* Contact is contact: a successful read keeps the watchdog fed, so a run
      * that only observes does not look like a machine gone silent. */

--- a/test/test_device.c
+++ b/test/test_device.c
@@ -222,6 +222,8 @@ static int test_exec_contract(void) {
     }
     char temp_prog[256], fail_prog[256], text_prog[256];
     char heater_prog[256], liar_prog[256], heater_file[256];
+    char low_prog[256], high_prog[256], atmin_prog[256], atmax_prog[256];
+    char wide_prog[256];
     (void)snprintf(heater_file, sizeof heater_file, "%s/heater.value", dir);
     if (write_script(dir, "temp", "echo 2350\n", temp_prog,
                      sizeof temp_prog) != 0 ||
@@ -230,7 +232,17 @@ static int test_exec_contract(void) {
         write_script(dir, "text", "echo warm\n", text_prog,
                      sizeof text_prog) != 0 ||
         write_script(dir, "liar", "echo 39\n", liar_prog,
-                     sizeof liar_prog) != 0) {
+                     sizeof liar_prog) != 0 ||
+        write_script(dir, "low", "echo -401\n", low_prog,
+                     sizeof low_prog) != 0 ||
+        write_script(dir, "high", "echo 9001\n", high_prog,
+                     sizeof high_prog) != 0 ||
+        write_script(dir, "atmin", "echo -400\n", atmin_prog,
+                     sizeof atmin_prog) != 0 ||
+        write_script(dir, "atmax", "echo 9000\n", atmax_prog,
+                     sizeof atmax_prog) != 0 ||
+        write_script(dir, "wide", "echo -9223372036854775808\n", wide_prog,
+                     sizeof wide_prog) != 0) {
         return 1;
     }
     char heater_body[512];
@@ -270,6 +282,32 @@ static int test_exec_contract(void) {
     if (spg_device_add_channel(&dev, &ch) != SPG_OK) {
         return 1;
     }
+    ch = (struct spg_device_channel){.name = "low", .min = -400, .max = 9000};
+    (void)snprintf(ch.program, sizeof ch.program, "%s", low_prog);
+    if (spg_device_add_channel(&dev, &ch) != SPG_OK) {
+        return 1;
+    }
+    ch = (struct spg_device_channel){.name = "high", .min = -400, .max = 9000};
+    (void)snprintf(ch.program, sizeof ch.program, "%s", high_prog);
+    if (spg_device_add_channel(&dev, &ch) != SPG_OK) {
+        return 1;
+    }
+    ch = (struct spg_device_channel){.name = "atmin", .min = -400, .max = 9000};
+    (void)snprintf(ch.program, sizeof ch.program, "%s", atmin_prog);
+    if (spg_device_add_channel(&dev, &ch) != SPG_OK) {
+        return 1;
+    }
+    ch = (struct spg_device_channel){.name = "atmax", .min = -400, .max = 9000};
+    (void)snprintf(ch.program, sizeof ch.program, "%s", atmax_prog);
+    if (spg_device_add_channel(&dev, &ch) != SPG_OK) {
+        return 1;
+    }
+    ch = (struct spg_device_channel){
+        .name = "wide", .min = INT64_MIN, .max = INT64_MAX};
+    (void)snprintf(ch.program, sizeof ch.program, "%s", wide_prog);
+    if (spg_device_add_channel(&dev, &ch) != SPG_OK) {
+        return 1;
+    }
 
     /* A reading is the printed number, and it counts as contact. */
     int64_t value = 0;
@@ -284,6 +322,31 @@ static int test_exec_contract(void) {
     }
     if (spg_device_read(&dev, "chatty", &value) != SPG_E_FORMAT ||
         value != 777) {
+        return 1;
+    }
+
+    /* A parsed value outside the channel range is refused, stays untouched,
+     * and does NOT count as watchdog contact (issue #120). */
+    dev.contact_pending = false;
+    if (spg_device_read(&dev, "low", &value) != SPG_E_LIMIT || value != 777 ||
+        dev.contact_pending) {
+        return 1;
+    }
+    if (spg_device_read(&dev, "high", &value) != SPG_E_LIMIT || value != 777 ||
+        dev.contact_pending) {
+        return 1;
+    }
+    /* The range is inclusive: exactly min and exactly max are readings. */
+    if (spg_device_read(&dev, "atmin", &value) != SPG_OK || value != -400) {
+        return 1;
+    }
+    if (spg_device_read(&dev, "atmax", &value) != SPG_OK || value != 9000) {
+        return 1;
+    }
+    /* INT64 extremes compare without overflow: a full-range channel accepts
+     * INT64_MIN itself. */
+    if (spg_device_read(&dev, "wide", &value) != SPG_OK ||
+        value != INT64_MIN) {
         return 1;
     }
 
@@ -312,13 +375,16 @@ static int test_exec_contract(void) {
     }
 
     /* A mixed sample: the dead sensors render unknown, the live ones their
-     * value, and the first failure is reported without blinding the rest. */
+     * value, and the first failure is reported without blinding the rest.
+     * Out-of-range channels (5, 6) are unknown like any other bad read. */
     struct spg_device_state state = {};
-    if (spg_device_sample(&dev, &state) == SPG_OK || state.n != 5u) {
+    if (spg_device_sample(&dev, &state) == SPG_OK || state.n != 10u) {
         return 1;
     }
     if (!state.readings[0].known || state.readings[0].value != 2350 ||
-        state.readings[1].known || state.readings[2].known) {
+        state.readings[1].known || state.readings[2].known ||
+        state.readings[5].known || state.readings[6].known ||
+        !state.readings[7].known || !state.readings[8].known) {
         return 1;
     }
     return 0;


### PR DESCRIPTION
Closes #120.

The configured channel range is now a plausibility bound for readings, not only for writes:

- `spg_device_read()` checks the parsed value against `channel->min/max`; out-of-range is `SPG_E_LIMIT`, distinguishable from `SPG_E_IO`/`SPG_E_FORMAT`.
- The output stays untouched — `spg_device_sample()` renders the channel `unknown`, never a valid-looking number.
- An implausible read does **not** set `contact_pending`, so it cannot keep a watchdog alive.
- Other channels keep being sampled (existing sample loop unchanged).
- `device.h` documents the range as inclusive and consistent for reads and writes.

Tests (extended `test/test_device.c`): exactly min / exactly max accepted; just under / just over rejected with untouched value and unfed watchdog; mixed sample keeps valid channels and marks the invalid one unknown; `INT64_MIN/INT64_MAX` full-range channel accepts `INT64_MIN` without overflow (pure comparisons).

Verification: `make test` green (50 passed, ASan/UBSan host-debug build); `make bench` — model bench skips on this host (no GGUF), the deterministic scripted-fake benchmark runs inside `make test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)