### PR TITLE
feat(eval): sequence mode for the task-shape key (set stays default)

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -106,8 +106,15 @@ is the honest place to build "learns from use."
 
 ## Deliberately open — practice decides
 
-- **Sequence over set (decision 6):** the finer shape key, if too many distinct
-  scripts share one capability set and a guard misses regressions.
+- **Sequence over set (decision 6): mechanism SHIPPED (#12), default
+  unchanged.** `spg_shape_from_script_mode(..., SPG_SHAPE_MODE_SEQUENCE, ...)`
+  builds the finer key — the ordered `'>'`-joined sequence of
+  `<kind>:<capability>` tokens, consecutive duplicates collapsed, `finish`
+  excluded, deterministically truncated at `SPG_SHAPE_MAX_TOKENS`. The SET key
+  stays the default everywhere (cheaper, more bounded); switching a caller to
+  the sequence key remains trigger-gated on an observed guard collision — two
+  distinct tasks sharing a guard where a lesson broke one but the guard was
+  the other.
 - **Post-check command (decision 2):** a last-step shell probe (`exit 0 =
   success`) verifying world state, for tasks that produce files rather than
   stdout.

--- a/include/geistshell/eval.h
+++ b/include/geistshell/eval.h
@@ -141,6 +141,25 @@ spg_eval_run_case(const struct spg_fake_response *script, size_t script_n,
     const struct spg_fake_response responses[], size_t n, size_t cap,
     char out[], size_t *len);
 
+/* #12 (LEARNING.md decision 6): how the shape key is built.
+ *
+ * SET is the default and stays what spg_shape_from_script computes: the
+ * deduplicated, sorted capability set — cheaper and more bounded. SEQUENCE is
+ * the finer key for when too many distinct scripts share one set and a single
+ * guard stops protecting meaningfully different tasks: the ORDERED sequence
+ * of "<kind>:<capability>" tokens, joined with '>', consecutive duplicates
+ * collapsed (a retried step is the same step, not a new shape). `finish` is
+ * excluded in both modes. A trajectory longer than SPG_SHAPE_MAX_TOKENS
+ * truncates deterministically at that many tokens. */
+enum spg_shape_mode {
+    SPG_SHAPE_MODE_SET = 0,
+    SPG_SHAPE_MODE_SEQUENCE,
+};
+
+[[nodiscard]] enum spg_status spg_shape_from_script_mode(
+    const struct spg_fake_response responses[], size_t n,
+    enum spg_shape_mode mode, size_t cap, char out[], size_t *len);
+
 /* Per-slug failure recurrence in one journal (docs/LEARNING.md P7): the
  * benefit of a kept lesson is not proven at mint time but observed in the
  * field — a lesson that works makes its failure slug stop recurring. This

--- a/src/eval/eval.c
+++ b/src/eval/eval.c
@@ -190,7 +190,16 @@ enum { SPG_SHAPE_MAX_TOKENS = 16u, SPG_SHAPE_TOKEN_MAX = 48u };
 enum spg_status spg_shape_from_script(const struct spg_fake_response responses[],
                                       const size_t n, const size_t cap,
                                       char out[], size_t *len) {
-    if (responses == nullptr || out == nullptr || len == nullptr || cap == 0u) {
+    return spg_shape_from_script_mode(responses, n, SPG_SHAPE_MODE_SET, cap,
+                                      out, len);
+}
+
+enum spg_status spg_shape_from_script_mode(
+    const struct spg_fake_response responses[], const size_t n,
+    const enum spg_shape_mode mode, const size_t cap, char out[],
+    size_t *len) {
+    if (responses == nullptr || out == nullptr || len == nullptr || cap == 0u ||
+        (mode != SPG_SHAPE_MODE_SET && mode != SPG_SHAPE_MODE_SEQUENCE)) {
         return SPG_E_INVALID_ARG;
     }
     *len   = 0u;
@@ -228,6 +237,21 @@ enum spg_status spg_shape_from_script(const struct spg_fake_response responses[]
             (void)snprintf(token, sizeof token, "%s", kind);
         }
 
+        if (mode == SPG_SHAPE_MODE_SEQUENCE) {
+            /* #12: order matters; only CONSECUTIVE duplicates collapse — a
+             * retried step is the same step, but a capability revisited later
+             * is a different trajectory. Overlong trajectories truncate
+             * deterministically at the token cap. */
+            if ((token_count > 0u &&
+                 strcmp(tokens[token_count - 1u], token) == 0) ||
+                token_count == SPG_SHAPE_MAX_TOKENS) {
+                continue;
+            }
+            (void)snprintf(tokens[token_count], sizeof tokens[0], "%s", token);
+            token_count++;
+            continue;
+        }
+
         /* insert into the sorted set, skipping duplicates */
         size_t pos = 0u;
         bool   dup = false;
@@ -252,7 +276,8 @@ enum spg_status spg_shape_from_script(const struct spg_fake_response responses[]
         token_count++;
     }
 
-    size_t w = 0u;
+    const char joiner = mode == SPG_SHAPE_MODE_SEQUENCE ? '>' : '+';
+    size_t     w      = 0u;
     for (size_t i = 0u; i < token_count; i++) {
         const size_t tn = strlen(tokens[i]);
         const size_t sep = (i > 0u) ? 1u : 0u;
@@ -261,7 +286,7 @@ enum spg_status spg_shape_from_script(const struct spg_fake_response responses[]
             return SPG_E_LIMIT;
         }
         if (sep) {
-            out[w++] = '+';
+            out[w++] = joiner;
         }
         memcpy(out + w, tokens[i], tn);
         w += tn;

--- a/test/test_guard_ring.c
+++ b/test/test_guard_ring.c
@@ -45,6 +45,95 @@ static int test_shape_key(void) {
     return 0;
 }
 
+/* #12 (decision 6): the sequence mode. Two trajectories that COLLIDE under
+ * the set key (same capabilities, different order) get distinct sequence
+ * keys — so a guard minted for one no longer silently stands in for the
+ * other. The set mode stays the default and is untouched. */
+static int test_shape_sequence_mode(void) {
+    const char r0[] =
+        "(recommend (kind local_shell) (capability \"proc.exec\") (cost 1) "
+        "(uses_network false) (confidence_bp 6000) (reason \"a\") "
+        "(command \"echo a\"))";
+    const char r1[] =
+        "(recommend (kind local_shell) (capability \"fs.write\") (cost 1) "
+        "(uses_network false) (confidence_bp 6000) (reason \"b\") "
+        "(command \"tee f\"))";
+    const char r2[] = "(recommend (kind finish) (reason \"done\"))";
+    struct spg_fake_response exec_then_write[] = {
+        {sizeof r0 - 1u, r0}, {sizeof r1 - 1u, r1}, {sizeof r2 - 1u, r2}};
+    struct spg_fake_response write_then_exec[] = {
+        {sizeof r1 - 1u, r1}, {sizeof r0 - 1u, r0}, {sizeof r2 - 1u, r2}};
+
+    /* the collision, demonstrated: identical SET keys */
+    char   set_a[256], set_b[256];
+    size_t len = 0u;
+    if (spg_shape_from_script(exec_then_write, 3u, sizeof set_a, set_a,
+                              &len) != SPG_OK ||
+        spg_shape_from_script(write_then_exec, 3u, sizeof set_b, set_b,
+                              &len) != SPG_OK ||
+        strcmp(set_a, set_b) != 0) {
+        return 1;
+    }
+
+    /* the resolution: distinct SEQUENCE keys, ordered, '>'-joined */
+    char seq_a[256], seq_b[256];
+    if (spg_shape_from_script_mode(exec_then_write, 3u,
+                                   SPG_SHAPE_MODE_SEQUENCE, sizeof seq_a,
+                                   seq_a, &len) != SPG_OK ||
+        spg_shape_from_script_mode(write_then_exec, 3u,
+                                   SPG_SHAPE_MODE_SEQUENCE, sizeof seq_b,
+                                   seq_b, &len) != SPG_OK) {
+        return 1;
+    }
+    if (strcmp(seq_a, "local_shell:proc.exec>local_shell:fs.write") != 0 ||
+        strcmp(seq_b, "local_shell:fs.write>local_shell:proc.exec") != 0) {
+        fprintf(stderr, "seq_a=%s seq_b=%s\n", seq_a, seq_b);
+        return 1;
+    }
+
+    /* consecutive duplicates collapse (a retried step is the same step),
+     * but a capability revisited LATER stays a distinct trajectory */
+    struct spg_fake_response retried[] = {
+        {sizeof r0 - 1u, r0}, {sizeof r0 - 1u, r0}, {sizeof r1 - 1u, r1}};
+    char seq_r[256];
+    if (spg_shape_from_script_mode(retried, 3u, SPG_SHAPE_MODE_SEQUENCE,
+                                   sizeof seq_r, seq_r, &len) != SPG_OK ||
+        strcmp(seq_r, seq_a) != 0) {
+        return 1;
+    }
+    struct spg_fake_response revisit[] = {
+        {sizeof r0 - 1u, r0}, {sizeof r1 - 1u, r1}, {sizeof r0 - 1u, r0}};
+    char seq_v[256];
+    if (spg_shape_from_script_mode(revisit, 3u, SPG_SHAPE_MODE_SEQUENCE,
+                                   sizeof seq_v, seq_v, &len) != SPG_OK ||
+        strcmp(seq_v, seq_a) == 0) {
+        return 1;
+    }
+
+    /* SET mode via the mode entry point is byte-identical to the default */
+    char via_mode[256];
+    if (spg_shape_from_script_mode(exec_then_write, 3u, SPG_SHAPE_MODE_SET,
+                                   sizeof via_mode, via_mode,
+                                   &len) != SPG_OK ||
+        strcmp(via_mode, set_a) != 0) {
+        return 1;
+    }
+
+    /* the guard ring dedups by the finer key: both order-variants now hold a
+     * guard, still bounded by distinct shapes (LRU-capped as ever) */
+    struct spg_guard_ring ring;
+    spg_guard_ring_init(&ring);
+    spg_guard_ring_record(&ring, seq_a, "/cfg/a.spg");
+    spg_guard_ring_record(&ring, seq_b, "/cfg/b.spg");
+    spg_guard_ring_record(&ring, seq_a, "/cfg/a.spg"); /* dedup, no growth */
+    if (spg_guard_ring_count(&ring) != 2u ||
+        spg_guard_ring_find(&ring, seq_a) == nullptr ||
+        spg_guard_ring_find(&ring, seq_b) == nullptr) {
+        return 1;
+    }
+    return 0;
+}
+
 static int test_ring_dedup_and_lru(void) {
     struct spg_guard_ring ring;
     spg_guard_ring_init(&ring);
@@ -160,6 +249,10 @@ static int test_guard_gate(void) {
 int main(void) {
     if (test_shape_key() != 0) {
         fprintf(stderr, "test_shape_key failed\n");
+        return 1;
+    }
+    if (test_shape_sequence_mode() != 0) {
+        fprintf(stderr, "test_shape_sequence_mode failed\n");
         return 1;
     }
     if (test_ring_dedup_and_lru() != 0) {


### PR DESCRIPTION
Closes #12.

`spg_shape_from_script_mode()` adds `SPG_SHAPE_MODE_SEQUENCE` behind a mode flag, per LEARNING.md decision 6:

- **Sequence key:** ordered `'>'`-joined `<kind>:<capability>` tokens; consecutive duplicates collapse (a retried step is the same step) while a capability revisited later stays distinct; `finish` excluded as in the set key; overlong trajectories truncate deterministically at `SPG_SHAPE_MAX_TOKENS`.
- **Set mode untouched and default:** `spg_shape_from_script()` is now a thin wrapper over the mode entry point with `SPG_SHAPE_MODE_SET`; byte-identical output (tested).
- **Guard ring:** dedups by whatever key it is given — the test shows both order-variants holding guards, still LRU-capped.

**The collision, demonstrated in `test_guard_ring.c`:** `exec→write` and `write→exec` produce identical SET keys (the collision) and distinct SEQUENCE keys (the resolution); the ring then holds one guard per variant instead of one guard silently standing in for both.

Per the tracking issue's rule (#78: #11/#12/#13 are trigger-gated), actually **switching** the runtime slug/guard key to the sequence mode stays gated on an observed guard collision in P4/P5 data — this PR ships the mechanism and its tests without changing any default behaviour.

Verification: `make test` green (50 passed, ASan/UBSan); `make bench` model part skips on this host (no GGUF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)