### PR TITLE
feat(eval): per-case tokens and wall_ms in the verdict JSONL

### DIFF
--- a/include/geistshell/eval.h
+++ b/include/geistshell/eval.h
@@ -55,6 +55,10 @@ struct spg_eval_case_result {
      * deny_reason when denied); otherwise the NONE/zero value. */
     enum spg_recommendation_reject_reason reject_reason;
     enum spg_policy_deny_reason           deny_reason;
+    /* Tokens the run consumed (usage.consumed.tokens), so a budget-bound run
+     * is diagnosable from the per-case verdict alone (#126). Deterministic for
+     * scripted fakes — the fake decoder counts one token per tick. */
+    uint64_t tokens_consumed;
 };
 
 [[nodiscard]] const char *spg_eval_outcome_to_string(enum spg_eval_outcome o);

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -2967,6 +2967,10 @@ struct eval_run_report {
      * action", and those want opposite fixes. */
     size_t case_parsed[EVAL_MAX_CASES];
     size_t case_gated[EVAL_MAX_CASES];
+    /* #126: tokens consumed per case, summed over samples. Deterministic for
+     * scripted fakes (one token per tick), so it can live in the default
+     * output — unlike wall time, which stays behind --timing. */
+    uint64_t case_tokens[EVAL_MAX_CASES];
     /* Phase 10 (#70): wall time per case and peak RSS for the whole suite.
      *
      * Measured here and nowhere else. The runtime reads no clock — that is what
@@ -3800,11 +3804,13 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
                     last = (struct spg_eval_case_result){
                         .outcome =
                             spg_eval_judge(&expect, &loop, rs, observation),
-                        .termination  = loop.termination,
-                        .steps_taken  = loop.steps_taken,
-                        .repairs_used = loop.repairs_used,
-                        .status       = rs,
+                        .termination     = loop.termination,
+                        .steps_taken     = loop.steps_taken,
+                        .repairs_used    = loop.repairs_used,
+                        .status          = rs,
+                        .tokens_consumed = usage.consumed.tokens,
                     };
+                    report->case_tokens[case_idx] += usage.consumed.tokens;
                     eval_tally_ladder(report, case_idx, &last);
                     if (has_diagnosis &&
                         !eval_tally_diagnosis(
@@ -3888,6 +3894,7 @@ static enum spg_status eval_run_suite(const char                 *suite_path,
                     goto done;
                 }
                 last = r;
+                report->case_tokens[case_idx] += r.tokens_consumed;
                 eval_tally_ladder(report, case_idx, &r);
                 if (has_diagnosis) {
                     const struct spg_agent_loop_result synth = {
@@ -4014,6 +4021,15 @@ static void eval_print_report(const char                   *suite_path,
         /* #53: the ladder, appended so existing consumers keep matching. */
         printf(",\"parsed\":%zu,\"gated\":%zu", report->case_parsed[i],
                report->case_gated[i]);
+        /* #126: cost. Tokens are deterministic (scripted fakes count one per
+         * tick) and always present; wall time varies run to run, so it stays
+         * behind --timing like latency_ms, under the issue's field name. */
+        printf(",\"tokens\":%llu",
+               (unsigned long long)report->case_tokens[i]);
+        if (report->report_timing) {
+            printf(",\"wall_ms\":%llu",
+                   (unsigned long long)report->case_latency_ms[i]);
+        }
         /* #64: only for diagnosis cases, so every other suite's output stays
          * byte-identical to what its consumers already parse. */
         if (report->case_expected[i][0] != '\0') {

--- a/src/eval/eval.c
+++ b/src/eval/eval.c
@@ -113,6 +113,7 @@ spg_eval_run_case(const struct spg_fake_response *script, const size_t script_n,
     result->steps_taken  = loop.steps_taken;
     result->actions_executed = loop.actions_executed;
     result->repairs_used = loop.repairs_used;
+    result->tokens_consumed = usage.consumed.tokens;
     /* Concrete signal from the final tick for reflection to learn from. */
     result->reject_reason = loop.last.recommendation.reject_reason;
     result->deny_reason   = loop.last.policy_gate.decision.deny_reason;

--- a/test/test_cli_eval.sh
+++ b/test/test_cli_eval.sh
@@ -54,6 +54,16 @@ grep -q 'invalid --temperature' "$T/temp.out"
 # task <= gate <= parse.
 printf '%s\n' "$OUT" | grep -q '"name":"sim-finish".*"parsed":1,"gated":1'
 
+# #126: per-case cost. Tokens are deterministic for scripted fakes (one per
+# tick, so a 2-step case is 2) and live in the default output; wall time
+# varies, so wall_ms appears only under --timing, next to latency_ms.
+printf '%s\n' "$OUT" | grep -q '"name":"sim-finish".*"tokens":2'
+if printf '%s\n' "$OUT" | grep -q '"wall_ms":'; then
+    echo "wall_ms leaked into the default (deterministic) output" >&2
+    exit 1
+fi
+"$SPG_BIN" eval --timing examples/eval/suite.spg | grep -q '"name":"sim-finish".*"tokens":2,"wall_ms":'
+
 # a reply that never parses earns NO rung
 cat > "$T/reject.spg" <<EOF
 (eval_suite


### PR DESCRIPTION
Closes #126.

- `spg_eval_case_result` gains `tokens_consumed` (from `usage.consumed.tokens`), filled in both the scripted-fake path (`spg_eval_run_case`) and the real-model path.
- The per-case JSONL line always carries `"tokens"` (summed over samples). It is deterministic for scripted fakes — one token per tick — so it can live in the default output without breaking byte-identical reports.
- `"wall_ms"` (per case) is emitted under `--timing`, alongside the existing `latency_ms` whose consumers (run_tournament/run_ablation/run_size_curve) stay untouched. Wall clock in the default output would break every diff-based fixture test, per the documented determinism rule in `eval_run_report`.

Acceptance: a budget-bound run is now diagnosable from the JSONL alone (tokens per case vs the configured budget); the arm comparison can quote time per case via `--timing`.

Tests: `test/test_cli_eval.sh` asserts `tokens:2` on a 2-step scripted case, absence of `wall_ms` in the default output, and presence under `--timing`.

Verification: `make test` green (50 passed, ASan/UBSan); `make bench` — model bench skips on this host (no GGUF), deterministic benchmark runs in `make test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)