### PR TITLE
feat(device): per-channel watchdog, serviced every tick and at run end

### DIFF
--- a/docs/machine-intelligence/Devices.md
+++ b/docs/machine-intelligence/Devices.md
@@ -322,6 +322,23 @@ Zeit aussieht und keine ist. Deshalb heißt das Flag `--device-watchdog-steps`.
 Mit `exec` bekommt der Watchdog eine Aufgabe mehr: ein Programm, das dauerhaft
 mit Timeout stirbt, ist Kontaktverlust — genauso wie ein stummer Socket.
 
+**Pro Kanal, pro Tick (#118).** Kontakt wird pro Kanal geführt: eine
+erfolgreiche Transaktion füttert genau den Kanal, über den sie lief, und
+zusätzlich den globalen Stempel. Abgelaufen ist der Watchdog, sobald der
+globale Stempel **oder irgendein schreibbarer Kanal** eine volle Frist ohne
+Kontakt ist — ein Sensor, der weiter antwortet, kann einen verstummten Aktor
+nicht mehr verdecken. (Reine Sensor-Tabellen laufen wie zuvor über den
+globalen Stempel: Lesen ist dort der einzige Kontakt, den es gibt.)
+
+Geprüft wird nicht mehr nur vor einem `device_write`:
+`spg_device_watchdog_service` läuft in jedem Agenten-Tick — auch in Ticks, die
+nur beobachten, Memory schreiben oder `finish` wählen — und noch einmal vor dem
+regulären Run-Ende. Beim Ablauf fährt er alle schreibbaren Kanäle best-effort
+auf ihren sicheren Wert und journaliert
+`(device_watchdog (outcome expired) (safe_state ok|failed))`. Ein anhaltender
+Ablauf wird **einmal** behandelt (Latch), nicht jeden Tick erneut;
+wiederkehrender Kontakt spannt den Latch neu.
+
 ## Die Aktion
 
 `SPG_ACTION_DEVICE_WRITE` — die erste **nicht umkehrbare** Aktion im

--- a/include/geistshell/device.h
+++ b/include/geistshell/device.h
@@ -60,6 +60,12 @@ struct spg_device_channel {
      * declared safe value is a channel nobody has decided about, and the
      * decision would then be made by whatever the machine was last told. */
     int64_t safe;
+    /* Per-channel watchdog bookkeeping (#118). A successful transaction on
+     * THIS channel is what feeds it — a sensor that answers must not keep an
+     * actuator that has gone silent looking alive. Same injected clock unit
+     * as the device-level fields. */
+    uint64_t last_contact;
+    bool     contact_pending;
 };
 
 struct spg_device {
@@ -75,7 +81,11 @@ struct spg_device {
     uint64_t watchdog_timeout; /* 0 disables it */
     uint64_t last_contact;
     bool     contact_pending; /* a transaction succeeded since the last check */
-    size_t   n_channels;
+    /* #118: the tick-level watchdog service latches after driving the safe
+     * state so an expiry that persists does not re-drive (and re-journal) it
+     * every tick; any successful contact re-arms the latch. */
+    bool   watchdog_tripped;
+    size_t n_channels;
     struct spg_device_channel channels[SPG_DEVICE_MAX_CHANNELS];
 };
 
@@ -199,12 +209,20 @@ void spg_device_arm_watchdog(struct spg_device *dev, uint64_t timeout,
                              uint64_t now);
 
 /* Fold in any successful transaction since the last call and report whether
- * the deadline has passed. Checking is what consumes the contact flag, so a
+ * the deadline has passed. Checking is what consumes the contact flags, so a
  * caller cannot succeed at keeping the machine alive while forgetting to
  * check — the two are the same call.
  *
  * EXPIRED is sticky until the next successful transaction: a machine that
- * answers once and goes quiet again must not look healthy in between. */
+ * answers once and goes quiet again must not look healthy in between.
+ *
+ * #118: the deadline is judged PER WRITABLE CHANNEL as well as globally. A
+ * writable channel is fed only by a successful write to it (arming stamps a
+ * baseline), so a sensor that keeps answering cannot mask an actuator whose
+ * writes stopped landing — EXPIRED as soon as ANY writable channel has gone
+ * a full timeout without contact. Read-only channels ride on the global
+ * deadline as before: for a plant of sensors, reads are the only contact
+ * there is. */
 [[nodiscard]] enum spg_device_watchdog
 spg_device_watchdog_check(struct spg_device *dev, uint64_t now);
 

--- a/include/geistshell/device_executor.h
+++ b/include/geistshell/device_executor.h
@@ -73,6 +73,27 @@ spg_device_executor_step(const struct spg_device_executor_state  *state,
                          const struct spg_policy_decision  *decision,
                          struct spg_device_executor_result *out);
 
+/* #118: tick-level watchdog service, independent of model actions. The agent
+ * loop calls this every tick and once more before a normal run end, so a
+ * contact loss is caught even when the model never asks for another
+ * device_write (or the run is about to finish).
+ *
+ * On the EXPIRED transition: drives every writable channel to its safe value
+ * (best effort, first failure reported in *out), journals
+ *   (device_watchdog (outcome expired) (safe_state ok|failed))
+ * under SPG_JOURNAL_EVENT_ACTION when journal+write_journal are set, and
+ * latches — a persisting expiry does not re-drive or re-journal every tick;
+ * any successful contact re-arms the latch (see spg_device.watchdog_tripped).
+ *
+ * device may be null (no machine on this run): nothing happens, SPG_OK.
+ * *out_sequence receives the journaled sequence (0 when nothing was written).
+ * out (nullable) receives what was done. The timestamp is the caller's
+ * injected clock, same unit the watchdog was armed with. */
+[[nodiscard]] enum spg_status spg_device_watchdog_service(
+    struct spg_device *device, struct spg_journal_writer *journal,
+    const struct spg_device_executor_config *config,
+    struct spg_device_executor_result       *out, uint64_t *out_sequence);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -62,8 +62,23 @@ spg_device_add_channel(struct spg_device               *dev,
         return SPG_E_LIMIT;
     }
     dev->channels[dev->n_channels] = *channel;
+    /* A channel added after arming inherits the device baseline instead of a
+     * zero stamp — otherwise it would look a whole epoch overdue at once. */
+    dev->channels[dev->n_channels].last_contact    = dev->last_contact;
+    dev->channels[dev->n_channels].contact_pending = false;
     dev->n_channels += 1u;
     return SPG_OK;
+}
+
+/* The mutable twin of spg_device_find, for the contact bookkeeping. */
+static struct spg_device_channel *find_mut(struct spg_device *dev,
+                                           const char        *name) {
+    for (size_t i = 0u; i < dev->n_channels; i += 1u) {
+        if (strcmp(dev->channels[i].name, name) == 0) {
+            return &dev->channels[i];
+        }
+    }
+    return nullptr;
 }
 
 const struct spg_device_channel *spg_device_find(const struct spg_device *dev,
@@ -317,10 +332,10 @@ static bool parse_output(const char text[], int64_t *out) {
 
 enum spg_status spg_device_read(struct spg_device *dev, const char *name,
                                 int64_t *out) {
-    if (dev == nullptr || out == nullptr) {
+    if (dev == nullptr || out == nullptr || name == nullptr) {
         return SPG_E_INVALID_ARG;
     }
-    const struct spg_device_channel *channel = spg_device_find(dev, name);
+    struct spg_device_channel *channel = find_mut(dev, name);
     if (channel == nullptr) {
         return SPG_E_NOT_FOUND;
     }
@@ -336,8 +351,10 @@ enum spg_status spg_device_read(struct spg_device *dev, const char *name,
     }
     *out = value;
     /* Contact is contact: a successful read keeps the watchdog fed, so a run
-     * that only observes does not look like a machine gone silent. */
-    dev->contact_pending = true;
+     * that only observes does not look like a machine gone silent. Feeds this
+     * CHANNEL and the device — never another channel (#118). */
+    dev->contact_pending     = true;
+    channel->contact_pending = true;
     return SPG_OK;
 }
 
@@ -349,7 +366,10 @@ enum spg_status spg_device_write(struct spg_device *dev, const char *name,
     /* Every refusal is decided BEFORE the fork, so all of it can be tested
      * without a program that exists. A safety check reachable only once a
      * machine is plugged in is a safety check nobody runs. */
-    const struct spg_device_channel *channel = spg_device_find(dev, name);
+    if (name == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    struct spg_device_channel *channel = find_mut(dev, name);
     if (channel == nullptr) {
         return SPG_E_NOT_FOUND;
     }
@@ -374,7 +394,8 @@ enum spg_status spg_device_write(struct spg_device *dev, const char *name,
          * next decision on a number the machine never accepted. */
         return SPG_E_IO;
     }
-    dev->contact_pending = true;
+    dev->contact_pending     = true;
+    channel->contact_pending = true;
     return SPG_OK;
 }
 
@@ -388,6 +409,13 @@ void spg_device_arm_watchdog(struct spg_device *dev, const uint64_t timeout,
     dev->watchdog_timeout = timeout;
     dev->last_contact     = now;
     dev->contact_pending  = false;
+    dev->watchdog_tripped = false;
+    for (size_t i = 0u; i < dev->n_channels; i += 1u) {
+        /* Arming is the baseline stamp: an armed watchdog must not fire on a
+         * channel that has simply not been spoken to yet. */
+        dev->channels[i].last_contact    = now;
+        dev->channels[i].contact_pending = false;
+    }
 }
 
 enum spg_device_watchdog spg_device_watchdog_check(struct spg_device *dev,
@@ -399,6 +427,12 @@ enum spg_device_watchdog spg_device_watchdog_check(struct spg_device *dev,
         dev->contact_pending = false;
         dev->last_contact    = now;
     }
+    for (size_t i = 0u; i < dev->n_channels; i += 1u) {
+        if (dev->channels[i].contact_pending) {
+            dev->channels[i].contact_pending = false;
+            dev->channels[i].last_contact    = now;
+        }
+    }
     if (dev->watchdog_timeout == 0u) {
         return SPG_WATCHDOG_DISABLED;
     }
@@ -409,9 +443,20 @@ enum spg_device_watchdog spg_device_watchdog_check(struct spg_device *dev,
          * expensive of the two wrong answers. */
         return SPG_WATCHDOG_OK;
     }
-    return (now - dev->last_contact) > dev->watchdog_timeout
-               ? SPG_WATCHDOG_EXPIRED
-               : SPG_WATCHDOG_OK;
+    if ((now - dev->last_contact) > dev->watchdog_timeout) {
+        return SPG_WATCHDOG_EXPIRED;
+    }
+    /* #118: every writable channel must have been fed within the deadline —
+     * a live sensor (which feeds the global stamp above) must not mask an
+     * actuator whose writes stopped landing. */
+    for (size_t i = 0u; i < dev->n_channels; i += 1u) {
+        const struct spg_device_channel *ch = &dev->channels[i];
+        if (ch->writable && now >= ch->last_contact &&
+            (now - ch->last_contact) > dev->watchdog_timeout) {
+            return SPG_WATCHDOG_EXPIRED;
+        }
+    }
+    return SPG_WATCHDOG_OK;
 }
 
 enum spg_status spg_device_safe_state(struct spg_device *dev) {

--- a/src/executor/device_executor.c
+++ b/src/executor/device_executor.c
@@ -142,3 +142,56 @@ spg_device_executor_step(const struct spg_device_executor_state  *state,
     out->sequence = sequence;
     return status_j;
 }
+
+enum spg_status spg_device_watchdog_service(
+    struct spg_device *device, struct spg_journal_writer *journal,
+    const struct spg_device_executor_config *config,
+    struct spg_device_executor_result *out, uint64_t *out_sequence) {
+    if (config == nullptr || out_sequence == nullptr) {
+        return SPG_E_INVALID_ARG;
+    }
+    *out_sequence = 0u;
+    if (out != nullptr) {
+        *out = (struct spg_device_executor_result){
+            .outcome = SPG_DEVICE_OUTCOME_NOT_EXECUTED};
+    }
+    if (device == nullptr) {
+        return SPG_OK; /* no machine on this run — nothing to guard */
+    }
+    const enum spg_device_watchdog wd =
+        spg_device_watchdog_check(device, config->timestamp_ns);
+    if (wd == SPG_WATCHDOG_OK) {
+        /* Contact resumed: the next expiry is a new event, not the tail of
+         * the last one. */
+        device->watchdog_tripped = false;
+        return SPG_OK;
+    }
+    if (wd != SPG_WATCHDOG_EXPIRED || device->watchdog_tripped) {
+        return SPG_OK; /* disabled, or already handled this expiry */
+    }
+    device->watchdog_tripped = true;
+    /* Same rule as the pre-write check: the one command a silent machine must
+     * still be given is its safe state. Best effort across all channels; the
+     * first failure is what the journal shows. */
+    const enum spg_status safe = spg_device_safe_state(device);
+    if (out != nullptr) {
+        out->outcome           = SPG_DEVICE_OUTCOME_WATCHDOG_EXPIRED;
+        out->safe_state_driven = true;
+        out->safe_state_status = safe;
+    }
+    if (!config->write_journal || journal == nullptr) {
+        return SPG_OK;
+    }
+    char      record[128] = {};
+    const int written =
+        snprintf(record, sizeof record,
+                 "(device_watchdog (outcome expired) (safe_state %s))",
+                 safe == SPG_OK ? "ok" : "failed");
+    if (written < 0 || (size_t)written >= sizeof record) {
+        return SPG_E_LIMIT;
+    }
+    return spg_journal_writer_append(
+        journal, config->timestamp_ns, config->parent_sequence,
+        SPG_JOURNAL_EVENT_ACTION, SPG_E_INVALID_STATE, (size_t)written,
+        (const uint8_t *)record, out_sequence);
+}

--- a/src/run/agent_loop.c
+++ b/src/run/agent_loop.c
@@ -6,6 +6,7 @@
 
 #include <time.h>
 
+#include "geistshell/device_executor.h" /* #118: tick-level watchdog service */
 #include "geistshell/mem_store.h" /* P6: slug-triggered directive injection */
 
 #include <stdio.h>
@@ -155,6 +156,26 @@ spg_agent_loop_run(struct spg_orchestrator_state           *state,
             result->termination = SPG_AGENT_LOOP_BUDGET;
             return SPG_OK;
         }
+        /* #118: the watchdog is a property of the governed machine, not of
+         * the model's willingness to emit another device_write. Checked
+         * before EVERY tick — including ticks whose action is observation,
+         * memory or finish — with the same injected clock the executors use,
+         * so a replay reaches the same verdict. */
+        if (state->device != nullptr) {
+            const struct spg_device_executor_config wd_cfg = {
+                .actor_id        = config->base.actor_id,
+                .timestamp_ns    = (uint64_t)step + 1u,
+                .parent_sequence = parent_sequence,
+                .write_journal   = config->base.write_journal,
+            };
+            uint64_t wd_seq = 0u;
+            (void)spg_device_watchdog_service(state->device, state->journal,
+                                              &wd_cfg, nullptr, &wd_seq);
+            if (wd_seq != 0u) {
+                parent_sequence = wd_seq;
+            }
+        }
+
         /* Expose every event logged so far (steps 1..step-1) to this step. */
         if (feedback) {
             state->journal_header_count = state->journal->header_log_count;

--- a/src/run/agent_run.c
+++ b/src/run/agent_run.c
@@ -1,5 +1,6 @@
 #include "geistshell/agent_run.h"
 
+#include "geistshell/device_executor.h" /* #118: watchdog check at run end */
 #include "geistshell/graph.h"
 #include "geistshell/mem_store.h" /* #40 follow-up: strong directive channel */
 #include "geistshell/memory.h"
@@ -139,5 +140,22 @@ enum spg_status spg_agent_run(const struct spg_agent_run_inputs *inputs,
         .journal_headers         = workspace->trajectory,
     };
 
-    return spg_agent_loop_run(&state, &loop_config, &ow, usage, result);
+    const enum spg_status loop_status =
+        spg_agent_loop_run(&state, &loop_config, &ow, usage, result);
+
+    /* #118: a run must not END with an unnoticed contact loss — the loop
+     * checks before each tick, so an expiry between the last tick and the
+     * terminal state would otherwise slip out unhandled. One more service
+     * pass at the clock value the next tick would have carried. */
+    if (inputs->device != nullptr && loop_status == SPG_OK) {
+        const struct spg_device_executor_config wd_cfg = {
+            .actor_id      = 1u,
+            .timestamp_ns  = (uint64_t)result->steps_taken + 1u,
+            .write_journal = inputs->journal != nullptr,
+        };
+        uint64_t wd_seq = 0u;
+        (void)spg_device_watchdog_service(inputs->device, inputs->journal,
+                                          &wd_cfg, nullptr, &wd_seq);
+    }
+    return loop_status;
 }

--- a/test/test_cli_device.sh
+++ b/test/test_cli_device.sh
@@ -165,3 +165,40 @@ strings build/device-demo.sgj | grep -q '(device-state (heater 40)' ||
     fail "the context was not re-sampled after the write"
 
 echo "test_cli_device: PASS (agent action)"
+
+# --- #118: the watchdog fires without a device_write to the dead channel ----
+# A dead actuator (its program always fails) while OTHER channels keep
+# answering: before #118 the shared contact flag let any live channel mask the
+# loss, and the check only ran when a device_write reached the executor. Now
+# the deadline is per writable channel and serviced every tick, so the run
+# journals the expiry and drives the safe state even though the model never
+# addressed the dead channel again.
+cat >"$DIR/deadheater" <<'EOS'
+#!/bin/sh
+exit 1
+EOS
+chmod 0755 "$DIR/deadheater"
+
+cat >"$DIR/watchdog.spg" <<EOF
+(device
+  (channel (name "heater") (program "$PWD/$DIR/deadheater") (range 0 100) (safe 0))
+  (channel (name "reset")  (program "$PWD/$DIR/reset")      (range 0 1) (safe 0))
+  (channel (name "temp")   (program "$PWD/$DIR/temp")       (range -400 9000)))
+EOF
+
+WFAKE=build/test-cli-device-watchdog-fake.txt
+printf '%s\n%s\n%s\n%s\n' \
+    '(recommend (kind device_write) (capability "device") (cost 1) (uses_network false) (confidence_bp 9000) (target "reset") (value 0) (reason "tick 1"))' \
+    '(recommend (kind device_write) (capability "device") (cost 1) (uses_network false) (confidence_bp 9000) (target "reset") (value 0) (reason "tick 2"))' \
+    '(recommend (kind device_write) (capability "device") (cost 1) (uses_network false) (confidence_bp 9000) (target "reset") (value 0) (reason "tick 3"))' \
+    '(recommend (kind finish) (reason "done"))' >"$WFAKE"
+
+"$SPG_BIN" agent --config examples/device/run.spg --fake-script "$WFAKE" \
+    --max-steps 6 --allow-exec --device "$DIR/watchdog.spg" \
+    --device-watchdog-steps 1 >/dev/null || fail "watchdog agent run failed"
+
+strings build/device-demo.sgj |
+    grep -q '(device_watchdog (outcome expired) (safe_state failed))' ||
+    fail "a dead actuator behind live channels never tripped the tick-level watchdog"
+
+echo "test_cli_device: PASS (tick-level watchdog)"

--- a/test/test_device.c
+++ b/test/test_device.c
@@ -369,6 +369,87 @@ static int test_watchdog(void) {
     return 0;
 }
 
+/* #118: a live sensor must not keep a silent actuator looking alive — the
+ * deadline is judged per writable channel, fed only by that channel's own
+ * transactions. Simulated with the flags the transport sets. */
+static int test_watchdog_per_channel(void) {
+    struct spg_device dev = {};
+    spg_device_init(&dev);
+    struct spg_device_channel heater = {.name     = "heater",
+                                        .program  = "/nonexistent/heater",
+                                        .min      = 0,
+                                        .max      = 100,
+                                        .writable = true,
+                                        .safe     = 0};
+    struct spg_device_channel valve  = {.name     = "valve",
+                                        .program  = "/nonexistent/valve",
+                                        .min      = 0,
+                                        .max      = 1,
+                                        .writable = true,
+                                        .safe     = 0};
+    struct spg_device_channel temp   = {.name    = "temp",
+                                        .program = "/nonexistent/temp",
+                                        .min     = -400,
+                                        .max     = 9000};
+    if (spg_device_add_channel(&dev, &heater) != SPG_OK ||
+        spg_device_add_channel(&dev, &valve) != SPG_OK ||
+        spg_device_add_channel(&dev, &temp) != SPG_OK) {
+        return 1;
+    }
+    spg_device_arm_watchdog(&dev, 10u, 0u);
+
+    /* Everything answers: fine. */
+    dev.contact_pending             = true;
+    dev.channels[0].contact_pending = true;
+    dev.channels[1].contact_pending = true;
+    dev.channels[2].contact_pending = true;
+    if (spg_device_watchdog_check(&dev, 5u) != SPG_WATCHDOG_OK) {
+        return 1;
+    }
+
+    /* From now on only the SENSOR answers. The global stamp stays fresh, but
+     * the actuators' writes stopped landing — expired, not masked. */
+    dev.contact_pending             = true;
+    dev.channels[2].contact_pending = true;
+    if (spg_device_watchdog_check(&dev, 10u) != SPG_WATCHDOG_OK) {
+        return 1; /* actuators fed at 5, deadline 10: 10-5 is not past it */
+    }
+    dev.contact_pending             = true;
+    dev.channels[2].contact_pending = true;
+    if (spg_device_watchdog_check(&dev, 16u) != SPG_WATCHDOG_EXPIRED) {
+        return 1;
+    }
+
+    /* Contact on actuator A must not cover actuator B. */
+    spg_device_arm_watchdog(&dev, 10u, 100u);
+    dev.contact_pending             = true;
+    dev.channels[0].contact_pending = true; /* heater answers */
+    if (spg_device_watchdog_check(&dev, 120u) != SPG_WATCHDOG_EXPIRED) {
+        return 1; /* valve last fed at arm time 100; 120-100 > 10 */
+    }
+
+    /* Re-arming stamps every channel: nothing is instantly overdue. */
+    spg_device_arm_watchdog(&dev, 10u, 1000u);
+    if (spg_device_watchdog_check(&dev, 1005u) != SPG_WATCHDOG_OK) {
+        return 1;
+    }
+
+    /* A read-only table still rides on the global deadline alone. */
+    struct spg_device sensors = {};
+    spg_device_init(&sensors);
+    if (spg_device_add_channel(&sensors, &temp) != SPG_OK) {
+        return 1;
+    }
+    spg_device_arm_watchdog(&sensors, 10u, 0u);
+    sensors.contact_pending             = true;
+    sensors.channels[0].contact_pending = true;
+    if (spg_device_watchdog_check(&sensors, 8u) != SPG_WATCHDOG_OK ||
+        spg_device_watchdog_check(&sensors, 30u) != SPG_WATCHDOG_EXPIRED) {
+        return 1;
+    }
+    return 0;
+}
+
 static int test_safe_state(void) {
     char dir[] = "/tmp/spg_device_XXXXXX";
     if (mkdtemp(dir) == nullptr) {
@@ -528,6 +609,7 @@ int main(void) {
         {"write_refusals", test_write_refusals},
         {"exec_contract", test_exec_contract},
         {"watchdog", test_watchdog},
+        {"watchdog_per_channel", test_watchdog_per_channel},
         {"safe_state", test_safe_state},
         {"state_render", test_state_render},
         {"sample_unreachable", test_sample_unreachable},

--- a/test/test_device_executor.c
+++ b/test/test_device_executor.c
@@ -136,6 +136,69 @@ static int test_watchdog_precedes_the_write(void) {
     return 0;
 }
 
+/* #118: the tick-level service — expiry handled without any device_write
+ * recommendation in flight, latched so a persisting expiry acts once, and
+ * re-armed by resumed contact. */
+static int test_watchdog_service(void) {
+    const struct spg_device_executor_config at5   = {.timestamp_ns = 5u};
+    const struct spg_device_executor_config at50  = {.timestamp_ns = 50u};
+    const struct spg_device_executor_config at60  = {.timestamp_ns = 60u};
+    const struct spg_device_executor_config at200 = {.timestamp_ns = 200u};
+    struct spg_device_executor_result       out   = {};
+    uint64_t                                seq   = 77u;
+
+    /* No machine on the run: a no-op, not an error. */
+    if (spg_device_watchdog_service(nullptr, nullptr, &at5, &out, &seq) !=
+            SPG_OK ||
+        seq != 0u || out.outcome != SPG_DEVICE_OUTCOME_NOT_EXECUTED) {
+        return 1;
+    }
+
+    struct spg_device dev = {};
+    build_device(&dev);
+    spg_device_arm_watchdog(&dev, 10u, 0u);
+
+    /* Within the deadline: nothing driven. */
+    if (spg_device_watchdog_service(&dev, nullptr, &at5, &out, &seq) !=
+            SPG_OK ||
+        out.safe_state_driven || dev.watchdog_tripped) {
+        return 1;
+    }
+
+    /* Expired: the safe state is driven even though NO device_write is in
+     * flight — this is the gap the service closes. The channel program does
+     * not exist, so the failed safe state must be visible, never silent. */
+    if (spg_device_watchdog_service(&dev, nullptr, &at50, &out, &seq) !=
+            SPG_OK ||
+        out.outcome != SPG_DEVICE_OUTCOME_WATCHDOG_EXPIRED ||
+        !out.safe_state_driven || out.safe_state_status == SPG_OK ||
+        !dev.watchdog_tripped) {
+        return 1;
+    }
+
+    /* Still expired on the next tick: latched, not re-driven. */
+    if (spg_device_watchdog_service(&dev, nullptr, &at60, &out, &seq) !=
+            SPG_OK ||
+        out.outcome != SPG_DEVICE_OUTCOME_NOT_EXECUTED) {
+        return 1;
+    }
+
+    /* Contact resumes: the latch re-arms, and a LATER expiry acts again. */
+    dev.contact_pending             = true;
+    dev.channels[0].contact_pending = true;
+    if (spg_device_watchdog_service(&dev, nullptr, &at60, &out, &seq) !=
+            SPG_OK ||
+        dev.watchdog_tripped) {
+        return 1;
+    }
+    if (spg_device_watchdog_service(&dev, nullptr, &at200, &out, &seq) !=
+            SPG_OK ||
+        out.outcome != SPG_DEVICE_OUTCOME_WATCHDOG_EXPIRED) {
+        return 1;
+    }
+    return 0;
+}
+
 /* A denied decision, or a recommendation of another kind, must never reach the
  * machine — the gate is upstream, and the executor must not second-guess it in
  * either direction. */
@@ -201,6 +264,7 @@ int main(void) {
         {"dry_run", test_dry_run},
         {"refused_out_of_range", test_refused_out_of_range},
         {"watchdog_precedes_the_write", test_watchdog_precedes_the_write},
+        {"watchdog_service", test_watchdog_service},
         {"not_our_action", test_not_our_action},
         {"span_bounds", test_span_bounds},
     };


### PR DESCRIPTION
Closes #118.

Two gaps from the architecture review on `cd94088`:

1. The watchdog only ran inside `spg_device_executor_step()` when an allowed `device_write` arrived — a run that stopped asking for device actions (or ended) never noticed a contact loss.
2. `spg_device_read()`/`spg_device_write()` shared one `contact_pending`, so a live sensor masked a dead actuator.

**Changes**

- Contact is now per channel: a successful transaction feeds its own channel plus the global stamp. `spg_device_watchdog_check()` reports EXPIRED when the global stamp **or any writable channel** has gone a full timeout without contact. Sensor-only tables ride on the global deadline as before (reads are the only contact there is). Sampling reads writable channels too, so a healthy actuator program answering reads counts as contact — expiry means the program actually went silent.
- New `spg_device_watchdog_service()` (device_executor.c): called before **every** agent tick — including observation/memory/finish ticks — and once more before a normal run end (in `spg_agent_run`). On the expiry transition it drives all writable channels to their safe values best-effort and journals `(device_watchdog (outcome expired) (safe_state ok|failed))` under the existing ACTION event kind.
- Latched: a persisting expiry is handled once, not re-driven/re-journaled every tick; resumed contact re-arms the latch.
- Clocks stay injected (the loop's step counter), so replay verdicts are byte-identical; `test_cli_baseline.sh` (pinned journal hash) stays green.
- `spg_device_arm_watchdog()` stamps every channel; channels added after arming inherit the device baseline instead of being instantly overdue.

**Tests**

- `test_device.c`: per-channel semantics — sensor cannot mask actuators, contact on actuator A does not cover B, re-arming stamps everything, sensor-only tables unchanged.
- `test_device_executor.c`: service function — no-device no-op, expiry without any device_write in flight, failed safe state visible, latch, re-arm on contact.
- `test_cli_device.sh` end-to-end: dead actuator program behind live channels, model issues only writes to a healthy channel + finish → the run journals `(device_watchdog (outcome expired) (safe_state failed))`.
- `docs/machine-intelligence/Devices.md` updated.

Verification: `make test` green (51 passed, ASan/UBSan); `make bench` model part skips on this host (no GGUF), deterministic benchmark runs in `make test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)